### PR TITLE
Track the nearest agent tab to the left for own-tab sidebars

### DIFF
--- a/docs/herdr-api-notes.md
+++ b/docs/herdr-api-notes.md
@@ -80,6 +80,13 @@ herdr agent send  <agent_pane> "<literal text>"   # writes input, no Enter
 herdr agent focus <agent_pane>                    # focus so the reviewer submits
 ```
 
+## Tabs (nearest-left send target)
+
+`herdr tab list [--workspace <ws>]` → `{"result":{"tabs":[ {tab_id, workspace_id, number, label, focused, agent_status, pane_count} ]}}` (verified live, 0.7.4).
+- `--workspace <ws>` filters to that workspace's tabs (verified live). `tab get <tab_id>` exposes no position/index field.
+- `number` is a per-workspace creation id with gaps after closed tabs, not a position.
+- **Ordering (verified by observation, 0.7.4):** the array is not sorted by `number`; it is the tab bar's visible left-to-right order, which the nearest-left rule (`../specs/herdr-host.md`, HH-NEAREST-LEFT) relies on. Confirmed with two live tests: focusing a tab does *not* reorder the array (a `focused` tab was observed at a non-first index, and focusing a middle tab left the array byte-identical), while dragging a tab to a new position *does* move it in the array — so the order tracks position, not focus/MRU. There is no documented API guarantee and no `position`/`index` field to fall back on, so this rests on that observed 0.7.4 behavior.
+
 ## Diff scopes (plain git, no herdr)
 
 - Uncommitted: `git -C <repo> diff` + `git status --porcelain -z --untracked-files=all`.

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -122,7 +122,8 @@ The binary reviews the pane's working directory, normalized to its git top level
 `Send` hands over every written comment at once. The target is resolved in order:
 
 1. the sole agent in the sidebar's tab,
-2. else the sole agent in its workspace.
+2. else the sole agent in its workspace,
+3. else the agent in the nearest tab to the left of the sidebar, in the visible left-to-right tab order.
 
 reviewr writes the comment blocks into the agent pane without submitting, then focuses it. You add context and press enter.
 
@@ -133,10 +134,13 @@ The candidate rules, coded for citation:
 | `HH-AGENT-PANES`           | Only panes carrying an `agent` field are candidates.                    |
 | `HH-NOT-SELF`              | The sidebar's own pane is never a candidate.                            |
 | `HH-TAB-WINS`              | A sole tab agent wins over the workspace fallback.                      |
-| `HH-SOLE-OR-REFUSE`        | Zero or several candidates refuse the send. Nothing is sent partially.  |
+| `HH-NEAREST-LEFT`          | With several workspace agents, the one in the nearest tab left of the sidebar wins. |
+| `HH-SOLE-OR-REFUSE`        | No resolvable candidate refuses the send. Nothing is sent partially.    |
 | `HH-REFUSE-SAYS-CLIPBOARD` | A refusal says why and points at the clipboard copy.                    |
 
-With `tab` placement the sidebar has its own tab, so resolution goes straight to the workspace fallback.
+The tab order is `herdr tab list`'s array order — the live left-to-right order that tracks drag-reorders, not the tab `number` (a creation id). Left of the sidebar means a lower array index in the same workspace; the nearest such agent tab wins, and a nearest tab holding several agents refuses rather than guess.
+
+With `tab` placement the sidebar has its own tab, so resolution skips the tab rule — to the sole workspace agent, then to the nearest agent tab on its left (`HH-NEAREST-LEFT`).
 
 ## Clipboard
 
@@ -165,7 +169,7 @@ Actions:
 Send and tracking:
 
 - Browsing and the clipboard export work without the herdr CLI. Sending and turn tracking need it. Without it, `last-turn` stays empty and `uncommitted` and `branch` are unaffected.
-- Turn tracking resolves the agent under the same candidate rules (`HH-AGENT-PANES`, `HH-NOT-SELF`, `HH-TAB-WINS`), so a plugin sidebar or shell in the tab never pauses tracking.
+- Turn tracking resolves the agent under the same candidate rules (`HH-AGENT-PANES`, `HH-NOT-SELF`, `HH-TAB-WINS`, `HH-NEAREST-LEFT`), so a Review tab with its own placement tracks the agent tab on its left, and a plugin sidebar or shell in the tab never pauses tracking.
 - A failed clipboard utility or `herdr agent send` reports the error. The comments stay in the list.
 - A turn shorter than one poll interval, or one whose start is masked by a transient `unknown` status, is missed. `last-turn` then shows the changes since the last observed turn start. It never shows lines the agent did not write.
 - A crash mid-snapshot costs at most one failed refresh. Ref updates are atomic. Leftover locks are cleared before the next snapshot and on every exit path.

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -29,6 +29,24 @@ struct AgentPane {
     workspace_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct TabListResponse {
+    result: TabList,
+}
+
+#[derive(Debug, Deserialize)]
+struct TabList {
+    tabs: Vec<TabRef>,
+}
+
+/// One `herdr tab list` entry. The array order is the live left-to-right tab order and
+/// tracks drag-reorders; `number` is a creation id, not a position, so only order counts.
+#[derive(Debug, Deserialize)]
+struct TabRef {
+    tab_id: String,
+    workspace_id: String,
+}
+
 fn herdr_bin() -> String {
     env::var("HERDR_BIN_PATH").unwrap_or_else(|_| "herdr".to_string())
 }
@@ -59,13 +77,42 @@ fn agent_list() -> Result<Vec<AgentPane>> {
     parse_agents(&herdr(&["agent", "list"])?)
 }
 
-/// The agent pane to send to: the sole agent in this tab, else the sole workspace agent.
+/// The workspace's tab ids in visible left-to-right order (`herdr tab list` array order).
+/// Best-effort: any failure yields an empty order, which disables the nearest-left rule
+/// without affecting the tab and sole-workspace resolutions.
+fn tab_order(ws: Option<&str>) -> Vec<String> {
+    let Some(ws) = ws else { return Vec::new() };
+    match herdr(&["tab", "list", "--workspace", ws]) {
+        Ok(json) => parse_tab_order(&json, ws),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// The `result.tabs` ids from `herdr tab list`, in array order, scoped to `ws`. A malformed
+/// envelope yields an empty order. `--workspace` already scopes the list; the `ws` filter is
+/// a guard against a herdr that ignores the flag and returns every workspace's tabs.
+fn parse_tab_order(json: &str, ws: &str) -> Vec<String> {
+    let Ok(response) = serde_json::from_str::<TabListResponse>(json) else {
+        return Vec::new();
+    };
+    response
+        .result
+        .tabs
+        .into_iter()
+        .filter(|tab| tab.workspace_id == ws)
+        .map(|tab| tab.tab_id)
+        .collect()
+}
+
+/// The agent pane to send to: the sole tab agent, else the sole workspace agent, else the
+/// agent in the nearest tab to the left of the sidebar (`specs/herdr-host.md`, HH-NEAREST-LEFT).
 ///
 /// A refusal says why and names the clipboard fallback (`specs/herdr-host.md`, HH-SOLE-OR-REFUSE/HH-REFUSE-SAYS-CLIPBOARD) —
 /// the status line renders it as `agent failed: <this message>`.
 pub fn resolve_agent_pane() -> Result<String> {
     let (tab, ws, me) = agent_env();
-    match pick_agent(&agent_list()?, tab.as_deref(), ws.as_deref(), me.as_deref()) {
+    let order = || tab_order(ws.as_deref());
+    match pick_agent(&agent_list()?, order, tab.as_deref(), ws.as_deref(), me.as_deref()) {
         Ok(agent) => Ok(agent.pane_id.clone()),
         Err(Refusal::NoAgent) => bail!("no agent here — copy to the clipboard instead"),
         Err(Refusal::Several) => bail!("several agents here — copy to the clipboard instead"),
@@ -83,7 +130,8 @@ fn parse_agents(json: &str) -> Result<Vec<AgentPane>> {
 /// treats an absent or ambiguous agent the same as a missing herdr — turn tracking pauses.
 pub fn resolved_agent_status() -> Result<Option<Status>> {
     let (tab, ws, me) = agent_env();
-    Ok(pick_agent(&agent_list()?, tab.as_deref(), ws.as_deref(), me.as_deref())
+    let order = || tab_order(ws.as_deref());
+    Ok(pick_agent(&agent_list()?, order, tab.as_deref(), ws.as_deref(), me.as_deref())
         .ok()
         .map(|agent| agent.agent_status))
 }
@@ -95,13 +143,19 @@ enum Refusal {
     Several,
 }
 
-/// The sole agent in this tab, else the sole workspace agent (`specs/herdr-host.md`, HH-AGENT-PANES through HH-SOLE-OR-REFUSE).
+/// The sole tab agent, else the sole workspace agent, else the agent in the nearest tab to
+/// the left of the sidebar (`specs/herdr-host.md`, HH-AGENT-PANES through HH-NEAREST-LEFT).
 ///
 /// The workspace candidates are a superset of the tab candidates whenever both env ids are
-/// present, so the refusal reason reads off the widest scope: no candidates anywhere is
-/// `NoAgent`, anything else is `Several`.
+/// present. The nearest-left rule only fires when several workspace agents remain, so a lone
+/// agent is always taken first. With nothing resolvable, no candidates anywhere is `NoAgent`,
+/// anything else is `Several`.
+///
+/// `tab_order` is lazy: only several workspace agents can reach the nearest-left rule, so the
+/// common single-agent resolutions never pay for the `herdr tab list` subprocess it wraps.
 fn pick_agent<'a>(
     agents: &'a [AgentPane],
+    tab_order: impl FnOnce() -> Vec<String>,
     tab: Option<&str>,
     ws: Option<&str>,
     me: Option<&str>,
@@ -110,10 +164,46 @@ fn pick_agent<'a>(
     if let &[agent] = in_tab.as_slice() {
         return Ok(agent);
     }
-    match candidates(agents, ws, me, |agent| &agent.workspace_id).as_slice() {
-        &[agent] => Ok(agent),
-        [] if in_tab.is_empty() => Err(Refusal::NoAgent),
-        _ => Err(Refusal::Several),
+    let in_ws = candidates(agents, ws, me, |agent| &agent.workspace_id);
+    if let &[agent] = in_ws.as_slice() {
+        return Ok(agent);
+    }
+    // `&&` short-circuits, so `tab_order()` (a `herdr tab list` subprocess) runs only when
+    // several workspace agents actually reach the nearest-left rule.
+    if in_ws.len() >= 2
+        && let Some(agent) = nearest_left_agent(&in_ws, &tab_order(), tab)
+    {
+        return Ok(agent);
+    }
+    if in_tab.is_empty() && in_ws.is_empty() {
+        Err(Refusal::NoAgent)
+    } else {
+        Err(Refusal::Several)
+    }
+}
+
+/// The workspace agent in the nearest tab to the left of the sidebar's own tab, by visible
+/// tab order (`specs/herdr-host.md`, HH-NEAREST-LEFT). `None` when the sidebar's tab is
+/// absent from the order, no agent sits left of it, or the nearest left tab holds several
+/// agents — a tab reviewr will not guess between.
+fn nearest_left_agent<'a>(
+    ws_agents: &[&'a AgentPane],
+    tab_order: &[String],
+    tab: Option<&str>,
+) -> Option<&'a AgentPane> {
+    let own = tab_order.iter().position(|id| Some(id.as_str()) == tab)?;
+    let position_of = |tab_id: &str| tab_order.iter().position(|id| id.as_str() == tab_id);
+    let left: Vec<(usize, &'a AgentPane)> = ws_agents
+        .iter()
+        .filter_map(|agent| position_of(agent.tab_id.as_str()).map(|pos| (pos, *agent)))
+        .filter(|(pos, _)| *pos < own)
+        .collect();
+    let nearest = left.iter().map(|(pos, _)| *pos).max()?;
+    let in_nearest: Vec<&'a AgentPane> =
+        left.into_iter().filter(|(pos, _)| *pos == nearest).map(|(_, agent)| agent).collect();
+    match in_nearest.as_slice() {
+        &[agent] => Some(agent),
+        _ => None,
     }
 }
 
@@ -150,7 +240,7 @@ pub fn focus(pane: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentPane, Refusal, Status, parse_agents, pick_agent};
+    use super::{AgentPane, Refusal, Status, parse_agents, parse_tab_order, pick_agent};
 
     /// One agent entry shaped like the real `herdr agent list` output (api notes).
     fn agent(pane: &str, tab: &str, ws: &str) -> AgentPane {
@@ -175,14 +265,28 @@ mod tests {
         }
     }
 
-    /// [`pick_agent`] reduced to the picked `pane_id`, for terse assertions.
+    /// [`pick_agent`] with no tab order, reduced to the picked `pane_id`. Exercises the tab
+    /// and sole-workspace rules; the nearest-left rule stays dormant with an empty order.
     fn pick(
         agents: &[AgentPane],
         tab: Option<&str>,
         ws: Option<&str>,
         me: Option<&str>,
     ) -> Result<String, Refusal> {
-        pick_agent(agents, tab, ws, me).map(|agent| agent.pane_id.clone())
+        pick_agent(agents, Vec::new, tab, ws, me).map(|agent| agent.pane_id.clone())
+    }
+
+    /// [`pick_agent`] with a visible tab order, reduced to the picked `pane_id`. Drives the
+    /// nearest-left rule; `order` lists tab ids left to right.
+    fn pick_ordered(
+        agents: &[AgentPane],
+        order: &[&str],
+        tab: Option<&str>,
+        ws: Option<&str>,
+        me: Option<&str>,
+    ) -> Result<String, Refusal> {
+        let order: Vec<String> = order.iter().map(ToString::to_string).collect();
+        pick_agent(agents, move || order, tab, ws, me).map(|agent| agent.pane_id.clone())
     }
 
     #[test]
@@ -257,5 +361,103 @@ mod tests {
         assert_eq!(parse_agents(wrapped).unwrap(), [agent("w8:p1", "w8:t1", "w8")]);
         assert!(parse_agents("[]").is_err());
         assert_eq!(serde_json::from_str::<Status>(r#""starting""#).unwrap(), Status::Unknown);
+    }
+
+    #[test]
+    fn nearest_left_binds_the_first_agent_left_of_the_sidebar() {
+        let agents = vec![agent("w:p1", "w:t1", "w"), agent("w:p7", "w:t7", "w")];
+        // Sidebar tab w:t5 has no agent; w:t2 to its left has none either, so the nearest
+        // agent tab left of it is w:t1 (HH-NEAREST-LEFT). w:t7 is to the right, ignored.
+        let order = ["w:t1", "w:t2", "w:t5", "w:t7"];
+        assert_eq!(
+            pick_ordered(&agents, &order, Some("w:t5"), Some("w"), None),
+            Ok("w:p1".to_string())
+        );
+    }
+
+    #[test]
+    fn nearest_left_prefers_the_closest_of_several_left_agents() {
+        let agents = vec![
+            agent("w:p1", "w:t1", "w"),
+            agent("w:p3", "w:t3", "w"),
+            agent("w:p7", "w:t7", "w"),
+        ];
+        // Two agents sit left of the sidebar (w:t1, w:t3); the closer one, w:t3, wins.
+        let order = ["w:t1", "w:t3", "w:t5", "w:t7"];
+        assert_eq!(
+            pick_ordered(&agents, &order, Some("w:t5"), Some("w"), None),
+            Ok("w:p3".to_string())
+        );
+    }
+
+    #[test]
+    fn a_sole_tab_agent_wins_over_an_agent_to_the_left() {
+        let agents = vec![agent("w:p5", "w:t5", "w"), agent("w:p1", "w:t1", "w")];
+        // The sidebar shares w:t5 with one agent; the tab rule takes it before nearest-left.
+        let order = ["w:t1", "w:t5"];
+        assert_eq!(
+            pick_ordered(&agents, &order, Some("w:t5"), Some("w"), Some("w:p9")),
+            Ok("w:p5".to_string())
+        );
+    }
+
+    #[test]
+    fn a_sole_workspace_agent_wins_even_when_it_is_to_the_right() {
+        let agents = vec![agent("w:p7", "w:t7", "w")];
+        // One agent, to the right of the sidebar: the sole-workspace rule still binds it, so
+        // nearest-left never runs (it only disambiguates several agents).
+        let order = ["w:t5", "w:t7"];
+        assert_eq!(
+            pick_ordered(&agents, &order, Some("w:t5"), Some("w"), None),
+            Ok("w:p7".to_string())
+        );
+    }
+
+    #[test]
+    fn several_agents_with_none_to_the_left_refuse_as_several() {
+        let agents = vec![agent("w:p7", "w:t7", "w"), agent("w:p9", "w:t9", "w")];
+        // Both agents are to the right of the sidebar and neither shares its tab — nothing to
+        // the left, so it refuses rather than guess (→ empty last-turn).
+        let order = ["w:t5", "w:t7", "w:t9"];
+        assert_eq!(
+            pick_ordered(&agents, &order, Some("w:t5"), Some("w"), None),
+            Err(Refusal::Several)
+        );
+    }
+
+    #[test]
+    fn several_agents_in_the_nearest_left_tab_refuse() {
+        let agents = vec![agent("w:p1", "w:t1", "w"), agent("w:p2", "w:t1", "w")];
+        // The nearest tab to the left holds two agents; reviewr will not guess between them.
+        let order = ["w:t1", "w:t5"];
+        assert_eq!(
+            pick_ordered(&agents, &order, Some("w:t5"), Some("w"), None),
+            Err(Refusal::Several)
+        );
+    }
+
+    #[test]
+    fn a_sidebar_tab_absent_from_the_order_disables_nearest_left() {
+        let agents = vec![agent("w:p1", "w:t1", "w"), agent("w:p3", "w:t3", "w")];
+        // The order predates the sidebar's tab (a stale `tab list`), so "left of it" is
+        // undefined — nearest-left stays dormant and two agents refuse (HH-NEAREST-LEFT).
+        let order = ["w:t1", "w:t3"];
+        assert_eq!(
+            pick_ordered(&agents, &order, Some("w:t9"), Some("w"), None),
+            Err(Refusal::Several)
+        );
+    }
+
+    #[test]
+    fn parse_tab_order_keeps_array_order_and_scopes_to_the_workspace() {
+        let json = r#"{"result":{"tabs":[
+            {"tab_id":"w:t7","workspace_id":"w","number":7,"focused":true},
+            {"tab_id":"w:t1","workspace_id":"w","number":1,"focused":false},
+            {"tab_id":"x:t2","workspace_id":"x","number":2,"focused":false}
+        ]}}"#;
+        // Array order is preserved (not sorted by `number`) and other workspaces drop out.
+        assert_eq!(parse_tab_order(json, "w"), ["w:t7".to_string(), "w:t1".to_string()]);
+        // A malformed envelope yields an empty order, which disables the nearest-left rule.
+        assert!(parse_tab_order("not json", "w").is_empty());
     }
 }


### PR DESCRIPTION
> **Transparency up front.** I built this as a **local patch for my own use** — I run reviewr in a dedicated "Review" tab and wanted it to track the agent tab to its left. I'm opening this PR as a **possible basis for adding the feature upstream**, not as a finished or authoritative proposal — take, adapt, or reshape whatever is useful, or close it if it doesn't fit your direction. It was **developed with AI assistance** (both the implementation and a five-axis AI review pass), so please scrutinize it accordingly rather than assuming it's been battle-tested.

## Problem

A `reviewr` sidebar in its **own tab** (a dedicated "Review" tab) can't resolve which agent to track when the workspace holds several agents:

- the tab rule (`HH-TAB-WINS`) finds no agent in the sidebar's tab, and
- the sole-workspace rule refuses on ambiguity (`HH-SOLE-OR-REFUSE`).

So `resolved_agent_status()` returns `None`, turn tracking pauses, no `refs/reviewr/turn-base/*` baseline is ever written, and the **last-turn** scope stays permanently empty. (`uncommitted` / `branch` are unaffected — they don't need an agent.)

## Change

Add a third resolution step after the tab and sole-workspace rules (`HH-NEAREST-LEFT`): bind to the agent in the **nearest tab to the left** of the sidebar, in the visible left-to-right tab order.

- **Ordering signal — `herdr tab list`'s array order.** I verified this equals the visible left-to-right order (and tracks drag-reorders), not focus/MRU order — see `docs/herdr-api-notes.md` for the two live tests: focusing a tab does *not* reorder the array (a focused tab was observed at a non-first index; focusing a middle tab left the array byte-identical), while dragging a tab *does* move it. The tab `number` is a stable creation id, not a position, so it's deliberately unused, and the API exposes no `position`/`index` field.
- **Precedence:** sole tab agent → sole workspace agent → nearest agent tab to the left → refuse. The sole-workspace rule still runs first, so a lone agent (even one to the right) is unaffected; nearest-left only disambiguates when several agents remain.
- **Lazy.** The `herdr tab list` subprocess runs **only** when several workspace agents actually reach the nearest-left rule (`in_ws.len() >= 2`), so the common single-agent poll path spawns nothing extra.
- Runs through the shared resolver, so both **turn tracking and Send** stay bound to the same agent.

## Tests & checks

- New unit tests in `src/herdr.rs`: nearest-left (closest wins, right-side ignored, sole-workspace-wins-even-to-the-right, several-with-none-left → refuse, several-in-nearest-tab → refuse, sole-tab-agent-wins, stale/absent order → dormant) plus a pure `parse_tab_order` seam test (array-order preservation, workspace scoping, malformed → empty).
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the full suite pass on `master` (v0.21.0).
- Docs: `specs/herdr-host.md` gains `HH-NEAREST-LEFT`; `docs/herdr-api-notes.md` documents the `tab list` shape and the verified ordering.

## Open questions for the maintainer

- The tab-ordering behavior is **verified by observation on herdr 0.7.4**, not by a documented API contract — that's the load-bearing assumption. If herdr documents (or changes) tab-array ordering, this rule depends on it.
- Happy to gate it behind a config flag, narrow it to turn-tracking only (leaving Send as-is), or adjust the precedence if you'd prefer a smaller surface.
