### PR TITLE
feat: add quick file navigation integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ below are the full reference.
 | `1` `2` `3` | Switch tab — Changes / All files / PR |
 | `u` `b` `t` | Switch scope — uncommitted / branch / last turn |
 | `j` `k` · `↑` `↓` | Move the cursor in the focused pane |
+| `f` `F` | Jump to the next / previous file (from either pane) |
 | `PageUp` `PageDown` | Move a page · `Ctrl+U` `Ctrl+D` move a half-page |
 | `Tab` | Switch focus between the file list and the diff |
 | `→` `←` | Expand / collapse a directory or expand a fold; otherwise scroll the diff sideways |

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -44,6 +44,7 @@ Every action has a keyboard binding. The mouse-relevant ones also work by click 
 | action | keyboard | mouse |
 |--------|----------|-------|
 | move the cursor in the focused pane — in the file list this selects a file and loads its diff | `j` / `k` / `↑` / `↓` | click a file row |
+| jump to the next / previous file, skipping directories — works from either pane | `f` / `F` | — |
 | collapse / expand the directory under the cursor | `←` / `→` | click the directory row |
 | switch focus between the file list and the diff | `tab` | click a pane |
 | move the cursor a page in the focused pane | `PageUp` / `PageDown` / `ctrl+u` / `ctrl+d` | — |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1024,6 +1024,50 @@ impl App {
         Ok(())
     }
 
+    /// Jump the cursor to the next file in the tree, skipping directories. Works from either
+    /// pane, chiefly the diff, so paging through files needn't detour through the list, and
+    /// clamps at the last file rather than wrapping, like the other cursor moves.
+    pub fn next_file(&mut self) {
+        self.step_file(true);
+    }
+
+    /// Jump the cursor to the previous file in the tree; see [`Self::next_file`].
+    pub fn prev_file(&mut self) {
+        self.step_file(false);
+    }
+
+    fn step_file(&mut self, forward: bool) {
+        if let Some(row) = self.nearest_file_row(forward) {
+            self.file_cursor = row;
+            self.open_cursor_file();
+            self.reveal_files = true;
+        }
+    }
+
+    /// The row index of the next/previous file from `file_cursor`, or the far end's file when
+    /// the cursor is already past it (a directory row past the last file counts as past it),
+    /// clamping rather than wrapping.
+    fn nearest_file_row(&self, forward: bool) -> Option<usize> {
+        if forward {
+            self.file_rows
+                .iter()
+                .enumerate()
+                .skip(self.file_cursor + 1)
+                .find(|(_, r)| r.file_index().is_some())
+                .map(|(i, _)| i)
+                .or_else(|| self.file_rows.iter().rposition(|r| r.file_index().is_some()))
+        } else {
+            self.file_rows
+                .get(..self.file_cursor)?
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, r)| r.file_index().is_some())
+                .map(|(i, _)| i)
+                .or_else(|| self.file_rows.iter().position(|r| r.file_index().is_some()))
+        }
+    }
+
     /// Collapse or expand the directory under the cursor, then rebuild the tree. The cursor
     /// stays on the directory row (still present, now toggled).
     fn toggle_dir(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,8 @@ fn handle_key(app: &mut App, key: KeyEvent, area: Rect) -> Result<()> {
         (Char('n'), _) => app.jump_comment(1),
         (Char('N'), _) => app.jump_comment(-1),
         (Char('l'), _) => app.open_list(),
+        (Char('f'), _) => app.next_file(),
+        (Char('F'), _) => app.prev_file(),
         // `esc` clears an in-progress line selection (the footer's `esc clear`).
         (Esc, _) => app.clear_selection(),
         _ => {}

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -205,6 +205,57 @@ fn toggling_a_directory_requests_a_reveal() {
 }
 
 #[test]
+fn jump_between_files_skipping_directories() {
+    let r = Repo::init();
+    // Two files in `src/` so it stays a real directory row rather than folding into a
+    // single-child `src/b.rs` chain.
+    r.write("src/b.rs", "x\n");
+    r.write("src/c.rs", "w\n");
+    r.write("a.rs", "y\n");
+    r.write("z.rs", "z\n");
+    r.commit_all("init");
+    r.write("src/b.rs", "x2\n");
+    r.write("src/c.rs", "w2\n");
+    r.write("a.rs", "y2\n");
+    r.write("z.rs", "z2\n");
+    let mut app = app_on(&r);
+
+    // Directories sort before files, so the tree is [Dir(src), src/b.rs, src/c.rs, a.rs,
+    // z.rs] — the initial cursor lands on the first *file* row, not the leading directory.
+    assert_eq!(app.diff_path.as_deref(), Some("src/b.rs"));
+
+    app.next_file();
+    assert_eq!(app.diff_path.as_deref(), Some("src/c.rs"));
+    app.next_file();
+    assert_eq!(app.diff_path.as_deref(), Some("a.rs"));
+    app.next_file();
+    assert_eq!(app.diff_path.as_deref(), Some("z.rs"));
+    // Clamps at the last file rather than wrapping.
+    app.next_file();
+    assert_eq!(app.diff_path.as_deref(), Some("z.rs"));
+
+    app.prev_file();
+    assert_eq!(app.diff_path.as_deref(), Some("a.rs"));
+    app.prev_file();
+    assert_eq!(app.diff_path.as_deref(), Some("src/c.rs"));
+    app.prev_file();
+    assert_eq!(app.diff_path.as_deref(), Some("src/b.rs"));
+    // Clamps at the first file — the directory row above it is never landed on.
+    app.prev_file();
+    assert_eq!(app.diff_path.as_deref(), Some("src/b.rs"));
+
+    // Starting from a directory row, `f` finds the nearest file forward.
+    app.file_cursor = app.file_rows.iter().position(|row| row.dir_path() == Some("src")).unwrap();
+    app.next_file();
+    assert_eq!(app.diff_path.as_deref(), Some("src/b.rs"));
+
+    // Works from the diff pane too, not just the file list.
+    app.focus = Focus::Diff;
+    app.next_file();
+    assert_eq!(app.diff_path.as_deref(), Some("src/c.rs"));
+}
+
+#[test]
 fn page_keys_move_the_cursor_in_both_panes() {
     let mut app = long_diff_app(40);
     // File pane: page moves the selection (not just the viewport).


### PR DESCRIPTION
## Description

This PR contains the changes for providing keybindings to quickly navigate between files without having to switch tabs. The new keybindings are `f` for navigating to the next file in the list and `F` for the navigating to the previous file.

## Changes

- Added the `next_file`, `prev_file`, `step_file` and `nearest_file_row` functions for navigating between files without having to switch tabs.
- Added basic testing to validate multiple scenarios.
- Updated the `README.md` file to include the new key bindings.

## Additional Notes

- Tested the integration locally and the navigation between files is working as expected. Also, there are currently no loop back to the initial file when reaching the end of the file list. This could be a future improvement if there's a need for it.
- The tests are passing as well using the command `just test`.
- The keybindings are just a proposal, opened to suggestions if there's a better alternative.