### PR TITLE
Resolve the PR against upstream when origin is a fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Rust 1.97 is now the minimum toolchain.** Local builds, Clippy, CI, and release builds use the
   same pinned compiler version.
 
+### Fixed
+- **The PR tab finds the pull request when `origin` is a fork.** A checkout whose `origin` is a
+  fork and whose base repository is the `upstream` remote now queries `upstream`, matching the
+  fork workflow. GitHub lists a pull request only under its base repository, so the previous
+  origin-only query showed the empty state.
+
 ## [0.17.0] — 2026-07-14
 
 ### Added

--- a/specs/forge-host.md
+++ b/specs/forge-host.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-27
-Last edited: 2026-07-12
+Last edited: 2026-07-14
 ---
 
 # forge host
@@ -61,7 +61,9 @@ github_host = "github.example.com"
 
 Host matching is case-insensitive. A missing setting adds no Enterprise host. `github.com` remains supported when the setting is present.
 
-Host identity comes from `origin`'s primary fetch URL after Git's `url.*.insteadOf` rewrite. A separate push URL does not affect PR reads.
+reviewr prefers the fork workflow's base repository as the fetch target: when a remote named `upstream` resolves to a supported GitHub repository, that repository is the target instead of `origin`. `origin` is then the contributor's fork, `upstream` is the base, and GitHub lists a pull request only under its base. An `upstream` that is absent or not a supported GitHub repository leaves `origin` as the target.
+
+Host identity comes from the fetch target's primary fetch URL after Git's `url.*.insteadOf` rewrite. A separate push URL does not affect PR reads.
 
 | condition                                                 | outcome                                                                         |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -75,7 +77,7 @@ The alias rows apply only to scp-style and `ssh://` origins. An alias is a trust
 
 Hosted URL forms use `http://`, `https://`, or `git://`. File URLs and other schemes are not GitHub repository identities and remain unsupported.
 
-A fetch target is the canonical matched host plus the origin's owner and repository. A fetch input adds the pinned `HEAD` and derived candidate branches. Base configuration shapes those candidates but is not a second identity of its own. `GH_HOST` cannot redirect a fetch to another instance.
+A fetch target is the canonical matched host plus the target repository's owner and name. A fetch input adds the pinned `HEAD` and derived candidate branches. Base configuration shapes those candidates but is not a second identity of its own. `GH_HOST` cannot redirect a fetch to another instance.
 
 ### Resolution
 
@@ -146,7 +148,7 @@ reviewr reads GitHub and never writes it, so every failure degrades to a clear s
 - An unauthenticated fetch preserves a same-input snapshot and shows `gh auth login --hostname <host>`. With no same-input snapshot, the remedy fills the tab.
 - An unsupported origin names the host and points Enterprise users to `github_host`.
 - Any other fetch failure preserves a same-input snapshot and shows the retry error. With no same-input snapshot, the error fills the tab.
-- A missing `origin` is a clean absence. Any other git command failure is transient and never read as absence, a detached `HEAD`, or an unsupported remote.
+- A missing `origin` or `upstream` is a clean absence. Any other git command failure is transient and never read as absence, a detached `HEAD`, or an unsupported remote.
 - No open PR shows a directional empty state naming the queried candidates. The next poll lights the tab up when a PR appears.
 - Every read is idempotent and side-effect-free. A retry returns the same snapshot.
 - Two active PR tabs on one worktree converge within one poll interval. An inactive tab catches up when entered.

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -312,7 +312,7 @@ fn fetch_inner(
     input: &PrFetchInput,
     cancelled: &AtomicBool,
 ) -> Result<PrView, GhError> {
-    let target = match &input.origin {
+    let target = match &input.target {
         crate::git::OriginIdentity::Repository(target) => target,
         crate::git::OriginIdentity::Missing | crate::git::OriginIdentity::Hostless => {
             return Ok(PrView::NeedsGitHubOrigin);

--- a/src/git.rs
+++ b/src/git.rs
@@ -209,11 +209,12 @@ fn git_strict(repo: &Path, args: &[&str]) -> Result<String, GitFail> {
 }
 
 /// Everything the PR fetch reads from local Git in one failure-aware pass. [`OriginIdentity`]
-/// preserves repository, missing, hostless, unsupported, and malformed origin states; the
-/// optional `HEAD` and candidate list preserve detached and unborn states.
+/// preserves repository, missing, hostless, unsupported, and malformed states for the fetch
+/// target — `origin`, or a supported `upstream` when the checkout is a fork; the optional
+/// `HEAD` and candidate list preserve detached and unborn states.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrFetchInput {
-    pub origin: OriginIdentity,
+    pub target: OriginIdentity,
     /// `HEAD` pinned to an OID at the start of the pass; every ancestry test, distance,
     /// and the `sync` count use this pin, so one fetch reads one consistent local state.
     pub head_oid: Option<String>,
@@ -230,10 +231,10 @@ pub fn pr_local(
     config_bases: &[String],
     github_host: Option<&str>,
 ) -> Result<PrFetchInput, GitFail> {
-    let origin = origin_identity(repo, github_host)?;
+    let target = fetch_target(repo, github_host)?;
     let Some(branch) = git_tristate(repo, &["symbolic-ref", "--quiet", "--short", "HEAD"])? else {
         // Detached HEAD — post-merge cleanup, not a review seat; nothing to publish.
-        return Ok(PrFetchInput { origin, head_oid: None, candidates: Vec::new() });
+        return Ok(PrFetchInput { target, head_oid: None, candidates: Vec::new() });
     };
     let head_oid = git_tristate(repo, &["rev-parse", "--verify", "--quiet", "HEAD^{commit}"])?;
     let bases = base_names(base_flag, config_bases);
@@ -246,17 +247,34 @@ pub fn pr_local(
         None => Vec::new(), // an unborn branch has no commits to compare against
     };
     let candidates = candidate_order(push_dest.as_deref(), &tips, &branch);
-    Ok(PrFetchInput { origin, head_oid, candidates })
+    Ok(PrFetchInput { target, head_oid, candidates })
 }
 
-/// Classify origin's primary rewritten fetch URL. A missing origin is a clean state; every other
-/// `remote get-url` failure is transient.
-/// `remote get-url` is kept over `config --get remote.origin.url` because it applies
+/// The repository PRs are queried against. A fork checkout keeps its base repo as the
+/// `upstream` remote (gh's convention) and GitHub lists the pull request only under the base,
+/// so a supported `upstream` outranks `origin`. When `upstream` is absent or is not a supported
+/// GitHub repository, `origin`'s identity — including its missing, hostless, unsupported, and
+/// malformed states — stands unchanged, so the origin-only outcomes are preserved.
+fn fetch_target(repo: &Path, github_host: Option<&str>) -> Result<OriginIdentity, GitFail> {
+    let origin = remote_identity(repo, "origin", github_host)?;
+    match remote_identity(repo, "upstream", github_host)? {
+        OriginIdentity::Repository(base) => Ok(OriginIdentity::Repository(base)),
+        _ => Ok(origin),
+    }
+}
+
+/// Classify a named remote's primary rewritten fetch URL. A missing remote is a clean
+/// [`OriginIdentity::Missing`]; every other `remote get-url` failure is transient.
+/// `remote get-url` is kept over `config --get remote.<name>.url` because it applies
 /// `url.<base>.insteadOf` rewrites, which can be what maps a shorthand to github.com. Its
 /// missing-remote exit code (2) is also git's generic usage-error code, so absence is told
 /// apart by the message text — stable English under [`run_git`]'s `LC_ALL=C`.
-fn origin_identity(repo: &Path, github_host: Option<&str>) -> Result<OriginIdentity, GitFail> {
-    let args = ["remote", "get-url", "origin"];
+fn remote_identity(
+    repo: &Path,
+    remote: &str,
+    github_host: Option<&str>,
+) -> Result<OriginIdentity, GitFail> {
+    let args = ["remote", "get-url", remote];
     let out = run_git(repo, &args)?;
     if out.status.success() {
         return Ok(classify_remote(String::from_utf8_lossy(&out.stdout).trim(), github_host));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1167,7 +1167,7 @@ mod refresh_tests {
 
     fn input(head: &str) -> PrFetchInput {
         PrFetchInput {
-            origin: OriginIdentity::Missing,
+            target: OriginIdentity::Missing,
             head_oid: Some(head.to_string()),
             candidates: vec!["feature".to_string()],
         }

--- a/tests/pr_candidates.rs
+++ b/tests/pr_candidates.rs
@@ -49,7 +49,7 @@ fn push_head_other_name_yields_the_remote_branch_before_the_local_name() {
     repo.git(&["update-ref", "refs/remotes/origin/other", "HEAD"]);
     let local = pr_local(repo.path(), None).expect("pr_local");
     assert_eq!(
-        local.origin,
+        local.target,
         OriginIdentity::Repository(RepoTarget {
             host: "github.com".to_string(),
             owner: "owner".to_string(),
@@ -179,7 +179,7 @@ fn a_missing_origin_is_absence_but_a_non_repo_is_failure() {
     repo.write("a.txt", "one\n");
     repo.commit_all("base");
     let local = pr_local(repo.path(), None).expect("pr_local");
-    assert_eq!(local.origin, OriginIdentity::Missing, "no origin remote is a clean absence");
+    assert_eq!(local.target, OriginIdentity::Missing, "no origin remote is a clean absence");
     assert_eq!(local.candidates, ["main"]);
 
     let dir = tempfile::tempdir().unwrap();
@@ -202,9 +202,45 @@ fn origin_identity_uses_instead_of_rewrite_and_ignores_pushurl() {
     .expect("pr_local");
 
     assert_eq!(
-        local.origin,
+        local.target,
         OriginIdentity::Repository(RepoTarget {
             host: "github.company.com".to_string(),
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+        })
+    );
+}
+
+#[test]
+fn a_supported_upstream_remote_is_the_fetch_target_over_a_fork_origin() {
+    // Contributor topology: `origin` is the user's fork, `upstream` is the base repo. GitHub
+    // lists the PR only under the base, so the fetch must target `upstream`, not the fork.
+    let repo = worktree();
+    repo.git(&["remote", "set-url", "origin", "https://github.com/contributor/repo.git"]);
+    repo.git(&["remote", "add", "upstream", "https://github.com/owner/repo.git"]);
+    let local = pr_local(repo.path(), None).expect("pr_local");
+    assert_eq!(
+        local.target,
+        OriginIdentity::Repository(RepoTarget {
+            host: "github.com".to_string(),
+            owner: "owner".to_string(),
+            name: "repo".to_string(),
+        }),
+        "a supported `upstream` is the base repo and outranks the fork `origin`"
+    );
+}
+
+#[test]
+fn a_non_github_upstream_leaves_origin_as_the_fetch_target() {
+    // The redirect fires only when `upstream` resolves to a supported GitHub repository; an
+    // `upstream` on another host must not shadow a working GitHub `origin`.
+    let repo = worktree();
+    repo.git(&["remote", "add", "upstream", "git@gitlab.com:base/repo.git"]);
+    let local = pr_local(repo.path(), None).expect("pr_local");
+    assert_eq!(
+        local.target,
+        OriginIdentity::Repository(RepoTarget {
+            host: "github.com".to_string(),
             owner: "owner".to_string(),
             name: "repo".to_string(),
         })


### PR DESCRIPTION
## Problem

In the fork workflow — `origin` is your fork, `upstream` is the base repository — the PR tab shows the empty state even when an open PR exists. `gh pr list` from the same worktree finds the PR, so it is specific to reviewr's resolution.

## Root cause

The PR fetch derived its target repository from `origin` alone (`git remote get-url origin`), then queried `repository(owner, name).pullRequests(headRefName: …)`. GitHub lists a pull request only under its **base** repository, so when `origin` is the fork the query hits the fork — which has no PRs — and legitimately returns nothing.

This is distinct from the fork-*head* topology already supported (#10 / v0.9.0), where `origin` *is* the base and the PR head lives in someone else's fork. That path matches by head-branch name; the missing piece was pointing the query at the base repository in the first place.

## Fix

Prefer a remote named `upstream` as the fetch target when it resolves to a supported GitHub repository, falling back to `origin` (with all its existing missing / unsupported / malformed states) otherwise. This mirrors the fork workflow's own convention — the same one `gh` follows — and adds no API calls, only one extra local `git remote get-url upstream`.

Because candidates are branch *names*, redirecting the target to the base is sufficient: the existing head-name matching and `isCrossRepository` / `⑂` handling resolve the fork-head PR unchanged.

Scope kept minimal — base-branch and candidate derivation (which read `refs/remotes/origin/*`) are untouched.

### Known limitation

This helps forks that have an `upstream` remote (the gh/hub convention). A fork cloned without one still shows the empty state; a parent-repo lookup via GraphQL (`repository { parent { owner name } }`) would cover that case and could be a follow-up if you'd prefer full coverage.

## Changes

- `src/git.rs`: new `fetch_target()` preferring a supported `upstream`; `origin_identity` generalized to `remote_identity(repo, remote, host)`.
- Renamed `PrFetchInput.origin` → `.target` — the field now holds the base repo in the fork topology.
- `specs/forge-host.md`: fetch-target precedence rule and failure semantics.
- `CHANGELOG.md`: Fixed entry under `[Unreleased]`.
- `tests/pr_candidates.rs`: fork-topology resolution test, plus a guard that a non-GitHub `upstream` does not override a working `origin`.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (388 passing, including the 2 new tests) all clean.
