### PR TITLE
Show aggregate change stats in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ button, and the scroll wheel all work too.
 
 ## The three tabs
 
-- **Changes** — the changed files for the active scope, with `+/-` stats. Pick a file to read its
-  syntax-highlighted diff. This is where you review and comment.
+- **Changes** — the changed files for the active scope, with per-file `+/-` stats and totals in
+  the header. Pick a file to read its syntax-highlighted diff. This is where you review and
+  comment.
 - **All files** — the whole worktree tree, not only what changed. The diff pane renders any
   file's current content. Git-ignored paths show too, dimmed. A directory ignored as a whole
   (`target/`, `node_modules/`) is one collapsed row that loads its contents only when you expand

--- a/specs/review-model.md
+++ b/specs/review-model.md
@@ -111,6 +111,9 @@ scripts/old_runner.py                 D   -47
 | `additions`     | integer | lines added in the scope, all lines for an untracked file         |
 | `deletions`     | integer | lines removed in the scope                                        |
 
+The header sums `additions` and `deletions` across the active scope. A refresh or scope switch
+replaces both totals with the new changeset's sums.
+
 ### Diff
 
 The selected file's structured diff, built from its old and new content (`diff-view.md`). Comment anchors and snippets come from it. An untracked file diffs against empty old content. A binary file lists, and its pane reads `binary — no line comments`.

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -11,7 +11,7 @@ The terminal interface: the layout, the keyboard and mouse, and how the view sta
 ## Overview
 
 ```
-┌ 1 Changes  2 All files  3 PR  [uncommitted]  9 changed ──── [ Send (3) ] ┐
+┌ 1 Changes  2 All files  3 PR  [uncommitted]  9 changed  +42 -18 ── [ Send (3) ] ┐
 │ ⋯  11 unmodified lines                       │ M llm_registry.py  +18 -8  │
 │ 40    def resolve(self, name):               │ M deep_research.py +155-62 │
 │ 41 ▌  from .z import w                         │ D old_runner.py    -47     │
@@ -26,7 +26,7 @@ The terminal interface: the layout, the keyboard and mouse, and how the view sta
 └────────────────────────────────────────────────────────────────────────────┘
 ```
 
-- The header shows the three tabs with the active one highlighted, the active scope, the changed-file count, and a clickable `Send` button with the comment count.
+- The header shows the three tabs with the active one highlighted, the active scope, its changed-file count and aggregate `+additions -deletions`, and a clickable `Send` button with the comment count.
 - The left pane is the selected file's diff (`diff-view.md`). The right pane is the file navigator (`file-list.md`).
 - The comment input opens inline, directly under the last line of the selection. It pushes the diff below it down and grows as you type. It is never a footer band.
 - The footer is a live action bar.
@@ -100,7 +100,7 @@ The actions follow the cursor:
 - `u/b/t scope` shows in every `Changes` and `All files` context, except where it is itself the primary.
 - Movement keys are never shown.
 - The comment editor and the comments list show their own actions.
-- The changed-file count lives in the header. The footer carries only the comment count, inside `s send N`.
+- The changed-file count and line totals live in the header. The footer carries only the comment count, inside `s send N`.
 - On `PR` the bar leads with the PR's state, then `o open ↗`, then orientation.
 
 ### Tabs

--- a/src/app.rs
+++ b/src/app.rs
@@ -1860,6 +1860,14 @@ impl App {
         self.changed.len()
     }
 
+    /// Aggregate line additions and deletions for the active scope. Use wider counters than the
+    /// per-file model so a large changeset cannot overflow while the header totals it.
+    pub fn changed_totals(&self) -> (u64, u64) {
+        self.changed.values().fold((0, 0), |(additions, deletions), change| {
+            (additions + u64::from(change.additions), deletions + u64::from(change.deletions))
+        })
+    }
+
     /// Whether a comment's anchor may have moved. A diff comment is stale once its file leaves
     /// the changeset; a File-view (content) comment only once its file is gone from the
     /// worktree, since it was never tied to the changeset (specs/review-model.md).

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -426,10 +426,20 @@ fn send_button(app: &App) -> String {
     format!("[ Send ({}) ]", app.store.len())
 }
 
-/// The header suffix: the active scope's changed-file count. Shared so the painter and the
-/// hit-test place the right-aligned `Send` button at the same column.
+fn header_summary(app: &App) -> (String, String, String) {
+    let (additions, deletions) = app.changed_totals();
+    (
+        format!("  {} changed  ", app.changed_count()),
+        format!("+{additions}"),
+        format!("-{deletions}"),
+    )
+}
+
+/// The header suffix: the active scope's changed-file count and aggregate line stats. Shared so
+/// the painter and the hit-test place the right-aligned `Send` button at the same column.
 fn header_suffix(app: &App) -> String {
-    format!("  {} changed", app.changed_count())
+    let (count, additions, deletions) = header_summary(app);
+    format!("{count}{additions} {deletions}")
 }
 
 /// The column the `Send` button paints at, matching `render_tab_bar`'s layout: right-aligned
@@ -476,7 +486,11 @@ fn render_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
     let bar = Style::default().bg(p.surface0);
     let mut spans = tab_bar_spans(app);
     spans.push(Span::styled(chip, bar.fg(p.yellow).add_modifier(Modifier::BOLD)));
-    spans.push(Span::styled(suffix, bar.fg(p.overlay0)));
+    let (count, additions, deletions) = header_summary(app);
+    spans.push(Span::styled(count, bar.fg(p.overlay0)));
+    spans.push(Span::styled(additions, bar.fg(p.green)));
+    spans.push(Span::styled(" ", bar));
+    spans.push(Span::styled(deletions, bar.fg(p.red)));
 
     let send_fg = if app.store.is_empty() { p.overlay0 } else { p.green };
     spans.push(Span::styled(" ".repeat(pad), bar));

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -1117,6 +1117,36 @@ fn switching_scope_swaps_the_changeset() {
 }
 
 #[test]
+fn aggregate_stats_follow_the_active_scope_and_refresh_every_change_kind() {
+    let r = Repo::init();
+    r.write("edited.rs", "one\ntwo\nthree\n");
+    r.write("deleted.rs", "gone one\ngone two\n");
+    r.write("old_name.rs", "stable rename contents\n");
+    r.commit_all("base");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("committed.rs", "branch one\nbranch two\n");
+    r.commit_all("feature work");
+
+    r.write("edited.rs", "one\nTWO\nthree\n");
+    r.remove("deleted.rs");
+    r.git(&["mv", "old_name.rs", "new_name.rs"]);
+    r.write("untracked.rs", "new one\nnew two\nnew three\n");
+
+    let mut app = App::new(r.path_buf(), Scope::Uncommitted, Some("main".to_string()));
+    app.reload().unwrap();
+    assert_eq!(app.changed_count(), 4, "edit, deletion, rename, and untracked file");
+    assert_eq!(app.changed_totals(), (4, 3));
+
+    app.set_scope(Scope::Branch).unwrap();
+    assert_eq!(app.changed_count(), 5, "branch adds the committed file");
+    assert_eq!(app.changed_totals(), (6, 3));
+
+    r.write("untracked.rs", "new one\nnew two\nnew three\nnew four\n");
+    app.reload().unwrap();
+    assert_eq!(app.changed_totals(), (7, 3), "refresh replaces the aggregate snapshot");
+}
+
+#[test]
 fn a_multi_line_range_comment_spans_lines_and_keeps_the_whole_snippet() {
     let r = edited_repo();
     let mut app = app_on(&r);

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -357,6 +357,20 @@ fn on_changed_line(app: &mut App) {
 }
 
 #[test]
+fn the_header_shows_scope_totals_at_constrained_width() {
+    let r = Repo::init();
+    r.write("edited.rs", "old\n");
+    r.commit_all("init");
+    r.write("edited.rs", "new\n");
+    r.write("untracked.rs", "one\ntwo\n");
+    let mut app = App::new(r.path_buf(), Scope::Uncommitted, None);
+    app.reload().unwrap();
+
+    let header = render_at(&app, 62).lines().next().unwrap().to_string();
+    assert!(header.contains("2 changed  +3 -1"), "aggregate stats fit exactly:\n{header}");
+}
+
+#[test]
 fn the_footer_shows_the_action_for_the_context() {
     let mut app = edited_app();
     on_changed_line(&mut app);


### PR DESCRIPTION
## Summary

- sum additions and deletions across the active scope with overflow-safe counters
- show `N changed  +A -D` in the header with colored line totals
- refresh totals across scope changes, edits, untracked files, deletions, and renames
- cover exact totals and constrained-width rendering

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --release`