### PR TITLE
Add configurable startup scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,12 @@ Create the file if it does not exist yet. herdr hands this directory to the plug
 reviewr's file, not herdr's. Settings added to herdr's own `~/.config/herdr/config.toml` never
 reach reviewr.
 
-The file accepts these six keys:
+The file accepts these seven keys:
 
 ```toml
 theme = "tokyo-night"
 base_branches = ["origin/develop", "origin/main", "main", "master"]
+default_scope = "branch"
 toggle_placement = "overlay"
 toggle_direction = "down"
 auto_open = false
@@ -219,6 +220,16 @@ on a dark terminal reads poorly, and so does the reverse. Available:
 
 Names match herdr's where both ship a palette. An unknown config name is an error. The standalone
 `--theme` development flag retains its older fallback to `catppuccin`.
+
+### Default scope
+
+Set the scope that reviewr selects when the sidebar starts. The default is `uncommitted`.
+Changing this key does not replace a scope you selected in a running session.
+
+```toml
+# ~/.config/herdr/plugins/config/persiyanov.reviewr/config.toml
+default_scope = "branch" # or "uncommitted" / "last-turn"
+```
 
 ### Base branch
 

--- a/specs/config.md
+++ b/specs/config.md
@@ -15,6 +15,7 @@ The plugin config is one typed value. A valid file may set any subset of the sup
 ```toml
 theme = "tokyo-night"
 base_branches = ["origin/develop", "origin/main", "main", "master"]
+default_scope = "branch"
 toggle_placement = "overlay"
 toggle_direction = "down"
 auto_open = false
@@ -25,6 +26,7 @@ github_host = "github.example.com"
 | ---------------------- | ------------------------------------------------------------------------ |
 | `theme`                | one name from the theme set in `theme.md`                                 |
 | `base_branches`        | non-empty array of non-empty ref names                                    |
+| `default_scope`        | `uncommitted`, `branch`, or `last-turn`                                   |
 | `toggle_placement`     | `split`, `overlay`, `zoomed`, or `tab`                                    |
 | `toggle_direction`     | `right` or `down`                                                         |
 | `auto_open`            | boolean                                                                  |

--- a/specs/review-model.md
+++ b/specs/review-model.md
@@ -42,7 +42,7 @@ The anchor rules:
 
 ### Scopes
 
-A scope selects which changes `Changes` shows and which files `All files` annotates. The two tabs share one active scope. The default is `uncommitted`.
+A scope selects which changes `Changes` shows and which files `All files` annotates. The two tabs share one active scope. Sessions start in `default_scope` from `config.toml`, or `uncommitted` when the key is omitted. Scope keys and the header chip change it for the rest of that session.
 
 | scope         | shows                                                          | source                                                       |
 | ------------- | --------------------------------------------------------------- | ------------------------------------------------------------ |

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,8 +60,15 @@ impl Config {
 /// sets no `base_branches` (`specs/review-model.md`).
 pub const DEFAULT_BASE_BRANCHES: [&str; 4] = ["origin/main", "origin/master", "main", "master"];
 
-const PLUGIN_CONFIG_KEYS: [&str; 6] =
-    ["theme", "base_branches", "toggle_placement", "toggle_direction", "auto_open", "github_host"];
+const PLUGIN_CONFIG_KEYS: [&str; 7] = [
+    "theme",
+    "base_branches",
+    "default_scope",
+    "toggle_placement",
+    "toggle_direction",
+    "auto_open",
+    "github_host",
+];
 
 /// Where the toggle action opens the sidebar.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -104,6 +111,7 @@ impl ToggleDirection {
 pub struct PluginConfig {
     theme: String,
     base_branches: Vec<String>,
+    default_scope: crate::model::Scope,
     toggle_placement: TogglePlacement,
     toggle_direction: ToggleDirection,
     auto_open: bool,
@@ -115,6 +123,7 @@ impl Default for PluginConfig {
         Self {
             theme: crate::theme::DEFAULT.to_owned(),
             base_branches: DEFAULT_BASE_BRANCHES.iter().map(|s| (*s).to_owned()).collect(),
+            default_scope: crate::model::Scope::Uncommitted,
             toggle_placement: TogglePlacement::Split,
             toggle_direction: ToggleDirection::Right,
             auto_open: true,
@@ -130,6 +139,10 @@ impl PluginConfig {
 
     pub fn base_branches(&self) -> &[String] {
         &self.base_branches
+    }
+
+    pub fn default_scope(&self) -> crate::model::Scope {
+        self.default_scope
     }
 
     pub fn toggle_placement(&self) -> TogglePlacement {
@@ -153,6 +166,7 @@ impl PluginConfig {
         serde_json::json!({
             "theme": self.theme,
             "base_branches": self.base_branches,
+            "default_scope": self.default_scope.config_value(),
             "toggle_placement": self.toggle_placement.as_str(),
             "toggle_direction": self.toggle_direction.as_str(),
             "auto_open": self.auto_open,
@@ -260,6 +274,25 @@ fn parse_plugin_config(path: &Path) -> Result<PluginConfig, PluginConfigError> {
             branches.push(branch.to_owned());
         }
         config.base_branches = branches;
+    }
+    if let Some(value) = table.get("default_scope") {
+        config.default_scope = match string_value(
+            path,
+            "default_scope",
+            value,
+            "one of uncommitted, branch, last-turn",
+        )? {
+            "uncommitted" => crate::model::Scope::Uncommitted,
+            "branch" => crate::model::Scope::Branch,
+            "last-turn" => crate::model::Scope::LastTurn,
+            _ => {
+                return Err(value_error(
+                    path,
+                    "default_scope",
+                    "one of uncommitted, branch, last-turn",
+                ));
+            }
+        };
     }
     if let Some(value) = table.get("toggle_placement") {
         config.toggle_placement = match string_value(
@@ -409,6 +442,7 @@ mod tests {
         let config = super::plugin_config_in(dir.path()).unwrap();
         assert_eq!(config.theme(), "gruvbox");
         assert_eq!(config.base_branches(), PluginConfig::default().base_branches());
+        assert_eq!(config.default_scope(), crate::model::Scope::Uncommitted);
         assert_eq!(config.toggle_placement(), TogglePlacement::Split);
         assert_eq!(config.toggle_direction(), ToggleDirection::Right);
         assert!(config.auto_open());
@@ -423,6 +457,7 @@ mod tests {
             concat!(
                 "theme = \"tokyo-night\"\n",
                 "base_branches = [\"origin/dev\", \"main\"]\n",
+                "default_scope = \"branch\"\n",
                 "toggle_placement = \"overlay\"\n",
                 "toggle_direction = \"down\"\n",
                 "auto_open = false\n",
@@ -433,6 +468,7 @@ mod tests {
         let config = super::plugin_config_in(dir.path()).unwrap();
         assert_eq!(config.theme(), "tokyo-night");
         assert_eq!(config.base_branches(), ["origin/dev", "main"]);
+        assert_eq!(config.default_scope(), crate::model::Scope::Branch);
         assert_eq!(config.toggle_placement(), TogglePlacement::Overlay);
         assert_eq!(config.toggle_direction(), ToggleDirection::Down);
         assert!(!config.auto_open());
@@ -464,6 +500,8 @@ mod tests {
             ("base_branches = [\"feature branch\"]\n", "`base_branches`"),
             ("base_branches = [\"-main\"]\n", "`base_branches`"),
             ("base_branches = [\"main\", 1]\n", "`base_branches`"),
+            ("default_scope = \"worktree\"\n", "`default_scope`"),
+            ("default_scope = 1\n", "`default_scope`"),
             ("toggle_placement = \"left\"\n", "`toggle_placement`"),
             ("toggle_direction = \"left\"\n", "`toggle_direction`"),
             ("auto_open = \"yes\"\n", "`auto_open`"),
@@ -495,7 +533,8 @@ mod tests {
     fn normalized_json_contains_every_key() {
         let value = PluginConfig::default().to_json();
         let object = value.as_object().unwrap();
-        assert_eq!(object.len(), 6);
+        assert_eq!(object.len(), 7);
+        assert_eq!(object["default_scope"], "uncommitted");
         assert_eq!(object["toggle_placement"], "split");
         assert_eq!(object["toggle_direction"], "right");
         assert_eq!(object["auto_open"], true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,14 @@ fn ready_app(cfg: &Config, plugin_config: PluginConfig) -> App {
     // A non-repo path is not an error — the sidebar opens to an empty state and starts showing
     // changes if the directory becomes a repo (specs/herdr-host.md).
     let repo = git::toplevel(&cfg.repo).unwrap_or_else(|| cfg.repo.clone());
-    logln!("start repo={} poll={:?} base={:?}", repo.display(), cfg.poll, cfg.base);
-    let mut app = App::new(repo, Scope::Uncommitted, cfg.base.clone());
+    logln!(
+        "start repo={} poll={:?} base={:?} scope={:?}",
+        repo.display(),
+        cfg.poll,
+        cfg.base,
+        plugin_config.default_scope()
+    );
+    let mut app = App::new(repo, plugin_config.default_scope(), cfg.base.clone());
     app.set_plugin_config(plugin_config);
     app.set_cli_theme(cfg.theme.clone());
     if let Some(wrap) = cfg.wrap {
@@ -999,6 +1005,7 @@ fn handle_mouse(app: &mut App, m: MouseEvent, area: Rect, heights: &[usize]) -> 
 mod refresh_tests {
     use super::{
         ActiveFetch, PrCoordinator, PrEffect, PrRefresh, TaggedPr, apply_plugin_config_observation,
+        ready_app,
     };
     use crate::app::App;
     use crate::config::{Config, plugin_config_in};
@@ -1136,6 +1143,32 @@ mod refresh_tests {
 
         assert!(cancelled.load(Ordering::Acquire));
         assert_eq!(coordinator.active_fetch_tag(), Some((7, 3)));
+    }
+
+    #[test]
+    fn configured_default_scope_selects_startup_scope_without_overriding_later_selection() {
+        let repo = tempfile::tempdir().unwrap();
+        let config_dir = tempfile::tempdir().unwrap();
+        let path = config_dir.path().join("config.toml");
+        std::fs::write(&path, "default_scope = \"branch\"\n").unwrap();
+        let cfg = Config::parse([repo.path().display().to_string()]);
+        let mut app = ready_app(&cfg, plugin_config_in(config_dir.path()).unwrap());
+        assert_eq!(app.scope, Scope::Branch);
+
+        app.scope = Scope::LastTurn;
+        std::fs::write(&path, "default_scope = \"uncommitted\"\n").unwrap();
+        let (tx, _rx) = mpsc::channel();
+        let mut epoch = 0;
+        let mut recovery_inflight = false;
+        assert!(apply_plugin_config_observation(
+            &mut app,
+            &cfg,
+            &mut epoch,
+            &tx,
+            &mut recovery_inflight,
+            plugin_config_in(config_dir.path()),
+        ));
+        assert_eq!(app.scope, Scope::LastTurn, "a live config reread preserves user navigation");
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,6 +20,15 @@ impl Scope {
         }
     }
 
+    /// Stable spelling used in plugin configuration and normalized JSON output.
+    pub fn config_value(self) -> &'static str {
+        match self {
+            Scope::Uncommitted => "uncommitted",
+            Scope::Branch => "branch",
+            Scope::LastTurn => "last-turn",
+        }
+    }
+
     /// Cycle to the next scope, for the header chip click: uncommitted → branch → last turn.
     #[must_use]
     pub fn cycle(self) -> Self {


### PR DESCRIPTION
## Summary

- add `default_scope` to plugin config with `uncommitted`, `branch`, and `last-turn` values
- start new and recovered sidebars in the configured scope while preserving in-session scope changes
- document the setting and cover parsing, validation, startup, and config rereads

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --release`