### PR TITLE
Release v0.8.2: snapshot survives a hard kill; manifest version matches the tag again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-07-09
+
+### Fixed
+- **A hard kill mid-snapshot no longer wedges the sidebar's refresh for that worktree.** A crash
+  during the turn snapshot's `git add` could leave a stale `reviewr-turn-index.lock` in the
+  worktree's git dir, and every refresh after that failed with `refresh failed: git ["add", "-A"]
+  failed: fatal: Unable to create … File exists` until the lock was deleted by hand. The snapshot
+  now clears any leftover temp index and its lock — both private to reviewr — before running and
+  on every exit path. See `specs/herdr-host.md`.
+- **`herdr plugin install` now delivers the current release again.** v0.8.1 shipped with
+  `herdr-plugin.toml` still saying `0.8.0`, and `install.sh` reads the manifest to pick the
+  download tag, so installs were silently getting the v0.8.0 binary — without the Send resolver
+  fix from #6. Both version files now carry 0.8.2.
+
 ## [0.8.1] — 2026-07-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-reviewr"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-reviewr"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 rust-version = "1.90"
 description = "A herdr-native review sidebar: browse an agent's changes and send comments back to chat, in the terminal."

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "persiyanov.reviewr"
 name = "reviewr"
-version = "0.8.0"
+version = "0.8.2"
 min_herdr_version = "0.7.0"
 platforms = ["macos", "linux"]
 description = "Native terminal code-review sidebar for herdr."

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -129,6 +129,7 @@ The snapshot is non-disruptive. reviewr writes a tree from the worktree through 
 - Turn tracking needs the agent status from the herdr CLI; without it the `last-turn` scope stays empty, while `uncommitted` and `branch` are unaffected. It resolves the agent under the same S1–S3 rules, so a plugin sidebar or shell in the tab never pauses tracking.
 - A turn that starts and ends within one poll interval — or whose start is masked by a transient `unknown` status — is never seen entering `working`, so its start is not snapshotted; `last-turn` then shows the changes accumulated since the last observed turn start, more than one turn, never lines the agent did not write.
 - A crash between the snapshot and the ref update leaves an orphaned tree object, which git garbage-collects; `git update-ref` is atomic, so the baseline ref is never half-written.
+- A hard kill mid-snapshot can leave the temporary index and the `.lock` git holds while writing it. Both are private to reviewr — the lock's only legitimate holder is a `git add` the snapshot itself spawned and waited on — so every snapshot clears any leftover pair before running and on every exit path. A stale lock therefore costs at most the one failed refresh that follows the crash, never a permanently wedged worktree.
 - The sidebar assumes one instance per worktree; two instances on the same worktree write the same per-worktree ref under last-writer-wins, which is harmless since both compute the same baseline.
 
 ## Non-goals

--- a/src/git.rs
+++ b/src/git.rs
@@ -177,10 +177,12 @@ pub fn snapshot_worktree(repo: &Path) -> Result<String> {
     let git_dir = PathBuf::from(git(repo, &["rev-parse", "--absolute-git-dir"])?.trim());
     let tmp_index = git_dir.join("reviewr-turn-index");
     let real_index = git_dir.join("index");
-    // Clear any temp index a prior hard crash left, then drop it on every exit path via the
-    // guard, so even a failed snapshot leaves nothing behind in the git dir.
-    let _ = std::fs::remove_file(&tmp_index);
-    let _guard = TempIndex(&tmp_index);
+    // Clear whatever a prior hard crash left — the temp index and the `.lock` git holds
+    // while writing it (a leftover lock fails every later `add` with "File exists") — then
+    // drop both on every exit path via the guard, so even a failed snapshot leaves nothing
+    // behind in the git dir.
+    let guard = TempIndex(&tmp_index);
+    guard.clear();
     // Seed from the real index so git's stat cache lets unchanged files skip hashing;
     // a fresh repo may have no index yet, so start empty in that case.
     if real_index.exists() {
@@ -191,12 +193,25 @@ pub fn snapshot_worktree(repo: &Path) -> Result<String> {
     Ok(tree.trim().to_string())
 }
 
-/// Removes a temporary index on drop, so a snapshot that fails midway never leaves one behind.
+/// Removes a temporary index and its git lock file on drop, so a snapshot that fails midway
+/// never leaves either behind.
 struct TempIndex<'a>(&'a Path);
+
+impl TempIndex<'_> {
+    /// Removes the index and the `<index>.lock` git creates beside it while writing. Safe at
+    /// any point we run: the lock's only legitimate holder is a live `git add` this process
+    /// spawned and has already waited on.
+    fn clear(&self) {
+        let _ = std::fs::remove_file(self.0);
+        let mut lock = self.0.as_os_str().to_owned();
+        lock.push(".lock");
+        let _ = std::fs::remove_file(Path::new(&lock));
+    }
+}
 
 impl Drop for TempIndex<'_> {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(self.0);
+        self.clear();
     }
 }
 

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -356,6 +356,23 @@ fn snapshot_worktree_never_mutates_the_repo() {
 }
 
 #[test]
+fn snapshot_worktree_recovers_from_a_stale_index_lock() {
+    let r = Repo::init();
+    r.write("a.rs", "x\n");
+    r.commit_all("init");
+
+    let git_dir = r.git(&["rev-parse", "--absolute-git-dir"]);
+    let git_dir = std::path::Path::new(git_dir.trim());
+    // A hard crash mid-`add` leaves git's lock on the temp index behind; a later snapshot
+    // must clear it instead of failing "Unable to create ... File exists" forever after.
+    std::fs::write(git_dir.join("reviewr-turn-index.lock"), "").unwrap();
+
+    let tree = snapshot_worktree(r.path()).unwrap();
+    assert_eq!(tree.len(), 40, "a tree object id");
+    assert!(!git_dir.join("reviewr-turn-index.lock").exists(), "the stale lock is cleared");
+}
+
+#[test]
 fn baseline_ref_round_trips_under_the_private_namespace() {
     let r = Repo::init();
     r.write("a.rs", "a\n");


### PR DESCRIPTION
## Fixed

- **A hard kill mid-snapshot no longer wedges the sidebar's refresh for that worktree.** A crash during the turn snapshot's `git add` could leave a stale `reviewr-turn-index.lock` in the worktree's git dir, and every refresh after that failed with `refresh failed: git ["add", "-A"] failed: fatal: Unable to create … File exists` until the lock was deleted by hand. `snapshot_worktree` now clears any leftover temp index and its lock — both private to reviewr — before running and on every exit path. Regression test included, guarantee documented in `specs/herdr-host.md`.
- **`herdr plugin install` delivers the current release again.** v0.8.1 shipped with `herdr-plugin.toml` still saying `0.8.0`, and `install.sh` reads the manifest to pick the download tag, so installs were silently getting the v0.8.0 binary — without the Send resolver fix from #6. Both version files now carry 0.8.2.

## Release checklist (docs/RELEASING.md)

- [x] Both versions bumped and equal (`Cargo.toml`, `herdr-plugin.toml`)
- [x] Changelog finalized (`## [0.8.2] — 2026-07-09`)
- [x] `Cargo.lock` refreshed
- [x] fmt + clippy + tests + release build green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)