### PR TITLE
Context-aware footer action bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   one line. `u/b/t scope` stays available everywhere while reviewing, and `s send N` appears once
   a comment is written. Replaces the static key-hint line.
 
+- **Simpler PR merge status** — the footer's merge state now shows only the actionable blockers,
+  `conflicts` and `blocked`; GitHub's `behind`, `unstable`, and still-computing states (jargon a
+  reviewer can't act on) fold into nothing.
+- **PR tab panes named distinctly** — the right navigator is now `Checks & comments` instead of a
+  second `PR`, so it no longer repeats the left reader's title.
+
 ### Fixed
 - **PR empty state renders once** — "no PR for this branch yet…" (and the other PR loading and
   degraded messages) showed in the header, the navigator, and the read pane at the same time; it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Context-aware footer** — the footer is now a live action bar: it shows the actions available
+  for what the cursor is on (comment a line, edit/delete the comment under the cursor, expand a
+  fold or directory, send), the most likely one highlighted, dropping the least relevant to fit
+  one line. `u/b/t scope` stays available everywhere while reviewing, and `s send N` appears once
+  a comment is written. Replaces the static key-hint line.
+
+### Fixed
+- **PR empty state renders once** — "no PR for this branch yet…" (and the other PR loading and
+  degraded messages) showed in the header, the navigator, and the read pane at the same time; it
+  now shows only in the read pane.
+
 ## [0.3.0] — 2026-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,7 +69,24 @@ herdr plugin link .
 `just install` (re)places the binary with a fresh file and ad-hoc re-signs it. On Apple Silicon
 that matters: overwriting a code-signed binary in place invalidates its signature, and macOS then
 SIGKILLs it at launch — so a plain `cp target/release/herdr-reviewr bin/` makes the sidebar pane
-open and close instantly. Re-run `just install` after each rebuild to refresh the linked binary.
+open and close instantly.
+
+**Iterating on changes.** The dev loop after the first link is:
+
+1. Edit the code.
+2. `just install` — rebuilds the binary and re-signs it under `bin/`.
+3. **Relaunch the sidebar** — toggle it off and back on with your keybind. The open pane keeps
+   running the *old* process until it is relaunched, so a rebuild alone changes nothing on screen.
+
+This only works while the plugin is **linked**, not installed from the marketplace. Check with
+`herdr plugin list`: a `github:…` source means the pane runs a *downloaded* binary under
+`~/.config/herdr/plugins/github/`, so your local rebuilds never appear no matter how often you
+`just install`. Switch a GitHub install to a dev link with:
+
+```bash
+herdr plugin uninstall persiyanov.reviewr   # config is keyed by id and survives
+herdr plugin link .
+```
 
 ## Configuration
 

--- a/docs/plans/2026-06-27-footer-keys-overlay/plan.md
+++ b/docs/plans/2026-06-27-footer-keys-overlay/plan.md
@@ -1,0 +1,76 @@
+# Context-Aware Footer — Delivery Plan
+
+**Specs:** ../../../specs/tui.md — the living reference this plan delivers
+
+## Milestone Map
+
+1. **Context-aware footer** — single milestone; the footer becomes a live action bar that shows the actions available for the current context, the primary highlighted, the rest dropped to fit one line.
+
+## Goal
+
+The footer teaches by showing: only the actions that work for what the cursor is on, most-relevant first, on every tab — no static legend, no overlay to memorize.
+
+## Definition of Done
+
+- The footer shows context-correct actions: a diff line offers `c comment · v select`; a live selection `c comment · esc clear`; a commented line `e edit · d delete · n/N jump`; a fold `→ expand fold`; a file `⇥ diff · u/b/t scope`; a directory `→ expand` / `← collapse`.
+- The primary action is visually highlighted; a dim stable `⇥ pane · 1·2·3 · q` cluster sits at the right; both fit one line, dropping least-relevant with a trailing `…`.
+- `s send N` (count folded in) appears whenever a comment is written, wherever the cursor is.
+- The PR tab footer leads with the PR state summary, then `o open ↗`, then orientation.
+- Approach A is gone: no `Mode::Help`, no keys overlay, no `?` binding.
+- `cargo test` green, including pure `footer_actions` context tests and footer render tests.
+
+## Exit State
+
+Closed list — anything not named here is not built.
+
+- `FooterAction` enum + `Tier` enum (`Primary` / `Normal` / `Orient`) in `app.rs`.
+- `App::footer_actions(&self) -> Vec<(FooterAction, Tier)>` in `app.rs` — the pure context→actions mapping, the testable brain.
+- `render_footer(frame, app, area)` in `ui.rs` — maps actions to key+label, styles by tier, fits one line (orientation dropped first, then trailing `Normal` actions; `…` when clipped); prepends the PR state summary on the PR tab; shows the transient status among the actions.
+- Action→(key,label) and tier→style mapping helpers in `ui.rs`.
+- `tab_bar_spans` and `Scope::cycle` — unchanged, retained.
+- The footer band is one fixed row (`vrows` reserves `Length(1)`); `footer_height` removed.
+
+**Removed** (Approach A, now superseded): `Mode::Help`, `App::open_help`/`close_help`, `render_keys_overlay`, the `?` bindings + Help key-dispatch branch + `Mode::Help` mouse guard, the `Mode::Help` render dispatch, the `?` keymap-table row, and the static `footer_content` hint strings.
+
+## Specs Touched
+
+| Spec | What this plan realizes | At the gate |
+| --- | --- | --- |
+| `tui.md` | the **Footer** section (the rest already ships) | Draft → Current |
+
+## Out of Scope
+
+- Colorblind diff-gutter cue and the silent-no-op status nudges — separate review items.
+- A `?` overflow overlay behind the `…` — explicitly rejected; `…` is a passive marker only.
+
+## Likely Files
+
+- `src/app.rs` — `FooterAction`/`Tier`, `footer_actions`; remove `Mode::Help` + `open_help`/`close_help`
+- `src/ui.rs` — `render_footer` rewrite + mapping helpers; remove `render_keys_overlay`, `footer_content`, `footer_height`; `vrows` footer → `Length(1)`
+- `src/lib.rs` — remove `?` bindings, Help dispatch, `Mode::Help` mouse guard
+- `tests/app_flow.rs` — `footer_actions` context tests; remove the Help-mode tests
+- `tests/render.rs` — footer action-bar render tests; remove the keys-overlay test
+
+## Execution Plan
+
+1. Remove Approach A from `app.rs` (`Mode::Help`, `open_help`/`close_help`, the `pending_location` arm) and `lib.rs` (`?` bindings, Help dispatch, mouse guard).
+2. Add `FooterAction` + `Tier` and `footer_actions` to `app.rs`.
+3. Rewrite `render_footer` in `ui.rs` (mapping helpers, tier styling, one-line fit + `…`, PR state prefix); remove `render_keys_overlay`, `footer_content`, `footer_height`; set `vrows` footer to one row; drop the `Mode::Help` render dispatch.
+4. Replace the keys-overlay/footer tests with `footer_actions` context tests and footer render tests.
+
+## Verification
+
+- **Done:** `cargo test`. `tests/app_flow.rs` asserts `footer_actions` returns the right primary per context (content→`Comment`, fold→`ExpandFold`, selection→`Comment`+`ClearSelection`, commented line→`EditComment`, file→`TogglePane`, dir→`Expand`/`Collapse`) and that `Send` appears iff the store is non-empty; `tests/render.rs` asserts the bar paints the primary, the orientation cluster, and a status among the actions.
+- **Tight:** the diff equals Exit State — no `Mode::Help`/overlay/`?` residue; `footer_content` and `footer_height` deleted, not left beside `render_footer`.
+- **Invariants upheld:**
+  - The footer never lists an action that wouldn't work in the state — covered by the per-context `footer_actions` tests (`specs/tui.md` Footer).
+  - A comment is never lost to a refresh — untouched.
+
+## Replan Triggers
+
+- If the fit/`…` logic can't keep the primary action visible at a realistic minimum sidebar width, revisit the drop order (not the model) and update `specs/tui.md`.
+
+## Replan Log
+
+- 2026-06-27: initial plan (lean footer + `?` overlay).
+- 2026-06-27: replanned to the context-aware action bar; Approach A (overlay + lean hints) superseded and removed.

--- a/specs/forge-host.md
+++ b/specs/forge-host.md
@@ -24,7 +24,7 @@ The snapshot:
 - `number`, `title`, `url` (int, string, string) — identity; `number` is `null` when the branch has no PR.
 - `state` (enum, `open`/`merged`/`closed`) and `is_draft` (bool) — lifecycle; only `open` is the live case.
 - `base_ref` (string) — the merge target; the PR head commit is read for `sync` (below) but not stored.
-- `merge` (enum, `clean`/`conflicting`/`behind`/`blocked`/`unstable`/`checking`) — derived from GitHub's `mergeable` and `mergeStateStatus`.
+- `merge` (enum, `clean`/`conflicting`/`blocked`) — the actionable merge blockers, derived from GitHub's `mergeable` and `mergeStateStatus`.
 - `sync` (enum, `in_sync`/`unpushed`/`behind`, with a count) — local `HEAD` vs `head_oid`.
 - `checks` (list) — one row per latest check: `name` and `status` (the conclusion folded in).
 - `comments` (list) — one row per comment, newest first: `kind`, `author`, `author_is_bot`, `anchor`, `body`, `snippet`, `created_at`, `is_resolved`, `is_outdated`, `reply_count`.
@@ -52,8 +52,8 @@ A `comments` row:
 
 ### Derived state
 
-- `merge` folds GitHub's `mergeable` and `mergeStateStatus`: `CONFLICTING`/`DIRTY` → `conflicting`, `BEHIND` → `behind`, `BLOCKED` → `blocked`, `UNSTABLE` → `unstable`, `CLEAN` → `clean`.
-- `mergeable=UNKNOWN` is GitHub computing lazily — it shows `checking`, never asserted as a conflict.
+- `merge` folds GitHub's `mergeable` and `mergeStateStatus` to the blockers worth surfacing: `CONFLICTING`/`DIRTY` → `conflicting`, `BLOCKED` → `blocked`; everything else (`CLEAN`, `BEHIND`, `UNSTABLE`, and still-computing `UNKNOWN`) → `clean`, which the footer shows as nothing.
+- `mergeable=UNKNOWN` is GitHub computing lazily — it folds to `clean`, never asserted as a conflict unless `mergeStateStatus` is `DIRTY`.
 - `sync` compares local `HEAD` to `head_oid` — equal is `in_sync`, `HEAD` ahead is `unpushed` (count via `git rev-list --count <head_oid>..HEAD`), `head_oid` ahead is `behind`.
 - `unpushed` means the checks and comments on screen describe an older commit than your local tree.
 

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -55,6 +55,7 @@ Every action has a keyboard binding. The mouse-relevant ones also work by click 
 | toggle line wrap | `w` | — |
 | resize the panes — widen / narrow the file list | `]` / `[` | drag the divider between the panes |
 | select a line range, removed lines included | `v` then move | click-drag in the diff |
+| clear the line selection | `esc` | — |
 | comment on the selection (opens the editor below — see Comment editor) | `c`, type, `enter` | after a drag-select |
 | edit the comment under the cursor | `e` | — |
 | delete the comment under the cursor | `d` | — |
@@ -80,7 +81,7 @@ The footer is a live action bar: it shows the actions available for what you are
 - **Primary action** — the most likely next step, in a bright accent, always shown.
 - **Other available actions** — what else works here, in normal text.
 - **Send** — `s send N`, with the comment count riding the action; it rises to just below the primary once any comment is written, and is absent when none are.
-- **Orientation** — a dim, stable cluster at the right (`⇥ pane · 1·2·3 tab · q quit`, less the pane toggle on `PR`); the only fixed part, dropped first when space is tight.
+- **Orientation** — a dim, stable cluster at the right — the pane toggle, the tab digits, and quit (`⇥ files · 1·2·3 · q`, less the pane toggle on `PR`); the only fixed part, dropped first when space is tight.
 - **Transient status** — a message like `comment added` shows briefly among the actions and fades; it never replaces them.
 
 The bar is one line, filled by priority — primary, then send, then the other actions, then orientation — until the width runs out; a trailing `…` marks anything clipped. Movement keys aren't shown: moving the cursor is obvious. The comment editor and the comments list show their own actions (see those sections).
@@ -93,7 +94,7 @@ The actions follow the cursor:
 | A live selection | `c comment` | `esc clear` |
 | A commented line | `e edit` | `d delete · n/N jump` |
 | A fold | `→ expand fold` | — |
-| A file (file list) | `⇥ review diff` | — |
+| A file (file list) | `⇥ diff` | — |
 | A collapsed directory | `→ expand` | — |
 | An expanded directory | `← collapse` | — |
 | Nothing to review (awaiting a turn) | `u/b/t scope` | `r refresh` |

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -115,7 +115,7 @@ The `PR` tab is a read-only mirror of the pull request, in the same two-pane fra
 
 ```
  1 Changes  2 All files  3 PR              Deep research: GPT-5.5/5.4-mini upgrade…  merged #226 ↗
-╭─ @codex · manager.py:115 ────────────────────────────╮╭─ PR ─────────────────────────╮
+╭─ @codex · manager.py:115 ──────────────────────────╮╭─ Checks & comments ──────────╮
 │ -    if primary_result.status == PERM_FAILURE:        ││ checks  ✗ 1 failing          │
 │ -        return primary_result                        ││  ✓ build-main-image          │
 │                                                       ││  ✓ review                    │
@@ -133,7 +133,7 @@ The `PR` tab is a read-only mirror of the pull request, in the same two-pane fra
 
 - The header right-anchors a clickable `status #226 ↗` chip — status colored by lifecycle (`open` green, `draft` yellow, `merged` mauve, `closed` red), the `↗` in the number's colour — with the PR title right-aligned to its left, truncated to fit. Clicking the chip (or `o`) opens the PR.
 - The footer is the action bar (see **Footer**): on this read-only tab it leads with the PR's merge, sync, and checks state and the comment count (`⚠ conflicts with main · ⇡ 2 unpushed · ✗ 1 failing · 5 comments`), with merge and sync shown only while the PR is open, then `o open ↗` and the dim orientation cluster. When a capped surface has more rows than fetched, a trailing `+more on GitHub ↗` marker is appended (`forge-host.md`).
-- The right pane is the navigator: a status-only `checks` section (each check as `icon name`) above the `comments` list, which is what the cursor walks.
+- The right pane (titled `Checks & comments`, so it doesn't repeat the left pane's `PR`) is the navigator: a status-only `checks` section (each check as `icon name`) above the `comments` list, which is what the cursor walks.
 - The `comments` list is newest first, each row `@author anchor age`, with an `outdated` or `resolved` marker where GitHub has receded the thread.
 - The left pane reads the selected comment: a finding shows its `diff_hunk` as text then the body, a review or plain comment shows its prose.
 - A human author is emphasised over the bots, so a person's comment stands out in a bot-heavy list.

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -1,5 +1,5 @@
 ---
-Status: Draft
+Status: Current
 Created: 2026-06-23
 Last edited: 2026-06-27
 ---
@@ -11,7 +11,7 @@ The terminal interface: how the review is laid out, how you drive it by keyboard
 ## Overview
 
 ```
-┌ 1 Changes  2 All files  [uncommitted]  9 changed ───────── [ Send (3) ] ┐
+┌ 1 Changes  2 All files  3 PR  [uncommitted]  9 changed ──── [ Send (3) ] ┐
 │ ⋯  11 unmodified lines                       │ M llm_registry.py  +18 -8  │
 │ 40    def resolve(self, name):               │ M deep_research.py +155-62 │
 │ 41 ▌  from .z import w                         │ D old_runner.py    -47     │
@@ -22,16 +22,16 @@ The terminal interface: how the review is laid out, how you drive it by keyboard
 │  └─────────────────────────────────────────┘ │                            │
 │ 42    return registry[name]                   │                            │
 ├───────────────────────────────────────────────┴──────────────────────────┤
-│ 9 changed · 3 comment(s)  1/2 tab · ⇥ pane · c comment · s send · l list │
+│ enter save · ⇧⏎ newline · esc cancel                                       │
 └────────────────────────────────────────────────────────────────────────────┘
 ```
 
-- The header shows both tabs with the active one highlighted, the scope, the count of files changed in the scope, and a clickable `Send` button with the comment count.
+- The header shows the three tabs with the active one highlighted, the scope, the count of files changed in the scope, and a clickable `Send` button with the comment count.
 - The left pane is the selected file's diff — syntax-highlighted, with line numbers, change bars, word-level emphasis, and foldable context, defined in `diff-view.md`.
 - The right pane is the changed-files navigator for the current scope — a directory tree, defined in `file-list.md`.
 - Comments are one set across both tabs and export together; each tab otherwise owns its state (see **Tabs**).
 - The comment input opens **inline, directly under the last line of the selection**, pushing the diff below it down; it grows as you type more lines. It is not a footer band.
-- The footer is a key-hint and status line.
+- The footer is a live action bar — the actions available for what you're doing now, the most likely one highlighted, the rest dropped to fit one line (see **Footer**).
 
 The tab bar shows `Changes`, `All files`, and `PR`. The active tab sets the two panes' content: a diff and changed-files tree in `Changes`, file content and a whole-repo tree in `All files`, and the PR's checks and comments in `PR` (see **PR tab**). The review loop — select, comment, send — is the same in `Changes` and `All files`; `PR` is a read-only mirror of the pull request, with no authoring.
 
@@ -69,6 +69,39 @@ Writing a comment: select a range or land on a line, press `c`, and an input box
 
 On save the input box closes and the comment stays visible: it renders as a **read-only card spliced inline under its line**, titled with its location, so written feedback is always on screen while reviewing rather than hidden behind a marker. `e` reopens the card under the cursor as an edit box in place (its card is hidden while editing); `d` deletes it. There is no single-vs-all choice: `s` / `S` (or the `Send` button) sends every written comment, and a successful send reports a transient status such as `sent 3 comments` that fades after a few seconds.
 
+### Footer
+
+The footer is a live action bar: it shows the actions available for what you are doing right now, the most likely one highlighted, and drops the least relevant when the line is full. It never lists a key that wouldn't work in the current state, so it teaches by showing rather than by a memorized map.
+
+```
+ c comment · v select lines                          │ ⇥ files · 1·2·3 · q
+```
+
+- **Primary action** — the most likely next step, in a bright accent, always shown.
+- **Other available actions** — what else works here, in normal text.
+- **Send** — `s send N`, with the comment count riding the action; it rises to just below the primary once any comment is written, and is absent when none are.
+- **Orientation** — a dim, stable cluster at the right (`⇥ pane · 1·2·3 tab · q quit`, less the pane toggle on `PR`); the only fixed part, dropped first when space is tight.
+- **Transient status** — a message like `comment added` shows briefly among the actions and fades; it never replaces them.
+
+The bar is one line, filled by priority — primary, then send, then the other actions, then orientation — until the width runs out; a trailing `…` marks anything clipped. Movement keys aren't shown: moving the cursor is obvious. The comment editor and the comments list show their own actions (see those sections).
+
+The actions follow the cursor:
+
+| Where the cursor is | Primary | Also |
+| --- | --- | --- |
+| A diff line | `c comment` | `v select` |
+| A live selection | `c comment` | `esc clear` |
+| A commented line | `e edit` | `d delete · n/N jump` |
+| A fold | `→ expand fold` | — |
+| A file (file list) | `⇥ review diff` | — |
+| A collapsed directory | `→ expand` | — |
+| An expanded directory | `← collapse` | — |
+| Nothing to review (awaiting a turn) | `u/b/t scope` | `r refresh` |
+
+`u/b/t scope` is always available while reviewing, so it shows in every context on the `Changes` and `All files` tabs alongside the context's own actions (except where switching scope is itself the primary — the empty and no-diff states). Whenever a comment is written, `s send N · l list` joins the bar wherever the cursor is. The changed-file count stays in the header (scope summary + `Send` button); the footer carries only the comment count, folded into `s send N`.
+
+On the read-only `PR` tab the bar leads with the PR's state — its merge, sync, checks, and comment counts — since that is the relevant thing to show, not authoring actions; `o open ↗` follows, then the orientation cluster (see **PR tab**).
+
 ### Tabs
 
 - Each tab owns its state: its opened file or card, the scroll, the cursor, and which directories are expanded or cards are sent. Nothing carries between the tabs.
@@ -95,11 +128,11 @@ The `PR` tab is a read-only mirror of the pull request, in the same two-pane fra
 │                                                       ││ @claude manager.py:39    2h  │
 │                                                       ││ @claude parse.py:187  outdated│
 ╰───────────────────────────────────────────────────────╯╰─────────────────────────────╯
- ⚠ conflicts with main · ⇡ 2 unpushed · ✗ 1 failing · 5 comments    j/k move · PgUp/PgDn scroll · o open ↗ · r refresh
+ ⚠ conflicts with main · ⇡ 2 unpushed · ✗ 1 failing · 5 comments   o open ↗   │ 1·2·3 · r · q
 ```
 
 - The header right-anchors a clickable `status #226 ↗` chip — status colored by lifecycle (`open` green, `draft` yellow, `merged` mauve, `closed` red), the `↗` in the number's colour — with the PR title right-aligned to its left, truncated to fit. Clicking the chip (or `o`) opens the PR.
-- The footer carries the merge, sync, and checks state and the comment count (`⚠ conflicts with main · ⇡ 2 unpushed · ✗ 1 failing · 5 comments`); merge and sync show only while the PR is open. When a capped surface has more rows than fetched, a trailing `+more on GitHub ↗` marker is appended (`forge-host.md`).
+- The footer is the action bar (see **Footer**): on this read-only tab it leads with the PR's merge, sync, and checks state and the comment count (`⚠ conflicts with main · ⇡ 2 unpushed · ✗ 1 failing · 5 comments`), with merge and sync shown only while the PR is open, then `o open ↗` and the dim orientation cluster. When a capped surface has more rows than fetched, a trailing `+more on GitHub ↗` marker is appended (`forge-host.md`).
 - The right pane is the navigator: a status-only `checks` section (each check as `icon name`) above the `comments` list, which is what the cursor walks.
 - The `comments` list is newest first, each row `@author anchor age`, with an `outdated` or `resolved` marker where GitHub has receded the thread.
 - The left pane reads the selected comment: a finding shows its `diff_hunk` as text then the body, a review or plain comment shows its prose.
@@ -176,6 +209,9 @@ The inline box is a plain-text field that behaves like an ordinary editor: the c
 - A plain text field, not a code editor — caret movement, edit-anywhere, word ops, and paste, but no selection, undo/redo, or markdown rendering. Review comments are short; that machinery is more than they need. Rejected: a fuller editor with selection and history.
 - The tab sets the view, not the file's state — `All files` shows a file's content even when it is changed; to read its diff you switch to `Changes`, so a tab renders one kind of thing. Rejected: showing the diff for changed files and content for unchanged ones in `All files`.
 - Click a tab to switch; the key is provisional — herdr is mouse-native, so the tab bar is clickable, and the keyboard binding is part of the open keymap. Rejected: locking a tab key now.
+- A context-aware action bar, not a static hint line — the footer shows only the actions that work for what the cursor is on, the most likely one highlighted, dropping the least relevant to fit one line. It teaches by surfacing the next move in place, so nothing has to be memorized. Rejected: a static dump of every binding (unscannable, grows with each key); and a lean footer plus a `?` keys overlay (still a map to open and learn, the opposite of teaching in place).
+- One footer painter across all tabs — a single band renders on every tab; only its contents differ (actions on the authoring tabs, the PR's state plus `o open` on `PR`). Rejected: the `PR` tab's separate, dimmer footer.
+- Changed count in the header, comment count in the footer's `Send` — the changed-file count stays in the header (scope summary + `Send` button); the footer carries only the comment count, folded into `s send N` so the tally rides the action it feeds. Rejected: a standalone count segment, or repeating `N changed` in the footer.
 
 ## Open decisions
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -118,12 +118,12 @@ pub enum FooterAction {
 }
 
 /// A footer action's visual weight, and its survival priority when the line is too narrow:
-/// `Orient` is dropped first, then trailing `Normal` actions; `Primary` is never dropped.
+/// `Orientation` is dropped first, then trailing `Normal` actions; `Primary` is never dropped.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Tier {
     Primary,
     Normal,
-    Orient,
+    Orientation,
 }
 
 /// The full state of the review session.
@@ -1508,7 +1508,7 @@ impl App {
     #[must_use]
     pub fn footer_actions(&self) -> Vec<(FooterAction, Tier)> {
         use FooterAction as A;
-        use Tier::{Normal, Orient, Primary};
+        use Tier::{Normal, Orientation, Primary};
 
         // A modal sub-task owns the whole bar — no tab/quit orientation while you're in one.
         match self.mode {
@@ -1527,15 +1527,17 @@ impl App {
             Mode::Normal => {}
         }
 
-        // The read-only PR tab: the state summary leads (rendered separately); `o open` is the act.
+        // The read-only PR tab: the state summary leads (rendered separately); `o open` is the
+        // act — available for any resolved PR, not only while a comment is selected, since `o`
+        // opens the PR URL itself (`pr_open`).
         if self.tab == Tab::Pr {
             let mut out = Vec::new();
-            if self.pr_selected_comment().is_some() {
+            if self.pr_snapshot().is_some() {
                 out.push((A::OpenPr, Primary));
             }
-            out.push((A::Tabs, Orient));
-            out.push((A::Refresh, Orient));
-            out.push((A::Quit, Orient));
+            out.push((A::Tabs, Orientation));
+            out.push((A::Refresh, Orientation));
+            out.push((A::Quit, Orientation));
             return out;
         }
 
@@ -1579,19 +1581,20 @@ impl App {
             out.push((A::Scope, Normal));
         }
 
-        // Once a comment is written, sending is the next relevant move — just below the primary.
+        // Once a comment is written, sending is the next relevant move — just below the primary
+        // (every branch above pushed a primary, so index 1 is in range).
         if !self.store.is_empty() {
-            out.insert(1.min(out.len()), (A::Send, Normal));
+            out.insert(1, (A::Send, Normal));
             out.push((A::List, Normal));
         }
 
         // The dim, stable orientation cluster: the pane toggle (unless it is already the
         // primary), the tabs, quit.
         if !pane_is_primary && !self.file_rows.is_empty() {
-            out.push((A::TogglePane, Orient));
+            out.push((A::TogglePane, Orientation));
         }
-        out.push((A::Tabs, Orient));
-        out.push((A::Quit, Orient));
+        out.push((A::Tabs, Orientation));
+        out.push((A::Quit, Orientation));
         out
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1511,17 +1511,20 @@ impl App {
         use Tier::{Normal, Orientation, Primary};
 
         // A modal sub-task owns the whole bar — no tab/quit orientation while you're in one.
+        // The escape action comes right after the primary so the exit hint survives a
+        // narrow-width trim (trailing actions are dropped first); modals have no orientation
+        // cluster to carry it otherwise.
         match self.mode {
             Mode::Composing { .. } => {
-                return vec![(A::Save, Primary), (A::Newline, Normal), (A::Cancel, Normal)];
+                return vec![(A::Save, Primary), (A::Cancel, Normal), (A::Newline, Normal)];
             }
             Mode::List => {
                 return vec![
                     (A::Send, Primary),
+                    (A::CloseList, Normal),
                     (A::Copy, Normal),
                     (A::EditComment, Normal),
                     (A::DeleteComment, Normal),
-                    (A::CloseList, Normal),
                 ];
             }
             Mode::Normal => {}
@@ -1566,7 +1569,7 @@ impl App {
         } else if self.select_anchor.is_some() {
             out.push((A::Comment, Primary));
             out.push((A::ClearSelection, Normal));
-        } else if self.commented_lines().contains(&self.diff_cursor) {
+        } else if self.comment_under_cursor().is_some() {
             out.push((A::EditComment, Primary));
             out.push((A::DeleteComment, Normal));
             out.push((A::JumpComment, Normal));

--- a/src/app.rs
+++ b/src/app.rs
@@ -88,6 +88,44 @@ pub enum Mode {
     List,
 }
 
+/// A footer action — what the bar offers for the current context. Semantic only: the renderer
+/// maps each to its key glyph and label and styles it by [`Tier`] (`specs/tui.md`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FooterAction {
+    Comment,
+    Select,
+    ClearSelection,
+    EditComment,
+    DeleteComment,
+    JumpComment,
+    ExpandFold,
+    ExpandDir,
+    CollapseDir,
+    /// Switch focus between the file list and the diff; the label names the destination pane.
+    TogglePane,
+    Scope,
+    Send,
+    List,
+    Copy,
+    Save,
+    Newline,
+    Cancel,
+    CloseList,
+    OpenPr,
+    Refresh,
+    Tabs,
+    Quit,
+}
+
+/// A footer action's visual weight, and its survival priority when the line is too narrow:
+/// `Orient` is dropped first, then trailing `Normal` actions; `Primary` is never dropped.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Tier {
+    Primary,
+    Normal,
+    Orient,
+}
+
 /// The full state of the review session.
 // The several bools (wrap, reveal_files, reveal_diff, resizing, should_quit) are independent
 // toggles, not a state machine in disguise, so the excessive-bools lint does not apply.
@@ -1073,6 +1111,14 @@ impl App {
         }
     }
 
+    /// Drop the range-selection anchor (the `esc` clear in the diff); a no-op when none is set.
+    pub fn clear_selection(&mut self) {
+        if self.select_anchor.is_some() {
+            self.select_anchor = None;
+            self.reveal_diff = true;
+        }
+    }
+
     /// The inclusive `[lo, hi]` diff-line range currently selected.
     pub fn selection_range(&self) -> (usize, usize) {
         match self.select_anchor {
@@ -1453,6 +1499,100 @@ impl App {
         if self.mode == Mode::List {
             self.mode = Mode::Normal;
         }
+    }
+
+    /// The actions the footer offers for the current context, most-relevant first, each tagged
+    /// with its visual tier. Pure — a context → action mapping, unit-tested without a terminal.
+    /// The renderer maps each to a key+label, styles it by tier, and drops the least relevant
+    /// (orientation first) to fit one line (`specs/tui.md`).
+    #[must_use]
+    pub fn footer_actions(&self) -> Vec<(FooterAction, Tier)> {
+        use FooterAction as A;
+        use Tier::{Normal, Orient, Primary};
+
+        // A modal sub-task owns the whole bar — no tab/quit orientation while you're in one.
+        match self.mode {
+            Mode::Composing { .. } => {
+                return vec![(A::Save, Primary), (A::Newline, Normal), (A::Cancel, Normal)];
+            }
+            Mode::List => {
+                return vec![
+                    (A::Send, Primary),
+                    (A::Copy, Normal),
+                    (A::EditComment, Normal),
+                    (A::DeleteComment, Normal),
+                    (A::CloseList, Normal),
+                ];
+            }
+            Mode::Normal => {}
+        }
+
+        // The read-only PR tab: the state summary leads (rendered separately); `o open` is the act.
+        if self.tab == Tab::Pr {
+            let mut out = Vec::new();
+            if self.pr_selected_comment().is_some() {
+                out.push((A::OpenPr, Primary));
+            }
+            out.push((A::Tabs, Orient));
+            out.push((A::Refresh, Orient));
+            out.push((A::Quit, Orient));
+            return out;
+        }
+
+        let mut out: Vec<(FooterAction, Tier)> = Vec::new();
+        // Whether the diff-jump is already the primary, so orientation doesn't repeat the toggle.
+        let mut pane_is_primary = false;
+
+        if self.file_rows.is_empty() {
+            // Nothing in scope to review: only switching scope or refreshing is useful.
+            out.push((A::Scope, Primary));
+            out.push((A::Refresh, Normal));
+        } else if self.focus == Focus::Files {
+            match self.file_rows.get(self.file_cursor).map(|r| &r.kind) {
+                Some(RowKind::Dir { expanded: true, .. }) => out.push((A::CollapseDir, Primary)),
+                Some(RowKind::Dir { expanded: false, .. }) => out.push((A::ExpandDir, Primary)),
+                _ => {
+                    out.push((A::TogglePane, Primary)); // ⇥ into the diff to review
+                    pane_is_primary = true;
+                }
+            }
+        } else if self.visible.is_empty() {
+            // Diff focused but nothing to show (e.g. a binary): only the scope switch helps.
+            out.push((A::Scope, Primary));
+        } else if self.on_fold() {
+            out.push((A::ExpandFold, Primary));
+        } else if self.select_anchor.is_some() {
+            out.push((A::Comment, Primary));
+            out.push((A::ClearSelection, Normal));
+        } else if self.commented_lines().contains(&self.diff_cursor) {
+            out.push((A::EditComment, Primary));
+            out.push((A::DeleteComment, Normal));
+            out.push((A::JumpComment, Normal));
+        } else {
+            out.push((A::Comment, Primary));
+            out.push((A::Select, Normal));
+        }
+
+        // Switching scope is always available while reviewing, so it shows in every context on
+        // the file tabs — unless it's already the primary (the empty / no-diff states above).
+        if !out.iter().any(|&(a, _)| a == A::Scope) {
+            out.push((A::Scope, Normal));
+        }
+
+        // Once a comment is written, sending is the next relevant move — just below the primary.
+        if !self.store.is_empty() {
+            out.insert(1.min(out.len()), (A::Send, Normal));
+            out.push((A::List, Normal));
+        }
+
+        // The dim, stable orientation cluster: the pane toggle (unless it is already the
+        // primary), the tabs, quit.
+        if !pane_is_primary && !self.file_rows.is_empty() {
+            out.push((A::TogglePane, Orient));
+        }
+        out.push((A::Tabs, Orient));
+        out.push((A::Quit, Orient));
+        out
     }
 
     pub fn list_move(&mut self, delta: isize) {

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -569,10 +569,10 @@ fn parse_iso(s: &str) -> Option<i64> {
     // Days from the civil date (Howard Hinnant's algorithm), then to seconds.
     let y = if mo <= 2 { y - 1 } else { y };
     let era = (if y >= 0 { y } else { y - 399 }) / 400;
-    let yoe = y - era * 400;
-    let doy = (153 * (if mo > 2 { mo - 3 } else { mo + 9 }) + 2) / 5 + d - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    let days = era * 146_097 + doe - 719_468;
+    let year_of_era = y - era * 400;
+    let day_of_year = (153 * (if mo > 2 { mo - 3 } else { mo + 9 }) + 2) / 5 + d - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    let days = era * 146_097 + day_of_era - 719_468;
     Some(days * 86_400 + h * 3600 + mi * 60 + se)
 }
 

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -58,16 +58,14 @@ pub enum PrState {
     Closed,
 }
 
-/// The mergeability, folded from GitHub's `mergeable` and `mergeStateStatus`.
+/// Whether the PR has a merge blocker worth surfacing, folded from GitHub's `mergeable` and
+/// `mergeStateStatus`. Only the actionable blockers are modelled; GitHub's `behind` / `unstable`
+/// / still-`checking` states carry nothing a reviewer acts on, so they fold into `Clean`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Merge {
     Clean,
     Conflicting,
-    Behind,
     Blocked,
-    Unstable,
-    /// GitHub is still computing mergeability (`UNKNOWN`).
-    Checking,
 }
 
 /// The local branch's position relative to the PR head (`head_oid`).
@@ -377,20 +375,14 @@ fn parse_state(s: &str) -> PrState {
     }
 }
 
-/// Fold GitHub's `mergeable` and `mergeStateStatus` into one [`Merge`]; `UNKNOWN` is `Checking`.
+/// Fold GitHub's `mergeable` and `mergeStateStatus` into a [`Merge`]. Only the actionable
+/// blockers are surfaced: conflicts and a `blocked` required gate. Everything else — `clean`,
+/// `behind`, `unstable`, and still-`unknown` (computing) — folds into `Clean` (shows nothing).
 fn derive_merge(mergeable: Option<&str>, state: Option<&str>) -> Merge {
-    match mergeable {
-        Some("CONFLICTING") => Merge::Conflicting,
-        Some("UNKNOWN") | None => match state {
-            Some("DIRTY") => Merge::Conflicting,
-            _ => Merge::Checking,
-        },
-        _ => match state {
-            Some("BEHIND") => Merge::Behind,
-            Some("BLOCKED") => Merge::Blocked,
-            Some("UNSTABLE") => Merge::Unstable,
-            _ => Merge::Clean,
-        },
+    match (mergeable, state) {
+        (Some("CONFLICTING"), _) | (_, Some("DIRTY")) => Merge::Conflicting,
+        (_, Some("BLOCKED")) => Merge::Blocked,
+        _ => Merge::Clean,
     }
 }
 
@@ -589,18 +581,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn merge_folds_the_two_github_fields() {
+    fn merge_surfaces_only_conflicts_and_blocked() {
         assert_eq!(derive_merge(Some("CONFLICTING"), Some("DIRTY")), Merge::Conflicting);
-        assert_eq!(derive_merge(Some("MERGEABLE"), Some("CLEAN")), Merge::Clean);
-        assert_eq!(derive_merge(Some("MERGEABLE"), Some("BEHIND")), Merge::Behind);
         assert_eq!(derive_merge(Some("MERGEABLE"), Some("BLOCKED")), Merge::Blocked);
-        assert_eq!(derive_merge(Some("MERGEABLE"), Some("UNSTABLE")), Merge::Unstable);
-        // UNKNOWN is GitHub computing lazily — never asserted as a conflict unless DIRTY.
-        assert_eq!(derive_merge(Some("UNKNOWN"), Some("UNKNOWN")), Merge::Checking);
+        // Everything non-actionable folds into Clean: clean, behind, unstable, still-computing.
+        assert_eq!(derive_merge(Some("MERGEABLE"), Some("CLEAN")), Merge::Clean);
+        assert_eq!(derive_merge(Some("MERGEABLE"), Some("BEHIND")), Merge::Clean);
+        assert_eq!(derive_merge(Some("MERGEABLE"), Some("UNSTABLE")), Merge::Clean);
+        assert_eq!(derive_merge(Some("UNKNOWN"), Some("UNKNOWN")), Merge::Clean);
+        // DIRTY means conflicts even while mergeability is still UNKNOWN or the field is missing.
         assert_eq!(derive_merge(Some("UNKNOWN"), Some("DIRTY")), Merge::Conflicting);
-        // `mergeable: null` (a missing field, not "UNKNOWN") folds the same as UNKNOWN.
-        assert_eq!(derive_merge(None, None), Merge::Checking);
         assert_eq!(derive_merge(None, Some("DIRTY")), Merge::Conflicting);
+        assert_eq!(derive_merge(None, None), Merge::Clean);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,6 +378,8 @@ fn handle_key(app: &mut App, key: KeyEvent, area: Rect) -> Result<()> {
         (Char('n'), _) => app.jump_comment(1),
         (Char('N'), _) => app.jump_comment(-1),
         (Char('l'), _) => app.open_list(),
+        // `esc` clears an in-progress line selection (the footer's `esc clear`).
+        (Esc, _) => app.clear_selection(),
         _ => {}
     }
     Ok(())
@@ -425,7 +427,7 @@ fn handle_mouse(app: &mut App, m: MouseEvent, area: Rect, heights: &[usize]) -> 
             } else if let Some(hit) = ui::hit_header(area, app, m.column, m.row) {
                 match hit {
                     ui::HeaderHit::Tab(tab) => app.set_tab(tab)?,
-                    ui::HeaderHit::Scope => app.set_scope(app.scope.toggled())?,
+                    ui::HeaderHit::Scope => app.set_scope(app.scope.cycle())?,
                     ui::HeaderHit::Send => app.export(&Agent),
                 }
             } else if let Some(i) = ui::hit_file(

--- a/src/model.rs
+++ b/src/model.rs
@@ -22,7 +22,7 @@ impl Scope {
 
     /// Cycle to the next scope, for the header chip click: uncommitted → branch → last turn.
     #[must_use]
-    pub fn toggled(self) -> Self {
+    pub fn cycle(self) -> Self {
         match self {
             Scope::Uncommitted => Scope::Branch,
             Scope::Branch => Scope::LastTurn,
@@ -173,11 +173,11 @@ mod tests {
     }
 
     #[test]
-    fn scope_toggles_and_labels() {
+    fn scope_cycles_and_labels() {
         // The chip click cycles through all three scopes and wraps.
-        assert_eq!(Scope::Uncommitted.toggled(), Scope::Branch);
-        assert_eq!(Scope::Branch.toggled(), Scope::LastTurn);
-        assert_eq!(Scope::LastTurn.toggled(), Scope::Uncommitted);
+        assert_eq!(Scope::Uncommitted.cycle(), Scope::Branch);
+        assert_eq!(Scope::Branch.cycle(), Scope::LastTurn);
+        assert_eq!(Scope::LastTurn.cycle(), Scope::Uncommitted);
         assert_eq!(Scope::Uncommitted.label(), "uncommitted");
         assert_eq!(Scope::LastTurn.label(), "last turn");
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -34,8 +34,8 @@ pub fn render(frame: &mut Frame, app: &App) {
         render_diff_view(frame, app, p.diff);
         render_file_list(frame, app, p.files);
     }
-    // One footer band on every tab, then any modal overlay on top (the keys overlay can open
-    // from the PR tab too, so it is drawn here, past the per-tab base).
+    // One footer band on every tab, drawn after the per-tab base so it sits on both layouts;
+    // then the comments-list modal on top when it is open.
     render_footer(frame, app, p.status);
 
     if app.mode == Mode::List {
@@ -1116,7 +1116,7 @@ fn render_composer(frame: &mut Frame, app: &App, area: Rect) {
 
 /// The key glyph and label for a footer action; an empty label renders the glyph alone. The
 /// `TogglePane` and `Send` labels depend on `app` (the destination pane, the comment count).
-fn action_kl(app: &App, action: FooterAction) -> (String, String) {
+fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
     use FooterAction as A;
     let (k, l): (&str, &str) = match action {
         A::Comment => ("c", "comment"),
@@ -1155,7 +1155,9 @@ fn tier_styles(tier: Tier) -> (Style, Style) {
             (Style::default().fg(cat::PEACH).add_modifier(Modifier::BOLD), text_style())
         }
         Tier::Normal => (Style::default().fg(cat::LAVENDER), Style::default().fg(cat::SUBTEXT0)),
-        Tier::Orient => (Style::default().fg(cat::OVERLAY0), Style::default().fg(cat::OVERLAY0)),
+        Tier::Orientation => {
+            (Style::default().fg(cat::OVERLAY0), Style::default().fg(cat::OVERLAY0))
+        }
     }
 }
 
@@ -1166,7 +1168,7 @@ fn action_spans(app: &App, acts: &[(FooterAction, Tier)]) -> Vec<Span<'static>> 
         if i > 0 {
             spans.push(Span::styled(" · ", Style::default().fg(cat::OVERLAY0)));
         }
-        let (key, label) = action_kl(app, action);
+        let (key, label) = action_key_label(app, action);
         let (key_style, label_style) = tier_styles(tier);
         spans.push(Span::styled(key, key_style));
         if !label.is_empty() {
@@ -1183,7 +1185,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
     let w = area.width as usize;
     let all = app.footer_actions();
     let (mut left_acts, orient_acts): (Vec<_>, Vec<_>) =
-        all.into_iter().partition(|&(_, t)| t != Tier::Orient);
+        all.into_iter().partition(|&(_, t)| t != Tier::Orientation);
 
     // The read-only PR tab leads with the PR's state summary; the transient status sits among
     // the actions and never displaces them.
@@ -1227,15 +1229,18 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         // Orientation is dropped; trim trailing `Normal` actions until the line fits, leaving
         // room for the `…` that marks the drop. The primary action is never trimmed.
         let dropped_orient = !orient.is_empty();
+        let mut popped = false;
         while line_width(&left) + 2 > w
             && left_acts.len() > 1
             && left_acts.last().is_some_and(|&(_, t)| t == Tier::Normal)
         {
             left_acts.pop();
+            popped = true;
             left = build_left(&left_acts);
         }
-        let trimmed = dropped_orient || line_width(&left) + 2 > w || left_acts.is_empty();
-        if trimmed {
+        // `…` whenever anything was clipped: the orientation cluster, a trimmed action, or a
+        // primary still too wide to fit.
+        if dropped_orient || popped || line_width(&left) + 2 > w {
             left.push(Span::styled(" …", Style::default().fg(cat::OVERLAY0)));
         }
         left

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1188,9 +1188,13 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
         all.into_iter().partition(|&(_, t)| t != Tier::Orientation);
 
     // The read-only PR tab leads with the PR's state summary; the transient status sits among
-    // the actions and never displaces them.
+    // the actions and never displaces them. The state line is capped so a long one never crowds
+    // the primary action (and the `…`) off the line — leaving room for the actions plus the marker.
+    let actions_w: usize = action_spans(app, &left_acts).iter().map(Span::width).sum();
     let pr_info = (app.tab == Tab::Pr).then(|| app.pr_snapshot()).flatten().map(|s| {
-        Span::styled(format!("{}   ", pr_state_line(s)), Style::default().fg(cat::SUBTEXT0))
+        let budget = w.saturating_sub(actions_w + 4).max(8);
+        let text = truncate_width(&format!("{}   ", pr_state_line(s)), budget);
+        Span::styled(text, Style::default().fg(cat::SUBTEXT0))
     });
     let status = (!app.status.is_empty())
         .then(|| Span::styled(format!("  · {} ", app.status), Style::default().fg(cat::PEACH)));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1367,10 +1367,7 @@ fn pr_state_line(s: &forge::PrSnapshot) -> String {
     if s.state == forge::PrState::Open {
         match s.merge {
             forge::Merge::Conflicting => parts.push(format!("⚠ conflicts with {}", s.base_ref)),
-            forge::Merge::Behind => parts.push(format!("behind {}", s.base_ref)),
             forge::Merge::Blocked => parts.push("blocked".into()),
-            forge::Merge::Unstable => parts.push("unstable".into()),
-            forge::Merge::Checking => parts.push("merge: checking…".into()),
             forge::Merge::Clean => {}
         }
         match s.sync {
@@ -1402,8 +1399,9 @@ fn checks_summary(s: &forge::PrSnapshot) -> String {
 /// The right navigator: the checks list above the newest-first comments list, with the cursor
 /// row filled and the view windowed to keep it on screen.
 fn render_pr_nav(frame: &mut Frame, app: &App, area: Rect) {
-    // Identity (number + title) lives in the header; this pane is just "PR".
-    let block = bordered("PR", true);
+    // The navigator over the PR's checks and comments. Identity lives in the header; the left
+    // pane reads the selected comment — so this pane names its contents, not "PR" again.
+    let block = bordered("Checks & comments", true);
     let inner = block.inner(area);
     frame.render_widget(block, area);
     let Some(s) = app.pr_snapshot() else {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -12,10 +12,10 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::app::{App, Focus, Mode, Tab};
+use crate::app::{App, Focus, FooterAction, Mode, Tab, Tier};
 use crate::diff::{FileDiff, FileState, Row};
 use crate::file_list::{Annotation, RowKind};
 use crate::forge;
@@ -29,34 +29,25 @@ pub fn render(frame: &mut Frame, app: &App) {
         render_pr_header(frame, app, p.tab);
         render_pr_read(frame, app, p.diff);
         render_pr_nav(frame, app, p.files);
-        render_pr_status(frame, app, p.status);
-        return;
+    } else {
+        render_tab_bar(frame, app, p.tab);
+        render_diff_view(frame, app, p.diff);
+        render_file_list(frame, app, p.files);
     }
-
-    render_tab_bar(frame, app, p.tab);
-    render_diff_view(frame, app, p.diff);
-    render_file_list(frame, app, p.files);
-    render_status_bar(frame, app, p.status);
+    // One footer band on every tab, then any modal overlay on top (the keys overlay can open
+    // from the PR tab too, so it is drawn here, past the per-tab base).
+    render_footer(frame, app, p.status);
 
     if app.mode == Mode::List {
         render_comments_list(frame, app, area);
     }
 }
 
-/// The vertical bands: tab bar, body, status. The comment input is inline in the
-/// diff, not a band of its own. The status band grows so its hints wrap rather than
-/// truncate at narrow widths.
+/// The vertical bands: tab bar, body, footer. The comment input is inline in the diff, not a
+/// band of its own. The footer action bar is one row — it fits by dropping the least-relevant
+/// actions, not by wrapping.
 fn vrows(area: Rect) -> Rc<[Rect]> {
-    let footer = footer_height(area.width);
-    Layout::vertical([Constraint::Length(1), Constraint::Min(3), Constraint::Length(footer)])
-        .split(area)
-}
-
-/// Rows the status band needs for the longest hint line to wrap at `width` (1–3).
-fn footer_height(width: u16) -> u16 {
-    // Widest footer (counts + status + the Normal-mode hints) is ~150 columns.
-    const FOOTER_COLS: u16 = 150;
-    FOOTER_COLS.div_ceil(width.max(1)).clamp(1, 3)
+    Layout::vertical([Constraint::Length(1), Constraint::Min(3), Constraint::Length(1)]).split(area)
 }
 
 /// The frame's layout rects: the diff pane, the file pane, and the whole body band. One
@@ -436,6 +427,27 @@ fn send_button_col(app: &App, width: usize) -> usize {
     before + width.saturating_sub(before + send_button(app).len())
 }
 
+/// The header's shared left side, painted by both tab bars: the lead pad, the three tab labels
+/// (the active one bright + underlined, the inactive ones at `SUBTEXT0`), and the trailing gap
+/// before each header's own suffix. One source so the two headers can't drift.
+fn tab_bar_spans(app: &App) -> Vec<Span<'static>> {
+    let bar = Style::default().bg(cat::SURFACE0);
+    let mut spans = vec![Span::styled(HEADER_LEAD, bar)];
+    for (i, (tab, label)) in TABS.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(TAB_GAP, bar));
+        }
+        let style = if *tab == app.tab {
+            bar.fg(cat::LAVENDER).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+        } else {
+            bar.fg(cat::SUBTEXT0)
+        };
+        spans.push(Span::styled(*label, style));
+    }
+    spans.push(Span::styled(HEADER_GAP, bar));
+    spans
+}
+
 fn render_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
     let chip = scope_chip(app);
     let suffix = header_suffix(app);
@@ -446,21 +458,7 @@ fn render_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
     // A quiet surface bar: the active tab in bright lavender, the inactive one dimmed, the
     // clickable scope and Send controls accented so they read as buttons.
     let bar = Style::default().bg(cat::SURFACE0);
-    let mut spans = vec![Span::styled(HEADER_LEAD, bar)];
-    for (i, (tab, label)) in TABS.iter().enumerate() {
-        if i > 0 {
-            spans.push(Span::styled(TAB_GAP, bar));
-        }
-        // The active tab is bright + underlined so the bar reads as tabs; the inactive one sits
-        // at `SUBTEXT0` (available), not the `OVERLAY0` disabled tone.
-        let style = if *tab == app.tab {
-            bar.fg(cat::LAVENDER).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
-        } else {
-            bar.fg(cat::SUBTEXT0)
-        };
-        spans.push(Span::styled(*label, style));
-    }
-    spans.push(Span::styled(HEADER_GAP, bar));
+    let mut spans = tab_bar_spans(app);
     spans.push(Span::styled(chip, bar.fg(cat::YELLOW).add_modifier(Modifier::BOLD)));
     spans.push(Span::styled(suffix, bar.fg(cat::OVERLAY0)));
 
@@ -1116,24 +1114,135 @@ fn render_composer(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(body, area);
 }
 
-fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
-    let left = format!(" {} changed · {} comment(s) ", app.changed_count(), app.store.len());
-    let mid = if app.status.is_empty() { String::new() } else { format!("· {} ", app.status) };
-    let hints = match app.mode {
-        Mode::Composing { .. } => "enter save · alt/shift+enter newline · esc cancel",
-        Mode::List => "↑↓ move · s send · y copy · e edit · d delete · esc close",
-        Mode::Normal => {
-            "1/2 tab · ⇥ pane · u/b/t scope · v select · c comment · s send · y copy · n/N jump · l list · r refresh · q quit"
+/// The key glyph and label for a footer action; an empty label renders the glyph alone. The
+/// `TogglePane` and `Send` labels depend on `app` (the destination pane, the comment count).
+fn action_kl(app: &App, action: FooterAction) -> (String, String) {
+    use FooterAction as A;
+    let (k, l): (&str, &str) = match action {
+        A::Comment => ("c", "comment"),
+        A::Select => ("v", "select"),
+        A::ClearSelection => ("esc", "clear"),
+        A::EditComment => ("e", "edit"),
+        A::DeleteComment => ("d", "delete"),
+        A::JumpComment => ("n/N", "jump"),
+        A::ExpandFold => ("→", "expand fold"),
+        A::ExpandDir => ("→", "expand"),
+        A::CollapseDir => ("←", "collapse"),
+        A::TogglePane => {
+            return ("⇥".into(), if app.focus == Focus::Files { "diff" } else { "files" }.into());
         }
+        A::Scope => ("u/b/t", "scope"),
+        A::Send => return ("s".into(), format!("send {}", app.store.len())),
+        A::List => ("l", "list"),
+        A::Copy => ("y", "copy"),
+        A::Save => ("enter", "save"),
+        A::Newline => ("⇧⏎", "newline"),
+        A::Cancel => ("esc", "cancel"),
+        A::CloseList => ("esc", "close"),
+        A::OpenPr => ("o", "open ↗"),
+        A::Refresh => ("r", "refresh"),
+        A::Tabs => ("1·2·3", ""),
+        A::Quit => ("q", ""),
     };
-    let line = Line::from(vec![
-        Span::styled(left, Style::default().fg(cat::TEXT)),
-        Span::styled(format!(" {mid}"), Style::default().fg(cat::PEACH)),
-        Span::styled(format!("  {hints}"), Style::default().fg(cat::OVERLAY0)),
-    ]);
-    // Fill the whole footer with the surface bar, matching the header band.
+    (k.into(), l.into())
+}
+
+/// A tier's `(key, label)` styles: the primary bright and bold, normal actions readable, the
+/// orientation cluster dim so the eye lands on what to do, not on the always-there anchors.
+fn tier_styles(tier: Tier) -> (Style, Style) {
+    match tier {
+        Tier::Primary => {
+            (Style::default().fg(cat::PEACH).add_modifier(Modifier::BOLD), text_style())
+        }
+        Tier::Normal => (Style::default().fg(cat::LAVENDER), Style::default().fg(cat::SUBTEXT0)),
+        Tier::Orient => (Style::default().fg(cat::OVERLAY0), Style::default().fg(cat::OVERLAY0)),
+    }
+}
+
+/// Render a run of actions as ` · `-separated `key label` spans, styled per tier.
+fn action_spans(app: &App, acts: &[(FooterAction, Tier)]) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    for (i, &(action, tier)) in acts.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" · ", Style::default().fg(cat::OVERLAY0)));
+        }
+        let (key, label) = action_kl(app, action);
+        let (key_style, label_style) = tier_styles(tier);
+        spans.push(Span::styled(key, key_style));
+        if !label.is_empty() {
+            spans.push(Span::styled(format!(" {label}"), label_style));
+        }
+    }
+    spans
+}
+
+/// The footer action bar: the context's actions (primary highlighted) packed left, the dim
+/// orientation cluster packed right, fitting one line — orientation dropped first, then trailing
+/// `Normal` actions, with a trailing `…` marking anything clipped (`specs/tui.md`).
+fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
+    let w = area.width as usize;
+    let all = app.footer_actions();
+    let (mut left_acts, orient_acts): (Vec<_>, Vec<_>) =
+        all.into_iter().partition(|&(_, t)| t != Tier::Orient);
+
+    // The read-only PR tab leads with the PR's state summary; the transient status sits among
+    // the actions and never displaces them.
+    let pr_info = (app.tab == Tab::Pr).then(|| app.pr_snapshot()).flatten().map(|s| {
+        Span::styled(format!("{}   ", pr_state_line(s)), Style::default().fg(cat::SUBTEXT0))
+    });
+    let status = (!app.status.is_empty())
+        .then(|| Span::styled(format!("  · {} ", app.status), Style::default().fg(cat::PEACH)));
+
+    let build_left = |acts: &[(FooterAction, Tier)]| -> Vec<Span<'static>> {
+        let mut spans = vec![Span::raw(" ")];
+        if let Some(info) = &pr_info {
+            spans.push(info.clone());
+        }
+        spans.extend(action_spans(app, acts));
+        if let Some(st) = &status {
+            spans.push(st.clone());
+        }
+        spans
+    };
+    let orient: Vec<Span> = if orient_acts.is_empty() {
+        Vec::new()
+    } else {
+        let mut spans = vec![Span::styled("│ ", Style::default().fg(cat::OVERLAY0))];
+        spans.extend(action_spans(app, &orient_acts));
+        spans
+    };
+    let orient_w: usize = orient.iter().map(Span::width).sum();
+
+    let mut left = build_left(&left_acts);
+    let line_width = |s: &[Span]| -> usize { s.iter().map(Span::width).sum() };
+    let fits_with_orient = !orient.is_empty() && line_width(&left) + 1 + orient_w <= w;
+
+    let spans = if fits_with_orient {
+        // Leave one trailing cell so the last hint (`q`) doesn't butt against the edge.
+        let pad = w.saturating_sub(line_width(&left) + orient_w + 1);
+        left.push(Span::raw(" ".repeat(pad)));
+        left.extend(orient);
+        left
+    } else {
+        // Orientation is dropped; trim trailing `Normal` actions until the line fits, leaving
+        // room for the `…` that marks the drop. The primary action is never trimmed.
+        let dropped_orient = !orient.is_empty();
+        while line_width(&left) + 2 > w
+            && left_acts.len() > 1
+            && left_acts.last().is_some_and(|&(_, t)| t == Tier::Normal)
+        {
+            left_acts.pop();
+            left = build_left(&left_acts);
+        }
+        let trimmed = dropped_orient || line_width(&left) + 2 > w || left_acts.is_empty();
+        if trimmed {
+            left.push(Span::styled(" …", Style::default().fg(cat::OVERLAY0)));
+        }
+        left
+    };
+
     frame.render_widget(
-        Paragraph::new(line).style(Style::default().bg(cat::SURFACE0)).wrap(Wrap { trim: false }),
+        Paragraph::new(Line::from(spans)).style(Style::default().bg(cat::SURFACE0)),
         area,
     );
 }
@@ -1204,44 +1313,27 @@ fn selectable_row(
 /// with the PR title right-aligned to its left. Merge/sync/checks live in the footer.
 fn render_pr_header(frame: &mut Frame, app: &App, area: Rect) {
     let bar = Style::default().bg(cat::SURFACE0);
-    let mut spans = vec![Span::styled(HEADER_LEAD, bar)];
-    for (i, (tab, label)) in TABS.iter().enumerate() {
-        if i > 0 {
-            spans.push(Span::styled(TAB_GAP, bar));
-        }
-        let style = if *tab == app.tab {
-            bar.fg(cat::LAVENDER).add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
-        } else {
-            bar.fg(cat::SUBTEXT0)
-        };
-        spans.push(Span::styled(*label, style));
-    }
-    spans.push(Span::styled(HEADER_GAP, bar));
+    let mut spans = tab_bar_spans(app);
     let lead_tabs: usize = spans.iter().map(Span::width).sum();
     let w = area.width as usize;
 
-    match &app.pr {
-        forge::PrView::Pr(s) => {
-            let number = format!("#{}", s.number);
-            let (status, color) = pr_status_chip(s);
-            let chip_w = pr_chip_width(s);
-            // The title fills the gap left of the chip, right-aligned against it (a leading pad).
-            let name = truncate_width(&s.title, w.saturating_sub(lead_tabs + chip_w + 2).max(4));
-            let pad = w.saturating_sub(lead_tabs + name.width() + 2 + chip_w);
-            spans.push(Span::styled(" ".repeat(pad), bar));
-            spans.push(Span::styled(name, bar.fg(cat::SUBTEXT0)));
-            spans.push(Span::styled("  ", bar));
-            spans.push(Span::styled(status, bar.fg(color).add_modifier(Modifier::BOLD)));
-            spans.push(Span::styled(" ", bar));
-            spans.push(Span::styled(number, bar.fg(cat::YELLOW).add_modifier(Modifier::BOLD)));
-            // The arrow shares the PR number's colour, reading as part of the clickable chip.
-            spans.push(Span::styled(" ↗", bar.fg(cat::YELLOW)));
-        }
-        forge::PrView::Ambiguous(n) => spans.push(Span::styled(
-            format!("{n} open PRs for this branch — open one on GitHub"),
-            bar.fg(cat::OVERLAY0),
-        )),
-        view => spans.push(Span::styled(pr_empty_msg(view), bar.fg(cat::OVERLAY0))),
+    // A resolved PR shows its identity chip; with no PR the header carries nothing — the read
+    // pane is the single home for the empty/degraded message, not repeated across all regions.
+    if let forge::PrView::Pr(s) = &app.pr {
+        let number = format!("#{}", s.number);
+        let (status, color) = pr_status_chip(s);
+        let chip_w = pr_chip_width(s);
+        // The title fills the gap left of the chip, right-aligned against it (a leading pad).
+        let name = truncate_width(&s.title, w.saturating_sub(lead_tabs + chip_w + 2).max(4));
+        let pad = w.saturating_sub(lead_tabs + name.width() + 2 + chip_w);
+        spans.push(Span::styled(" ".repeat(pad), bar));
+        spans.push(Span::styled(name, bar.fg(cat::SUBTEXT0)));
+        spans.push(Span::styled("  ", bar));
+        spans.push(Span::styled(status, bar.fg(color).add_modifier(Modifier::BOLD)));
+        spans.push(Span::styled(" ", bar));
+        spans.push(Span::styled(number, bar.fg(cat::YELLOW).add_modifier(Modifier::BOLD)));
+        // The arrow shares the PR number's colour, reading as part of the clickable chip.
+        spans.push(Span::styled(" ↗", bar.fg(cat::YELLOW)));
     }
 
     // Fill the rest of the bar (the Pr arm already reaches the right edge).
@@ -1315,7 +1407,7 @@ fn render_pr_nav(frame: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
     let Some(s) = app.pr_snapshot() else {
-        frame.render_widget(dim_paragraph(pr_empty_msg(&app.pr)), inner);
+        // The empty/degraded message lives once, in the read pane; this navigator stays blank.
         return;
     };
     let width = inner.width as usize;
@@ -1438,18 +1530,6 @@ fn render_pr_read(frame: &mut Frame, app: &App, area: Rect) {
     // so casting first could wrap a large value below the clamp.
     let scroll = app.pr_read_scroll.min(lines.len().saturating_sub(1)) as u16;
     frame.render_widget(Paragraph::new(lines).scroll((scroll, 0)), inner);
-}
-
-/// The PR tab's footer: counts and the read-only key hints.
-fn render_pr_status(frame: &mut Frame, app: &App, area: Rect) {
-    let line = if !app.status.is_empty() {
-        app.status.clone()
-    } else if let Some(s) = app.pr_snapshot() {
-        format!(" {}    j/k move · PgUp/PgDn scroll · o open ↗ · r refresh", pr_state_line(s))
-    } else {
-        " PR    r refresh · q quit".to_string()
-    };
-    frame.render_widget(Paragraph::new(line).style(Style::default().fg(cat::SUBTEXT0)), area);
 }
 
 /// The one-line message for a loading or degraded PR view, each naming what unblocks it.

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -470,6 +470,42 @@ fn the_footer_offers_scope_everywhere_on_a_file_tab() {
 }
 
 #[test]
+fn the_pr_footer_offers_open_for_any_resolved_pr() {
+    use herdr_reviewr::app::Tab;
+    use herdr_reviewr::forge::{Merge, PrSnapshot, PrState, PrView, Sync};
+
+    let r = edited_repo();
+    let mut app = app_on(&r);
+    app.set_tab(Tab::Pr).unwrap();
+    // No resolved PR (still loading): nothing to open.
+    assert!(
+        !app.footer_actions().iter().any(|&(a, _)| a == FooterAction::OpenPr),
+        "no resolved PR → no open action"
+    );
+
+    // A resolved PR with zero comments still offers `o open` — `o` opens the PR URL, not a comment.
+    app.pr = PrView::Pr(Box::new(PrSnapshot {
+        number: 7,
+        title: "t".into(),
+        url: "u".into(),
+        state: PrState::Open,
+        is_draft: false,
+        base_ref: "main".into(),
+        merge: Merge::Clean,
+        sync: Sync::InSync,
+        checks: vec![],
+        comments: vec![],
+        truncated: false,
+    }));
+    assert!(app.pr_selected_comment().is_none(), "zero comments → nothing selected");
+    assert_eq!(
+        app.footer_actions().first().map(|&(a, _)| a),
+        Some(FooterAction::OpenPr),
+        "a resolved PR offers open even with no comments"
+    );
+}
+
+#[test]
 fn the_footer_offers_send_only_once_a_comment_exists() {
     let mut app = composing_app();
     app.cancel_comment();

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 
 use anyhow::{Result, bail};
 use common::Repo;
-use herdr_reviewr::app::{App, Focus, Mode};
+use herdr_reviewr::app::{App, Focus, FooterAction, Mode};
 use herdr_reviewr::export::ExportTarget;
 use herdr_reviewr::model::{Scope, Side};
 
@@ -419,6 +419,69 @@ fn a_paste_outside_the_editor_is_ignored() {
     let mut app = app_on(&r); // Normal mode, not composing
     app.input_paste("ignored");
     assert!(app.input.is_empty(), "paste does nothing outside the comment editor");
+}
+
+/// The primary (first) footer action for the current context.
+fn primary(app: &App) -> FooterAction {
+    app.footer_actions().first().expect("a footer action").0
+}
+
+#[test]
+fn the_footer_offers_the_action_for_what_the_cursor_is_on() {
+    let mut app = composing_app(); // diff focus, on a changed line, composer open
+    app.cancel_comment(); // back to Normal, still on the changed line
+    assert_eq!(primary(&app), FooterAction::Comment, "a diff line offers comment");
+
+    app.toggle_select();
+    assert_eq!(primary(&app), FooterAction::Comment, "a live selection still leads with comment");
+    assert!(
+        app.footer_actions().iter().any(|&(a, _)| a == FooterAction::ClearSelection),
+        "and offers to clear the selection"
+    );
+    app.toggle_select();
+
+    comment_on(&mut app, '+', "note");
+    // The cursor now sits on the line it just commented.
+    assert_eq!(primary(&app), FooterAction::EditComment, "a commented line offers edit");
+    assert!(
+        app.footer_actions().iter().any(|&(a, _)| a == FooterAction::Send),
+        "a written comment surfaces send wherever the cursor is"
+    );
+}
+
+#[test]
+fn esc_clears_a_live_selection() {
+    let mut app = composing_app();
+    app.cancel_comment();
+    app.toggle_select();
+    assert!(app.select_anchor.is_some(), "v starts a selection");
+    app.clear_selection();
+    assert!(app.select_anchor.is_none(), "esc clears the selection");
+}
+
+#[test]
+fn the_footer_offers_scope_everywhere_on_a_file_tab() {
+    let mut app = composing_app();
+    app.cancel_comment(); // diff focus, on a content line
+    let has_scope = |a: &App| a.footer_actions().iter().any(|&(x, _)| x == FooterAction::Scope);
+    assert!(has_scope(&app), "scope shows while reviewing a diff line");
+    app.focus = Focus::Files;
+    assert!(has_scope(&app), "scope shows in the file list too");
+}
+
+#[test]
+fn the_footer_offers_send_only_once_a_comment_exists() {
+    let mut app = composing_app();
+    app.cancel_comment();
+    assert!(
+        !app.footer_actions().iter().any(|&(a, _)| a == FooterAction::Send),
+        "no comments yet → no send action"
+    );
+    comment_on(&mut app, '+', "note");
+    assert!(
+        app.footer_actions().iter().any(|&(a, _)| a == FooterAction::Send),
+        "a comment written → send appears"
+    );
 }
 
 /// A repo whose `big.rs` has 40 lines with one change in the middle, so the head and

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -369,6 +369,34 @@ fn the_footer_drops_to_fit_and_marks_the_clip() {
 }
 
 #[test]
+fn the_pr_footer_keeps_the_open_action_when_the_state_line_is_long() {
+    use herdr_reviewr::app::Tab;
+    use herdr_reviewr::forge::{Check, CheckStatus, Merge, PrSnapshot, PrState, PrView, Sync};
+    let r = Repo::init();
+    r.write("x.rs", "y\n");
+    r.commit_all("init");
+    let mut app = App::new(r.path_buf(), Scope::Uncommitted, None);
+    app.reload().unwrap();
+    app.set_tab(Tab::Pr).unwrap();
+    app.pr = PrView::Pr(Box::new(PrSnapshot {
+        number: 226,
+        title: "t".into(),
+        url: "u".into(),
+        state: PrState::Open,
+        is_draft: false,
+        base_ref: "main".into(),
+        merge: Merge::Conflicting, // a long state line: conflicts · behind · failing · +more
+        sync: Sync::Behind(3),
+        checks: vec![Check { name: "ci".into(), status: CheckStatus::Failure }],
+        comments: vec![],
+        truncated: true,
+    }));
+    // At narrow width the state line is capped so the primary `o open ↗` is never crowded off.
+    let footer = footer_line(&render_at(&app, 60));
+    assert!(footer.contains("o open"), "the open action survives a long state line:\n{footer}");
+}
+
+#[test]
 fn the_footer_keeps_its_actions_alongside_a_status() {
     let mut app = edited_app();
     on_changed_line(&mut app);

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -39,6 +39,13 @@ fn render_buffer(app: &App) -> Buffer {
     terminal.backend().buffer().clone()
 }
 
+/// Render at a specific width (height fixed), for footer fit-to-width assertions.
+fn render_at(app: &App, width: u16) -> String {
+    let mut terminal = Terminal::new(TestBackend::new(width, 12)).unwrap();
+    terminal.draw(|f| ui::render(f, app)).unwrap();
+    dump(terminal.backend().buffer())
+}
+
 /// Catppuccin surface2 — the shared selection/cursor fill.
 const SELECTION_BG: ratatui::style::Color = ratatui::style::Color::Rgb(0x58, 0x5b, 0x70);
 /// Catppuccin peach — the comment-editor caret block.
@@ -342,6 +349,23 @@ fn the_footer_shows_the_action_for_the_context() {
     assert!(footer.contains("c comment"), "a diff line offers comment:\n{footer}");
     assert!(footer.contains("v select"), "and selecting a range:\n{footer}");
     assert!(!footer.contains("changed"), "the changed count is not in the footer:\n{footer}");
+}
+
+#[test]
+fn the_footer_drops_to_fit_and_marks_the_clip() {
+    let mut app = edited_app();
+    on_changed_line(&mut app); // diff focus, content line → c comment · v select · …
+    // Wide: every action fits, nothing is clipped.
+    let wide = footer_line(&render_at(&app, 120));
+    assert!(
+        wide.contains("c comment") && wide.contains("v select") && !wide.contains('…'),
+        "wide footer shows all actions, no clip marker:\n{wide}"
+    );
+    // Narrow: the primary survives, the least-relevant actions are trimmed, and `…` marks it.
+    let narrow = footer_line(&render_at(&app, 18));
+    assert!(narrow.contains("c comment"), "the primary action is never dropped:\n{narrow}");
+    assert!(narrow.contains('…'), "the clip is marked with …:\n{narrow}");
+    assert!(!narrow.contains("v select"), "the least-relevant action is trimmed:\n{narrow}");
 }
 
 #[test]

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -320,18 +320,42 @@ fn shows_tab_bar_file_list_and_diff() {
     assert!(out.contains("uncommitted"), "current scope shown");
     assert!(out.contains("hello.rs"), "file appears in the list");
     assert!(out.contains("BETA"), "diff content is rendered");
-    assert!(out.contains("changed"), "status bar shows the changed count");
+    assert!(out.contains("changed"), "the header shows the changed count");
+}
+
+/// The last non-blank rendered row — the footer band.
+fn footer_line(out: &str) -> String {
+    out.lines().rev().find(|l| !l.trim().is_empty()).unwrap_or_default().to_string()
+}
+
+/// Focus the diff on its first changed line.
+fn on_changed_line(app: &mut App) {
+    app.focus = Focus::Diff;
+    app.diff_cursor = app.visible.iter().position(|r| r.marker() == '+').unwrap();
 }
 
 #[test]
-fn the_footer_hints_wrap_instead_of_truncating() {
-    let app = edited_app();
-    // At a narrow width the Normal-mode hint line is far longer than the pane, so without
-    // wrapping the last hint ("quit") would be cut off the right edge.
-    let mut terminal = Terminal::new(TestBackend::new(60, 24)).unwrap();
-    terminal.draw(|f| ui::render(f, &app)).unwrap();
-    let out = dump(terminal.backend().buffer());
-    assert!(out.contains("quit"), "the wrapped footer keeps its last hint:\n{out}");
+fn the_footer_shows_the_action_for_the_context() {
+    let mut app = edited_app();
+    on_changed_line(&mut app);
+    let footer = footer_line(&render(&app));
+    assert!(footer.contains("c comment"), "a diff line offers comment:\n{footer}");
+    assert!(footer.contains("v select"), "and selecting a range:\n{footer}");
+    assert!(!footer.contains("changed"), "the changed count is not in the footer:\n{footer}");
+}
+
+#[test]
+fn the_footer_keeps_its_actions_alongside_a_status() {
+    let mut app = edited_app();
+    on_changed_line(&mut app);
+    app.status = "comment added".to_string();
+    let footer = footer_line(&render(&app));
+    // A status sits among the actions, never replacing them.
+    assert!(footer.contains("comment added"), "the status shows:\n{footer}");
+    assert!(
+        footer.contains("c comment"),
+        "the primary action persists alongside a status:\n{footer}"
+    );
 }
 
 #[test]
@@ -547,9 +571,16 @@ fn all_files_tab_bar_footer_and_count_read_for_the_tab() {
     let out = render(&app);
     assert!(out.contains("1 Changes"), "tab labels carry their switch digit:\n{out}");
     assert!(out.contains("2 All files"));
-    assert!(out.contains("1 changed"), "the count is named 'changed' in All files:\n{out}");
-    assert!(out.contains("1/2 tab"), "the footer hints the tab keys:\n{out}");
-    assert!(!out.contains("tab focus"), "the colliding 'tab focus' hint is renamed:\n{out}");
+    assert!(
+        out.contains("1 changed"),
+        "the changed count stays in the header on All files:\n{out}"
+    );
+    let footer = footer_line(&out);
+    assert!(footer.contains("scope"), "the footer shows context actions on All files:\n{footer}");
+    assert!(
+        !footer.contains("changed"),
+        "the changed count is not repeated in the footer:\n{footer}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Replaces the static footer hint line with a **live action bar**: it shows only the actions that work for what the cursor is on, the most likely one highlighted, dropping the least relevant to fit one line. The footer teaches by showing — no static legend, no keymap to memorize.

Examples:
- a diff line → `c comment · v select`
- a live selection → `c comment · esc clear`
- a commented line → `e edit · d delete · n/N jump`
- a fold → `→ expand fold`; a file → `⇥ diff`; a directory → `→ expand` / `← collapse`
- `u/b/t scope` stays available everywhere while reviewing; `s send N` appears once a comment is written
- a dim, stable `⇥ · 1·2·3 · q` orientation cluster sits at the right

## How

- `App::footer_actions() -> Vec<(FooterAction, Tier)>` — a pure context→actions mapping in `app.rs`, unit-tested without a terminal.
- `render_footer` in `ui.rs` maps each action to a key+label, styles it by tier, and fits one line (orientation dropped first, then trailing actions, with a trailing `…`).

## Also

- **Fix:** the PR empty-state message ("no PR for this branch yet…") rendered in the header, navigator, and read pane at once — now once, in the read pane.
- **Tidy:** one shared `tab_bar_spans` helper for both headers; `Scope::toggled` → `cycle`.

## Spec & tests

- `specs/tui.md` Footer section rewritten and promoted Draft → Current; `CHANGELOG.md` updated.
- 202 tests pass (new `footer_actions` context tests + footer render tests); clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)