### PR TITLE
Feat/gitlab forge

### DIFF
--- a/specs/config.md
+++ b/specs/config.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-07-10
-Last edited: 2026-07-21
+Last edited: 2026-07-22
 ---
 
 # Configuration
@@ -21,6 +21,7 @@ toggle_placement = "overlay"
 toggle_direction = "down"
 auto_open = false
 github_host = "github.example.com"
+gitlab_host = "gitlab.example.com"
 
 [keybindings]
 comment = ["c", "ㅊ"]
@@ -37,7 +38,8 @@ find    = ["ctrl+f"]
 | `toggle_placement`   | `split`, `overlay`, `zoomed`, or `tab`                                             |
 | `toggle_direction`   | `right` or `down`                                                                  |
 | `auto_open`          | boolean                                                                            |
-| `github_host`        | bare hostname other than `github.com`                                              |
+| `github_host`        | bare hostname other than `github.com` or `gitlab.com`                              |
+| `gitlab_host`        | bare hostname other than `github.com` or `gitlab.com`, distinct from `github_host` |
 | `keybindings`        | table of actions from the keymap in `input.md`, each a non-empty array of keys     |
 
 ## Behavior

--- a/specs/forge-host.md
+++ b/specs/forge-host.md
@@ -1,16 +1,16 @@
 ---
 Status: Current
 Created: 2026-06-27
-Last edited: 2026-07-18
+Last edited: 2026-07-22
 ---
 
 # forge host
 
-How reviewr reads one pull request from GitHub — identity, state, checks, comments — through the `gh` CLI, for the read-only `PR` tab (`pr-tab.md`). It never writes back.
+How reviewr reads one pull request — identity, state, checks, comments — from GitHub through `gh` or from GitLab through `glab`, for the read-only `PR` tab (`pr-tab.md`). It never writes back. A GitLab merge request reads as a PR throughout.
 
 ## Overview
 
-reviewr resolves the worktree's pull request through its commits, then reads a snapshot of it through `gh` on each poll. Every shown PR provably belongs to this worktree's work. The snapshot is the single value the `PR` tab renders.
+reviewr resolves the worktree's pull request through its commits, then reads a snapshot of it through the forge's CLI on each poll. Every shown PR provably belongs to this worktree's work. The snapshot is the single value the `PR` tab renders.
 
 ```
 PR #226  open  persiyanov/deep-research-benchmark → main   ⇡ 2 unpushed
@@ -23,13 +23,13 @@ The snapshot:
 
 | field                  | type   | meaning                                                                     |
 | ---------------------- | ------ | --------------------------------------------------------------------------- |
-| `number`               | int?   | PR number, `null` when no PR resolves                                       |
+| `number`               | int?   | PR number (a GitLab MR's `iid`), `null` when no PR resolves                 |
 | `title`, `url`         | string | identity                                                                    |
-| `body`                 | string | the PR description as GitHub returns it, empty when none                    |
+| `body`                 | string | the PR description as the forge returns it, empty when none                 |
 | `state`                | enum   | `open`, `merged`, or `closed`                                               |
 | `is_draft`             | bool   | draft flag                                                                  |
 | `head_ref`             | string | the PR's head branch name, which may differ from the local branch           |
-| `head_is_fork`         | bool   | the head lives in another repository (GitHub's `isCrossRepository`)         |
+| `head_is_fork`         | bool   | the head lives in another repository                                        |
 | `base_ref`             | string | the merge target                                                            |
 | `merge`                | enum   | `clean`, `conflicting`, or `blocked`                                        |
 | `sync`                 | enum   | `in_sync`, `unpushed`, `behind`, or `unknown`, with a count when known      |
@@ -44,43 +44,46 @@ A `comments` row:
 | `kind`                       | enum   | `review` (a review's body), `comment` (conversation), `finding` (inline) |
 | `author`, `author_is_bot`    | string, bool | the `@login` and whether it is a bot                              |
 | `anchor`                     | string | `path:line` for a `finding`, the literal kind word otherwise            |
-| `body`, `snippet`            | string | the text as GitHub returns it, no chrome-stripping or format parsing; only a `finding` carries a snippet |
+| `body`, `snippet`            | string | the text as the forge returns it, no chrome-stripping or format parsing; only a `finding` carries a snippet |
 | `created_at`                 | time   | post time, the newest-first sort key                                    |
 | `is_resolved`, `is_outdated` | bool   | thread state for a `finding`, always false otherwise                    |
 | `reply_count`                | int    | replies on a `finding`'s thread beyond the root                         |
 
 ## Behavior
 
-### GitHub hosts
+### Forge hosts
 
-`github_host` in reviewr's `config.toml` adds one GitHub Enterprise hostname. Its value contract lives in `config.md`.
+`github.com` and `gitlab.com` are supported without configuration. Each config key adds one self-managed hostname; the value contracts live in `config.md`.
 
 ```toml
 github_host = "github.example.com"
+gitlab_host = "gitlab.example.com"
 ```
 
-Host matching is case-insensitive. A missing setting adds no Enterprise host. `github.com` remains supported when the setting is present.
+Host matching is case-insensitive. A missing setting adds no self-managed host. The built-in hosts remain supported when a setting is present. The host decides the forge, and the forge decides the CLI: `gh` for GitHub, `glab` for GitLab.
+
+A GitHub repository path is exactly `owner/repository`. A GitLab repository path nests: every segment before the repository name is its namespace (`group/sub/team/repository`).
 
 Both remotes use the primary fetch URL after Git's `url.*.insteadOf` rewrite. A separate push URL does not affect PR reads.
 
-| remote state                                                               | outcome                                                                  |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `upstream` names `github.com` or exact `github_host` with `owner/repository` | reviewr reads that repository                                            |
-| `upstream` is absent, hostless, unsupported, or malformed                  | `origin` determines the repository                                       |
-| reading `upstream` fails                                                   | reviewr shows the retryable Git error and never falls through            |
-| `origin` names `github.com` or exact `github_host` with `owner/repository`   | reviewr reads that repository                                            |
-| `origin` names another hosted repository                                   | reviewr names the unsupported host and points Enterprise users to config |
-| `origin` is missing or hostless                                            | reviewr says the PR tab needs a supported GitHub `upstream` or `origin`   |
-| `origin` names a supported host without `owner/repository`                  | reviewr says the GitHub origin is malformed                              |
-| reading `origin` fails                                                     | reviewr shows the retryable Git error                                    |
+| remote state                                                | outcome                                                                     |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `upstream` names a supported host with a repository path    | reviewr reads that repository                                               |
+| `upstream` is absent, hostless, unsupported, or malformed   | `origin` determines the repository                                          |
+| reading `upstream` fails                                    | reviewr shows the retryable Git error and never falls through               |
+| `origin` names a supported host with a repository path      | reviewr reads that repository                                               |
+| `origin` names another hosted repository                    | reviewr names the unsupported host and points self-managed users to config  |
+| `origin` is missing or hostless                             | reviewr says the PR tab needs a supported `upstream` or `origin`            |
+| `origin` names a supported host without a repository path   | reviewr says the origin is malformed                                        |
+| reading `origin` fails                                      | reviewr shows the retryable Git error                                       |
 
 A fork clone with `origin` pointed at the fork and a supported `upstream` pointed at the base
 repository resolves the base repository's PR without setup.
 
 Canonical SSH remotes work in scp-style (`git@host:owner/repository.git`) and `ssh://` forms. Hosted
-URL forms use `http://`, `https://`, or `git://`. File URLs and other schemes are not GitHub
-repository identities. SSH aliases are not inferred as canonical GitHub hosts. `GH_HOST` cannot
-redirect a fetch.
+URL forms use `http://`, `https://`, or `git://`. File URLs and other schemes are not forge
+repository identities. SSH aliases are not inferred as canonical forge hosts. Neither `GH_HOST` nor
+`GITLAB_HOST` can redirect a fetch.
 
 ### Resolution
 
@@ -118,20 +121,24 @@ What a user observes:
 
 - `merge` folds GitHub's fields to the blockers worth surfacing: `CONFLICTING`/`DIRTY` → `conflicting`, `BLOCKED` → `blocked`, and everything else (`CLEAN`, `BEHIND`, `UNSTABLE`, still-computing `UNKNOWN`) → `clean`, which the footer shows as nothing.
 - `mergeable=UNKNOWN` is GitHub computing lazily. It folds to `clean` unless `mergeStateStatus` is `DIRTY`.
+- On GitLab, `merge` folds the same way: conflicts → `conflicting`; the reviewer-actionable gates (approvals, unresolved discussions, requested changes, policies, external status checks) → `blocked`; everything else (mergeable, still-checking, a running pipeline, need-rebase) → `clean`.
 - `sync` compares the pinned `HEAD` OID to the PR's `head_oid`: equal is `in_sync`, `HEAD` ahead is `unpushed` with a `git rev-list --count` count, and `head_oid` ahead is `behind`. If the PR head object is unavailable locally, the relation is `unknown`; reviewr never guesses `in_sync`.
 - `unpushed` means the checks and comments on screen describe an older commit than the local tree.
 
 ### Checks
 
 - A check row is the latest run for its name. A passed re-run replaces an earlier failure.
-- Check runs and commit statuses normalize into one list.
+- On GitHub, check runs and commit statuses normalize into one list.
+- On GitLab, the head pipeline's jobs are the list. A manual gate reads as skipped; a canceled job as failed.
 - A top-level rollup gives the overall pass or fail.
 
 ### Comments
 
-- Three surfaces merge into one list: submitted reviews, inline threads, and conversation comments.
-- A bot's PR-level posts collapse to its latest. A human's are each kept.
-- `is_resolved` and `is_outdated` come from GitHub, never recomputed against the worktree.
+- On GitHub, three surfaces merge into one list: submitted reviews, inline threads, and conversation comments.
+- On GitLab, the discussion roots are the list: a positioned root is a `finding`, an unpositioned one a `comment`. The `review` kind never occurs. System notes (assignments, review requests) are dropped.
+- A GitLab `finding` carries no snippet and never marks outdated — GitLab exposes neither.
+- A bot's PR-level posts collapse to its latest. A human's are each kept. GitHub marks a bot by its `[bot]` login suffix; GitLab by the account's own bot marker, whatever its username.
+- `is_resolved` and `is_outdated` come from the forge, never recomputed against the worktree.
 - Outdated and resolved threads stay in the list with their marker.
 - Each surface reads its newest 100 rows, never paged to exhaustion. A further page on any surface — reviews, comments, threads, or checks — sets `truncated`, and `pr-tab.md` marks the capped list, so it is never presented as complete.
 
@@ -145,47 +152,47 @@ What a user observes:
 - Every other observed change keeps the snapshot painted and refetches behind it. The same pull request with newer work is stale, not wrong. The in-flight glyph covers the gap (`tui.md`).
 - Either observation starts the replacement fetch at once, on or off the tab, so entering the tab finds fresh work already underway.
 - One fetch is in flight at a time. One or more triggers arriving mid-flight supersede its result and start one fresh fetch when it completes.
-- A GitHub change during a fetch can appear on the following fetch.
+- A forge change during a fetch can appear on the following fetch.
 - Each fetch uses one validated config snapshot for host and base selection (→ CFG-ONE-SNAPSHOT, `config.md`).
-- A GitHub result paints only if the current config, repository target, pinned `HEAD`, pinned base, and
+- A forge result paints only if the current config, repository target, pinned `HEAD`, pinned base, and
   publication points still match the input that produced it. If reviewr cannot prove that match, the
   result never paints, and one replacement fetch starts against the current input.
 - If the repository target is proven unchanged before a later branch-state read fails, the visible
-  same-target snapshot stays with a retry notice; the next refresh performs a fresh GitHub fetch.
+  same-target snapshot stays with a retry notice; the next refresh performs a fresh forge fetch.
 - The snapshot re-derives in full each fetch. reviewr keeps no hidden or historical PR cache beyond the visible snapshot.
 - Exiting reviewr stops scheduling and restores the terminal immediately. No later PR completion
   can paint.
 
 ## Failure semantics
 
-reviewr reads GitHub and never writes it, so every failure degrades to a clear state. `Changes` and `All files` are unaffected.
+reviewr reads the forge and never writes it, so every failure degrades to a clear state. `Changes` and `All files` are unaffected.
 
 - A same-input failure preserves the visible snapshot and shows its remedy. With no same-input snapshot, the remedy fills the tab.
 
-| failure               | remedy shown                      |
-| --------------------- | --------------------------------- |
-| missing `gh`          | the install step                  |
-| unauthenticated fetch | `gh auth login --hostname <host>` |
+| failure                       | remedy shown                                 |
+| ----------------------------- | -------------------------------------------- |
+| missing forge CLI             | the install step for `gh` or `glab`          |
+| unauthenticated fetch         | `<cli> auth login --hostname <host>`         |
 | any other fetch error | the retry error                   |
 
 - A failure before the repository target resolves replaces any snapshot with the retryable Git error. reviewr cannot prove that the snapshot still belongs to the current target.
 - A branch-state Git failure after the same repository target resolves preserves the visible
   same-target snapshot with the retryable Git error.
-- An unsupported origin names the host and points Enterprise users to `github_host`.
+- An unsupported origin names the host and points self-managed users to `github_host` / `gitlab_host`.
 - No PR at any lifecycle state shows a calm empty state. The next poll lights the tab up when a PR appears.
 - Every read is side-effect-free.
 - Two active PR tabs on one worktree converge within one poll interval. An inactive tab catches up when entered.
 
 ## Non-goals
 
-- No writes to GitHub. reviewr never posts, resolves a thread, re-runs a check, or merges. It never routes PR feedback to the agent.
+- No writes to the forge. reviewr never posts, resolves a thread, re-runs a check, or merges. It never routes PR feedback to the agent.
 - No repository selector or cross-repository search.
 - No different parent repositories across sibling worktrees from one clone. Use a separate clone for each parent.
 - No SSH host-alias normalization. An alias-only repository needs a canonical-host remote.
 - No discovery of an unrecorded publication name on a non-`origin` remote.
-- No event subscription. The snapshot polls `gh`, no webhook or socket.
-- No server-version compatibility layer for Enterprise schemas.
-- No second forge. GitHub via `gh` only.
+- No event subscription. The snapshot polls the forge CLI, no webhook or socket.
+- No server-version compatibility layer for self-managed schemas.
+- No third forge. GitHub via `gh` and GitLab via `glab` only.
 
 ## Related specs
 

--- a/specs/forge-host.md
+++ b/specs/forge-host.md
@@ -23,6 +23,7 @@ The snapshot:
 
 | field                  | type   | meaning                                                                     |
 | ---------------------- | ------ | --------------------------------------------------------------------------- |
+| `forge`                | enum   | `github` or `gitlab` — names the remote surface in the tab's chrome        |
 | `number`               | int?   | PR number (a GitLab MR's `iid`), `null` when no PR resolves                 |
 | `title`, `url`         | string | identity                                                                    |
 | `body`                 | string | the PR description as the forge returns it, empty when none                 |

--- a/specs/pr-tab.md
+++ b/specs/pr-tab.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-07-17
-Last edited: 2026-07-21
+Last edited: 2026-07-22
 ---
 
 # PR tab
@@ -10,7 +10,7 @@ A read-only mirror of the pull request in the sidebar's two-pane frame: identity
 
 ## Overview
 
-The navigator shows checks and selects the description or a comment. The read pane shows that selection. The header carries the PR's identity and state. The tab reads GitHub through `forge-host.md` and writes nothing. Its only outward action opens a link in the browser.
+The navigator shows checks and selects the description or a comment. The read pane shows that selection. The header carries the PR's identity and state. The tab reads the forge through `forge-host.md` and writes nothing. Its only outward action opens a link in the browser.
 
 ```
  1 Changes  2 All files  3 PR    Deep research: GPT-5.5/5.4-mini upgrade…  deep-research  merged #226 ↗
@@ -37,14 +37,14 @@ The navigator shows checks and selects the description or a comment. The read pa
 
 - The header right-anchors a clickable `status #226 ↗` chip, status colored by lifecycle: `open` green, `draft` yellow, `merged` mauve, `closed` red. The PR title sits to its left, truncated to fit.
 - Between title and chip sits the resolved head branch (`head_ref`, `forge-host.md`), dim, prefixed `⑂ ` when the head lives in a fork. On a narrow bar the branch drops first.
-- The footer leads with merge, sync, checks, and comment counts, then `o open ↗` and the `?`. Merge and sync show only while the PR is open. A capped surface appends `+more on GitHub ↗` (`forge-host.md`).
+- The footer leads with merge, sync, checks, and comment counts, then `o open ↗` and the `?`. Merge and sync show only while the PR is open. A capped surface appends `+more on <forge> ↗`, named per the snapshot's forge (`forge-host.md`).
 - The `?` expands to the `go` band and a `move` band of down, up, and the page keys. The `PR` tab has no hunk or file steps (`input.md`).
 - The ordinary no-PR body says only `No pull request yet. Ready to ship?` A detached HEAD says `No pull request found — HEAD is detached.`
 
 ### Navigator and read pane
 
 - The navigator, titled `Checks & comments`, shows a status-only checks section above the comments list. The cursor walks the description row and the comments.
-- Comments list newest first, each row `@author anchor age`, with `outdated` or `resolved` markers where GitHub receded the thread.
+- Comments list newest first, each row `@author anchor age`, with `outdated` or `resolved` markers where the forge receded the thread.
 - A non-empty PR description pins a `description` row at the top of the navigator, above the checks. An emptied description vanishes like a comment: the cursor clamps, the read pane resets.
 - The read pane shows the selected comment: a finding shows its `snippet` then the body, a review or plain comment shows its prose, the description row shows the PR description.
 - Bodies render as markdown (`markdown.md`). A finding's `snippet` stays plain `+`/`−`-colored lines.
@@ -56,7 +56,7 @@ The navigator shows checks and selects the description or a comment. The read pa
 - A retry notice for a preserved snapshot stays fixed above the read body, so it remains visible without resetting the reader's scroll.
 - The authoring keys (`s`, `c`, `v`, `d`, `e`) do nothing here.
 - A merged or closed PR shows the same mirror, read-only.
-- No usable `gh` shows the matching failure state from `forge-host.md`, naming the command that unblocks it.
+- No usable forge CLI (`gh`/`glab`) shows the matching failure state from `forge-host.md`, naming the command that unblocks it.
 
 ### Refresh
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,7 +71,7 @@ pub(crate) fn canonical_base(entry: &str) -> String {
         .to_string()
 }
 
-const PLUGIN_CONFIG_KEYS: [&str; 9] = [
+const PLUGIN_CONFIG_KEYS: [&str; 10] = [
     "theme",
     "base_branches",
     "default_scope",
@@ -80,6 +80,7 @@ const PLUGIN_CONFIG_KEYS: [&str; 9] = [
     "toggle_direction",
     "auto_open",
     "github_host",
+    "gitlab_host",
     "keybindings",
 ];
 
@@ -168,6 +169,7 @@ pub struct PluginConfig {
     toggle_direction: ToggleDirection,
     auto_open: bool,
     github_host: Option<String>,
+    gitlab_host: Option<String>,
     keymap: crate::keymap::Keymap,
 }
 
@@ -182,6 +184,7 @@ impl Default for PluginConfig {
             toggle_direction: ToggleDirection::Right,
             auto_open: true,
             github_host: None,
+            gitlab_host: None,
             keymap: crate::keymap::Keymap::default(),
         }
     }
@@ -222,6 +225,15 @@ impl PluginConfig {
         self.github_host.as_deref()
     }
 
+    pub fn gitlab_host(&self) -> Option<&str> {
+        self.gitlab_host.as_deref()
+    }
+
+    /// Both configured self-managed hosts, as remote classification consumes them.
+    pub fn forge_hosts(&self) -> crate::git::ForgeHosts<'_> {
+        crate::git::ForgeHosts { github: self.github_host(), gitlab: self.gitlab_host() }
+    }
+
     /// The resolved keymap: the defaults with this snapshot's `[keybindings]` applied.
     pub fn keymap(&self) -> &crate::keymap::Keymap {
         &self.keymap
@@ -247,6 +259,7 @@ impl PluginConfig {
             "toggle_direction": self.toggle_direction.as_str(),
             "auto_open": self.auto_open,
             "github_host": self.github_host,
+            "gitlab_host": self.gitlab_host,
             "keybindings": keybindings,
         })
     }
@@ -423,12 +436,25 @@ fn parse_plugin_config(path: &Path) -> Result<PluginConfig, PluginConfigError> {
         config.auto_open =
             value.as_bool().ok_or_else(|| value_error(path, "auto_open", "a boolean"))?;
     }
-    if let Some(value) = table.get("github_host") {
-        let host = string_value(path, "github_host", value, "a bare hostname outside github.com")?;
-        if !valid_enterprise_host(host) {
-            return Err(value_error(path, "github_host", "a bare hostname other than github.com"));
+    for (key, slot) in
+        [("github_host", &mut config.github_host), ("gitlab_host", &mut config.gitlab_host)]
+    {
+        if let Some(value) = table.get(key) {
+            let expected = "a bare hostname other than github.com or gitlab.com";
+            let host = string_value(path, key, value, expected)?;
+            if !valid_selfmanaged_host(host) {
+                return Err(value_error(path, key, expected));
+            }
+            *slot = Some(host.to_ascii_lowercase());
         }
-        config.github_host = Some(host.to_ascii_lowercase());
+    }
+    if let (Some(github), Some(gitlab)) = (&config.github_host, &config.gitlab_host)
+        && github == gitlab
+    {
+        return Err(PluginConfigError::new(
+            path,
+            format!("invalid value for `gitlab_host`: `github_host` already names {github:?}"),
+        ));
     }
     if let Some(value) = table.get("keybindings") {
         config.keymap = parse_keybindings(path, value)?;
@@ -535,9 +561,11 @@ fn unknown_key_error(path: &Path, key: &str, options: &str) -> PluginConfigError
     PluginConfigError::new(path, format!("unknown key {key:?}; expected one of {options}"))
 }
 
-fn valid_enterprise_host(host: &str) -> bool {
+/// A configured self-managed host must sit outside both built-in hosts, which already
+/// classify to their forges.
+fn valid_selfmanaged_host(host: &str) -> bool {
     let lower = host.to_ascii_lowercase();
-    lower != "github.com" && valid_host_syntax(host)
+    lower != "github.com" && lower != "gitlab.com" && valid_host_syntax(host)
 }
 
 /// The bare ASCII DNS-name grammar shared by configured and selected canonical hosts.
@@ -636,6 +664,7 @@ mod tests {
         assert_eq!(config.toggle_direction(), ToggleDirection::Right);
         assert!(config.auto_open());
         assert_eq!(config.github_host(), None);
+        assert_eq!(config.gitlab_host(), None);
     }
 
     #[test]
@@ -652,6 +681,7 @@ mod tests {
                 "toggle_direction = \"down\"\n",
                 "auto_open = false\n",
                 "github_host = \"GitHub.Example.COM\"\n",
+                "gitlab_host = \"GitLab.Example.COM\"\n",
             ),
         )
         .unwrap();
@@ -665,6 +695,7 @@ mod tests {
         assert_eq!(config.toggle_direction(), ToggleDirection::Down);
         assert!(!config.auto_open());
         assert_eq!(config.github_host(), Some("github.example.com"));
+        assert_eq!(config.gitlab_host(), Some("gitlab.example.com"));
     }
 
     #[test]
@@ -716,6 +747,10 @@ mod tests {
             ("auto_open = \"yes\"\n", "`auto_open`"),
             ("github_host = \"https://github.example.com\"\n", "`github_host`"),
             ("github_host = \"github.com\"\n", "`github_host`"),
+            ("github_host = \"gitlab.com\"\n", "`github_host`"),
+            ("gitlab_host = \"https://gitlab.example.com\"\n", "`gitlab_host`"),
+            ("gitlab_host = \"gitlab.com\"\n", "`gitlab_host`"),
+            ("gitlab_host = \"github.com\"\n", "`gitlab_host`"),
         ];
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
@@ -734,6 +769,18 @@ mod tests {
             .unwrap();
         let config = super::plugin_config_in(dir.path()).expect("valid literal Enterprise host");
         assert_eq!(config.github_host(), Some("github.com-work"));
+    }
+
+    #[test]
+    fn one_host_cannot_serve_both_forges() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            "github_host = \"git.example.com\"\ngitlab_host = \"Git.Example.COM\"\n",
+        )
+        .unwrap();
+        let error = super::plugin_config_in(dir.path()).unwrap_err().to_string();
+        assert!(error.contains("`gitlab_host`") && error.contains("`github_host`"), "{error}");
     }
 
     #[test]
@@ -887,6 +934,7 @@ mod tests {
         assert_eq!(object["toggle_direction"], "right");
         assert_eq!(object["auto_open"], true);
         assert!(object["github_host"].is_null());
+        assert!(object["gitlab_host"].is_null());
         let keybindings = object["keybindings"].as_object().unwrap();
         assert_eq!(
             keybindings.len(),

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -1,9 +1,10 @@
-//! Read-only GitHub access: the pull request's identity, state, checks, and comments.
+//! Read-only forge access: the pull request's identity, state, checks, and comments.
 //!
 //! See `specs/forge-host.md`. A fetch first derives [`PrFetchInput`] from local Git and one
-//! validated config snapshot, then reads its canonical target through explicitly hosted `gh`
-//! GraphQL calls. It never posts, resolves, re-runs, merges, or otherwise writes to GitHub. The
-//! `PR` tab renders the [`PrSnapshot`] this module produces; degradation is in-band as [`PrView`].
+//! validated config snapshot, then reads its canonical target through explicitly hosted CLI
+//! calls — the GitHub queries live in [`github`]. It never posts, resolves, re-runs, merges,
+//! or otherwise writes to the forge. The `PR` tab renders the [`PrSnapshot`] this module
+//! produces; degradation is in-band as [`PrView`].
 
 use std::io::Read;
 use std::path::Path;
@@ -13,7 +14,7 @@ use std::thread;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde_json::Value;
+mod github;
 
 /// What the `PR` tab shows: the resolved snapshot, or a degraded state with its own remedy.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -71,7 +72,7 @@ impl PrView {
     }
 }
 
-/// One pull request's state, read fresh from GitHub each poll.
+/// One pull request's state, read fresh from the forge each poll.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrSnapshot {
     pub number: u64,
@@ -198,9 +199,24 @@ impl PrSnapshot {
     }
 }
 
-/// Run explicitly targeted `gh` arguments in `repo` and return stdout or a classified failure.
-fn gh(repo: &Path, host: &str, args: &[&str], cancelled: &AtomicBool) -> Result<String, GhError> {
-    let child = Command::new("gh")
+/// One forge-CLI subprocess failure, before backend-specific stderr classification.
+enum CliFailure {
+    /// The binary is not on `PATH`.
+    Missing,
+    /// A spawn or wait error, or a cancellation — never classified further.
+    Other(String),
+    /// A non-zero exit; the backend classifies the stderr wording.
+    Stderr(String),
+}
+
+/// Run `program` with `args` in `repo` and return stdout or an unclassified failure.
+fn run_cli(
+    program: &str,
+    repo: &Path,
+    args: &[&str],
+    cancelled: &AtomicBool,
+) -> Result<String, CliFailure> {
+    let child = Command::new(program)
         .current_dir(repo)
         .args(args)
         .stdout(Stdio::piped())
@@ -209,12 +225,12 @@ fn gh(repo: &Path, host: &str, args: &[&str], cancelled: &AtomicBool) -> Result<
     let mut child = match child {
         Ok(child) => child,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Err(GhError::NoGh);
+            return Err(CliFailure::Missing);
         }
-        Err(error) => return Err(GhError::Other(error.to_string())),
+        Err(error) => return Err(CliFailure::Other(error.to_string())),
     };
 
-    // Drain both pipes while polling so a large GraphQL response cannot fill a pipe and block
+    // Drain both pipes while polling so a large API response cannot fill a pipe and block
     // the child before it exits. A superseded config/fetch kills the process; the coordinator
     // keeps ownership until this worker reports completion, preserving one real fetch in flight.
     let mut stdout = child.stdout.take().expect("piped stdout");
@@ -241,33 +257,22 @@ fn gh(repo: &Path, host: &str, args: &[&str], cancelled: &AtomicBool) -> Result<
                 let _ = child.wait();
                 let _ = stdout_reader.join();
                 let _ = stderr_reader.join();
-                return Err(GhError::Other(error.to_string()));
+                return Err(CliFailure::Other(error.to_string()));
             }
         }
     };
     let stdout = stdout_reader.join().unwrap_or_default();
     let stderr = stderr_reader.join().unwrap_or_default();
     if cancelled.load(Ordering::Acquire) {
-        return Err(GhError::Other("request cancelled".to_string()));
+        return Err(CliFailure::Other("request cancelled".to_string()));
     }
     if status.success() {
         return Ok(String::from_utf8_lossy(&stdout).into_owned());
     }
-    Err(classify_failure(&String::from_utf8_lossy(&stderr), host))
+    Err(CliFailure::Stderr(String::from_utf8_lossy(&stderr).into_owned()))
 }
 
-/// Map a failed `gh`'s stderr to a degraded state by its wording — `gh` has no stable exit
-/// codes for these. An unrecognised failure is `Other` → a transient `Error` view.
-fn classify_failure(stderr: &str, host: &str) -> GhError {
-    let s = stderr.to_lowercase();
-    if s.contains("not logged") || s.contains("authentication") || s.contains("gh auth login") {
-        GhError::NotAuthed(host.to_owned())
-    } else {
-        GhError::Other(stderr.trim().to_string())
-    }
-}
-
-/// A classified `gh` failure, mapped to a [`PrView`] degraded state.
+/// A classified forge-CLI failure, mapped to a [`PrView`] degraded state.
 #[derive(Debug, PartialEq, Eq)]
 enum GhError {
     NoGh,
@@ -354,13 +359,13 @@ fn fetch_input_inner(
     Ok(PrFetchInput { repository, origin_repository, local })
 }
 
-/// Read GitHub for one already-derived input. Degradation stays in-band for the PR tab.
+/// Read the forge for one already-derived input. Degradation stays in-band for the PR tab.
 #[must_use]
 pub fn fetch(repo: &Path, input: &PrFetchInput) -> PrView {
     fetch_cancellable(repo, input, &AtomicBool::new(false))
 }
 
-/// Read GitHub with a cancellation signal owned by the event-loop coordinator.
+/// Read the forge with a cancellation signal owned by the event-loop coordinator.
 #[must_use]
 pub(crate) fn fetch_cancellable(
     repo: &Path,
@@ -412,8 +417,13 @@ fn fetch_inner(
     };
     let source = select_source(input.origin_repository.as_ref(), repository);
     let head = nominated_head(&input.local);
-    let assoc =
-        associate_points(&target, source, &input.local.points, &input.local.absorbed, head)?;
+    let assoc = github::associate_points(
+        &target,
+        source,
+        &input.local.points,
+        &input.local.absorbed,
+        head,
+    )?;
     let number = match pick_open(&assoc.open, input) {
         Pick::One(n) => n,
         Pick::Ambiguous(count) => {
@@ -426,7 +436,7 @@ fn fetch_inner(
             }
         },
     };
-    let detail = pr_detail(&target, number)?;
+    let detail = github::pr_detail(&target, number)?;
     let node = &detail["data"]["repository"]["pullRequest"];
     if node.is_null() {
         return Ok(PrView::NoPr);
@@ -441,7 +451,7 @@ fn fetch_inner(
         ),
         _ => Sync::Unknown,
     };
-    Ok(PrView::Pr(Box::new(build_snapshot(node, sync))))
+    Ok(PrView::Pr(Box::new(github::build_snapshot(node, sync))))
 }
 
 /// The local branch's position relative to the PR head, from `git`'s ahead/behind counts. A
@@ -504,173 +514,11 @@ fn nominated_head(local: &crate::git::PrLocalState) -> Option<&str> {
         .filter(|head| local.head_nominates && !local.points.iter().any(|point| point.oid == *head))
 }
 
-/// The closed-lookup aliases, one per `(point, tip name)` pair: `(alias, var, point index,
-/// name)`. Build, vars, and parse all enumerate through this one owner, so the alias ↔
-/// point pairing cannot drift between them. Capped at 8 pairs — a tip that many refs point
-/// at (post-release coincidences, mirror refs) must not balloon the query past API limits.
-fn closed_aliases(points: &[crate::git::PublicationPoint]) -> Vec<(String, String, usize, String)> {
-    points
-        .iter()
-        .enumerate()
-        .flat_map(|(i, point)| {
-            point
-                .names
-                .iter()
-                .enumerate()
-                .map(move |(j, name)| (format!("c{i}_{j}"), format!("b{i}_{j}"), i, name.clone()))
-        })
-        .take(8)
-        .collect()
-}
-
-/// Ask the forge which PRs contain each publication point, in one aliased call against the
-/// `source` repository, with the closed-unmerged name lookup against the target riding
-/// along (`specs/forge-host.md`). Only PRs based on the target repository count.
-fn associate_points(
-    target: &FetchTarget<'_>,
-    source: &crate::git::RepoTarget,
-    points: &[crate::git::PublicationPoint],
-    absorbed: &[String],
-    head: Option<&str>,
-) -> Result<Association, GhError> {
-    let closed = closed_aliases(points);
-    let query =
-        build_association_query(points.len() + absorbed.len() + head.iter().count(), &closed);
-    let mut vars = vec![
-        ("so".to_string(), source.owner().to_string()),
-        ("sn".to_string(), source.name().to_string()),
-        ("to".to_string(), target.owner.to_string()),
-        ("tn".to_string(), target.name.to_string()),
-    ];
-    for (i, oid) in points
-        .iter()
-        .map(|p| p.oid.as_str())
-        .chain(absorbed.iter().map(String::as_str))
-        .chain(head)
-        .enumerate()
-    {
-        vars.push((format!("p{i}"), oid.to_string()));
-    }
-    for (_, var, _, name) in &closed {
-        vars.push((var.clone(), name.clone()));
-    }
-    let v = graphql(target.repo, target.host, &query, &vars, target.cancelled)?;
-    Ok(parse_association(&v, points, absorbed, head, &closed))
-}
-
-/// The aliased association query: `p{i}: object(oid:$p{i})` per nominated OID — points,
-/// absorbed candidates, then the exact-identity `HEAD` — against the source repository,
-/// plus one closed-PR lookup per `(point, tip name)` pair against the target. The target block always carries `id` — the rename-proof base filter, and
-/// the reason the block is never an empty selection set. Values ride as variables, never
-/// in the query text.
-fn build_association_query(oids: usize, closed: &[(String, String, usize, String)]) -> String {
-    use std::fmt::Write;
-    let mut q = String::from("query($so:String!,$sn:String!,$to:String!,$tn:String!");
-    for i in 0..oids {
-        let _ = write!(q, ",$p{i}:GitObjectID!");
-    }
-    for (_, var, _, _) in closed {
-        let _ = write!(q, ",${var}:String!");
-    }
-    q.push_str("){src:repository(owner:$so,name:$sn){");
-    for i in 0..oids {
-        let _ = write!(
-            q,
-            "p{i}:object(oid:$p{i}){{... on Commit{{associatedPullRequests(first:100){{nodes{{\
-             number state headRefOid headRefName createdAt mergedAt \
-             baseRepository{{id}}}}}}}}}} "
-        );
-    }
-    q.push_str("} tgt:repository(owner:$to,name:$tn){id ");
-    for (alias, var, _, _) in closed {
-        let _ = write!(
-            q,
-            "{alias}:pullRequests(headRefName:${var}, states:[CLOSED], first:10, \
-             orderBy:{{field:CREATED_AT, direction:DESC}}){{nodes{{\
-             number headRefOid headRefName createdAt}}}} "
-        );
-    }
-    q.push_str("}}");
-    q
-}
-
 /// Push `pr` unless its number is already in `bucket` — a PR's identity is its number.
 fn push_unique(bucket: &mut Vec<AssocPr>, pr: AssocPr) {
     if !bucket.iter().any(|have| have.number == pr.number) {
         bucket.push(pr);
     }
-}
-
-/// Split the association response by lifecycle. Association nodes keep only PRs whose base
-/// repository `id` equals the target's — ids survive renames and transfers, names do not.
-/// Nodes from `absorbed` aliases are admitted only as a merged PR whose head is exactly an
-/// absorbed commit — the parked epilogue. Nodes from the `head` alias are admitted only
-/// when their head is exactly the pinned `HEAD` — the exact-identity epilogue. Closed
-/// nodes keep only an exact head match to their point — identity, never a name
-/// (`specs/forge-host.md`). Duplicates collapse.
-fn parse_association(
-    v: &Value,
-    points: &[crate::git::PublicationPoint],
-    absorbed: &[String],
-    head: Option<&str>,
-    closed: &[(String, String, usize, String)],
-) -> Association {
-    let mut assoc = Association::default();
-    let target_id = v["data"]["tgt"]["id"].as_str().unwrap_or_default();
-    let pr_of = |node: &Value| -> Option<AssocPr> {
-        Some(AssocPr {
-            number: node["number"].as_u64()?,
-            head_oid: node["headRefOid"].as_str().unwrap_or_default().to_string(),
-            head_ref: node["headRefName"].as_str().unwrap_or_default().to_string(),
-            merged_at: node["mergedAt"].as_str().unwrap_or_default().to_string(),
-            created_at: node["createdAt"].as_str().unwrap_or_default().to_string(),
-        })
-    };
-    for i in 0..points.len() + absorbed.len() + head.iter().count() {
-        let from_absorbed = i >= points.len() && i < points.len() + absorbed.len();
-        let from_head = i >= points.len() + absorbed.len();
-        let nodes = &v["data"]["src"][format!("p{i}").as_str()]["associatedPullRequests"]["nodes"];
-        for node in nodes.as_array().into_iter().flatten() {
-            let base = node["baseRepository"]["id"].as_str().unwrap_or_default();
-            if base.is_empty() || base != target_id {
-                continue;
-            }
-            let Some(pr) = pr_of(node) else { continue };
-            if from_absorbed {
-                // An absorbed commit is base history, which proves nothing by containment.
-                // Only the exact parked epilogue is admissible: a merged PR whose head is
-                // an absorbed commit itself.
-                let exact = absorbed.iter().any(|oid| oid == &pr.head_oid);
-                if exact && node["state"].as_str() == Some("MERGED") {
-                    push_unique(&mut assoc.merged, pr);
-                }
-                continue;
-            }
-            if from_head {
-                // The pinned HEAD is not published, so containment proves nothing. Only
-                // exact identity admits: the worktree is parked on the PR's own head.
-                if Some(pr.head_oid.as_str()) != head {
-                    continue;
-                }
-            }
-            match node["state"].as_str() {
-                Some("OPEN") => push_unique(&mut assoc.open, pr),
-                Some("MERGED") => push_unique(&mut assoc.merged, pr),
-                _ => {}
-            }
-        }
-    }
-    for (alias, _, i, _) in closed {
-        let nodes = &v["data"]["tgt"][alias.as_str()]["nodes"];
-        for node in nodes.as_array().into_iter().flatten() {
-            let Some(pr) = pr_of(node) else { continue };
-            if pr.head_oid != points[*i].oid {
-                continue;
-            }
-            push_unique(&mut assoc.closed, pr);
-        }
-    }
-    assoc
 }
 
 /// The winner among the open PRs (`specs/forge-host.md` "Resolution").
@@ -738,247 +586,6 @@ fn pick_closed(closed: &[AssocPr]) -> Option<u64> {
     newest_by(closed, |pr| &pr.created_at)
 }
 
-/// All of one PR's state in a single direct GraphQL call — identity, mergeability, checks,
-/// reviews, plain comments, and review threads. Each list surface reads its newest 100 rows
-/// (`last:100`, flagged by `hasPreviousPage`) — ample for any real PR in a review sidebar —
-/// and flags a fuller surface so the UI can mark it, rather than paging to exhaustion
-/// (`specs/forge-host.md`). Checks keep `first:100`/`hasNextPage`.
-fn pr_detail(target: &FetchTarget<'_>, number: u64) -> Result<Value, GhError> {
-    let q = build_detail_query(number);
-    let vars = vec![
-        ("o".to_string(), target.owner.to_string()),
-        ("n".to_string(), target.name.to_string()),
-    ];
-    graphql(target.repo, target.host, &q, &vars, target.cancelled)
-}
-
-/// Project one PR directly, including fork identity and capped check/comment surfaces.
-fn build_detail_query(number: u64) -> String {
-    format!(
-        "query($o:String!,$n:String!){{repository(owner:$o,name:$n){{\
-         pullRequest(number:{number}){{\
-         number title url body isDraft state mergeable mergeStateStatus baseRefName headRefName \
-         headRefOid isCrossRepository \
-         commits(last:1){{nodes{{commit{{statusCheckRollup{{contexts(first:100){{pageInfo{{hasNextPage}} nodes{{__typename \
-         ... on CheckRun{{name status conclusion}} ... on StatusContext{{context state}}}}}}}}}}}}}} \
-         reviews(last:100){{pageInfo{{hasPreviousPage}} nodes{{author{{login}} body submittedAt}}}} \
-         comments(last:100){{pageInfo{{hasPreviousPage}} nodes{{author{{login}} body createdAt}}}} \
-         reviewThreads(last:100){{pageInfo{{hasPreviousPage}} nodes{{isResolved isOutdated path line \
-         comments(first:1){{totalCount nodes{{author{{login}} body createdAt diffHunk}}}}}}}}}}}}}}"
-    )
-}
-
-/// Run a GraphQL `query` with `vars` and parse the response. Every variable is passed with
-/// `-f` (raw string) — `-F` type-coerces, so a branch literally named `123` would arrive
-/// as an Int and fail its `String!` declaration.
-fn graphql(
-    repo: &Path,
-    host: &str,
-    query: &str,
-    vars: &[(String, String)],
-    cancelled: &AtomicBool,
-) -> Result<Value, GhError> {
-    let args = graphql_args(host, query, vars);
-    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    let out = gh(repo, host, &arg_refs, cancelled)?;
-    serde_json::from_str(&out).map_err(|e| GhError::Other(e.to_string()))
-}
-
-fn graphql_args(host: &str, query: &str, vars: &[(String, String)]) -> Vec<String> {
-    let mut args: Vec<String> = vec![
-        "api".to_string(),
-        "graphql".to_string(),
-        "--hostname".to_string(),
-        host.to_owned(),
-        "-f".to_string(),
-        format!("query={query}"),
-    ];
-    for (key, value) in vars {
-        args.push("-f".to_string());
-        args.push(format!("{key}={value}"));
-    }
-    args
-}
-
-// ---- Pure normalization (unit-tested) --------------------------------------------------
-
-/// Assemble the snapshot from the `gh pr view` JSON, the computed `sync`, and the merged comments.
-fn build_snapshot(node: &Value, sync: Sync) -> PrSnapshot {
-    let contexts = &node["commits"]["nodes"][0]["commit"]["statusCheckRollup"]["contexts"];
-    let rollup = &contexts["nodes"];
-    // A surface whose page reports more in the direction it pages is a prefix, not the whole set.
-    // Each query asks only for its own flag — `hasPreviousPage` for the `last:` lists,
-    // `hasNextPage` for checks — so OR-ing both reads whichever applies; the absent one is false.
-    let more = |conn: &Value| {
-        conn["pageInfo"]["hasNextPage"].as_bool().unwrap_or(false)
-            || conn["pageInfo"]["hasPreviousPage"].as_bool().unwrap_or(false)
-    };
-    let truncated = more(contexts)
-        || more(&node["reviews"])
-        || more(&node["comments"])
-        || more(&node["reviewThreads"]);
-    PrSnapshot {
-        number: node["number"].as_u64().unwrap_or_default(),
-        title: node["title"].as_str().unwrap_or_default().to_string(),
-        url: node["url"].as_str().unwrap_or_default().to_string(),
-        body: node["body"].as_str().unwrap_or_default().to_string(),
-        state: parse_state(node["state"].as_str().unwrap_or("OPEN")),
-        is_draft: node["isDraft"].as_bool().unwrap_or(false),
-        head_ref: node["headRefName"].as_str().unwrap_or_default().to_string(),
-        head_is_fork: node["isCrossRepository"].as_bool().unwrap_or(false),
-        base_ref: node["baseRefName"].as_str().unwrap_or_default().to_string(),
-        merge: derive_merge(node["mergeable"].as_str(), node["mergeStateStatus"].as_str()),
-        sync,
-        checks: normalize_checks(rollup),
-        comments: merge_comments(
-            &node["reviews"]["nodes"],
-            &node["comments"]["nodes"],
-            &node["reviewThreads"]["nodes"],
-        ),
-        truncated,
-    }
-}
-
-fn parse_state(s: &str) -> PrState {
-    match s {
-        "MERGED" => PrState::Merged,
-        "CLOSED" => PrState::Closed,
-        _ => PrState::Open,
-    }
-}
-
-/// Fold GitHub's `mergeable` and `mergeStateStatus` into a [`Merge`]. Only the actionable
-/// blockers are surfaced: conflicts and a `blocked` required gate. Everything else — `clean`,
-/// `behind`, `unstable`, and still-`unknown` (computing) — folds into `Clean` (shows nothing).
-fn derive_merge(mergeable: Option<&str>, state: Option<&str>) -> Merge {
-    match (mergeable, state) {
-        (Some("CONFLICTING"), _) | (_, Some("DIRTY")) => Merge::Conflicting,
-        (_, Some("BLOCKED")) => Merge::Blocked,
-        _ => Merge::Clean,
-    }
-}
-
-/// The latest run per check name, normalised from check runs and commit statuses.
-fn normalize_checks(rollup: &Value) -> Vec<Check> {
-    let mut out: Vec<Check> = Vec::new();
-    for node in rollup.as_array().into_iter().flatten() {
-        let name =
-            node["name"].as_str().or_else(|| node["context"].as_str()).unwrap_or("").to_string();
-        if name.is_empty() {
-            continue;
-        }
-        let status = check_status(node);
-        // Latest wins: a later array entry for the same name (a re-run) replaces the earlier.
-        if let Some(slot) = out.iter_mut().find(|c| c.name == name) {
-            *slot = Check { name, status };
-        } else {
-            out.push(Check { name, status });
-        }
-    }
-    out
-}
-
-/// Normalise one check node — a check run (`status`/`conclusion`) or a commit status (`state`)
-/// — to a [`CheckStatus`].
-fn check_status(node: &Value) -> CheckStatus {
-    // Check runs carry `status`/`conclusion`; commit statuses carry `state`.
-    if let Some(state) = node["state"].as_str() {
-        return match state {
-            "SUCCESS" => CheckStatus::Success,
-            "FAILURE" | "ERROR" => CheckStatus::Failure,
-            _ => CheckStatus::Pending,
-        };
-    }
-    match node["status"].as_str() {
-        Some("COMPLETED") => match node["conclusion"].as_str() {
-            Some("SUCCESS") => CheckStatus::Success,
-            Some("SKIPPED" | "NEUTRAL") => CheckStatus::Skipped,
-            // FAILURE / TIMED_OUT / CANCELLED / ACTION_REQUIRED / a missing conclusion all read
-            // as a failed check — something needs attention.
-            _ => CheckStatus::Failure,
-        },
-        Some("IN_PROGRESS") => CheckStatus::Running,
-        _ => CheckStatus::Pending,
-    }
-}
-
-/// Merge the three comment surfaces (GraphQL `reviews`, `comments`, and `reviewThreads` node
-/// arrays) into one newest-first list, keeping only a bot's latest PR-level post and each human's.
-fn merge_comments(reviews: &Value, issues: &Value, threads: &Value) -> Vec<Comment> {
-    let mut out: Vec<Comment> = Vec::new();
-
-    // Submitted reviews with a non-empty body (the PR-level `review` cards).
-    for r in reviews.as_array().into_iter().flatten() {
-        let body = r["body"].as_str().unwrap_or("").trim().to_string();
-        if body.is_empty() {
-            continue;
-        }
-        out.push(prose_comment(CommentKind::Review, &r["author"], body, r["submittedAt"].as_str()));
-    }
-
-    // Plain conversation comments (the `comment` cards).
-    for c in issues.as_array().into_iter().flatten() {
-        let body = c["body"].as_str().unwrap_or("").trim().to_string();
-        if body.is_empty() {
-            continue;
-        }
-        out.push(prose_comment(CommentKind::Comment, &c["author"], body, c["createdAt"].as_str()));
-    }
-
-    // Inline review threads (the `finding` cards), with resolved/outdated and replies.
-    for t in threads.as_array().into_iter().flatten() {
-        let root = &t["comments"]["nodes"][0];
-        let login = root["author"]["login"].as_str().unwrap_or("").to_string();
-        let path = t["path"].as_str().unwrap_or("");
-        let anchor = match t["line"].as_u64() {
-            Some(line) => format!("{path}:{line}"),
-            None => path.to_string(),
-        };
-        out.push(Comment {
-            kind: CommentKind::Finding,
-            author_is_bot: is_bot(&login),
-            author: login,
-            anchor,
-            body: root["body"].as_str().unwrap_or("").trim().to_string(),
-            snippet: root["diffHunk"].as_str().filter(|h| !h.is_empty()).map(str::to_string),
-            created_at: root["createdAt"].as_str().unwrap_or("").to_string(),
-            is_resolved: t["isResolved"].as_bool().unwrap_or(false),
-            is_outdated: t["isOutdated"].as_bool().unwrap_or(false),
-            reply_count: t["comments"]["totalCount"].as_u64().unwrap_or(1).saturating_sub(1) as u32,
-        });
-    }
-
-    dedup_bot_prose(&mut out);
-    // Newest first: ISO-8601 `…Z` strings sort lexically in chronological order.
-    out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-    out
-}
-
-fn prose_comment(
-    kind: CommentKind,
-    user: &Value,
-    body: String,
-    created_at: Option<&str>,
-) -> Comment {
-    let login = user["login"].as_str().unwrap_or("").to_string();
-    let anchor = match kind {
-        CommentKind::Review => "review",
-        _ => "comment",
-    };
-    Comment {
-        kind,
-        author_is_bot: is_bot(&login),
-        author: login,
-        anchor: anchor.to_string(),
-        body,
-        snippet: None,
-        created_at: created_at.unwrap_or("").to_string(),
-        is_resolved: false,
-        is_outdated: false,
-        reply_count: 0,
-    }
-}
-
 /// Keep only the latest PR-level (`review`/`comment`) post per bot author; humans keep all.
 fn dedup_bot_prose(out: &mut Vec<Comment>) {
     let mut keep_newest: std::collections::HashMap<String, String> =
@@ -995,11 +602,6 @@ fn dedup_bot_prose(out: &mut Vec<Comment>) {
         !(c.author_is_bot && c.kind != CommentKind::Finding)
             || keep_newest.get(&c.author) == Some(&c.created_at)
     });
-}
-
-/// Whether a GitHub login is an app/bot (`…[bot]`).
-fn is_bot(login: &str) -> bool {
-    login.ends_with("[bot]")
 }
 
 /// A relative age label (`5m`, `2h`, `3d`, `2w`) from an ISO-8601 `…Z` timestamp, against `now`.
@@ -1051,131 +653,6 @@ fn parse_iso(s: &str) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn merge_surfaces_only_conflicts_and_blocked() {
-        assert_eq!(derive_merge(Some("CONFLICTING"), Some("DIRTY")), Merge::Conflicting);
-        assert_eq!(derive_merge(Some("MERGEABLE"), Some("BLOCKED")), Merge::Blocked);
-        // Everything non-actionable folds into Clean: clean, behind, unstable, still-computing.
-        assert_eq!(derive_merge(Some("MERGEABLE"), Some("CLEAN")), Merge::Clean);
-        assert_eq!(derive_merge(Some("MERGEABLE"), Some("BEHIND")), Merge::Clean);
-        assert_eq!(derive_merge(Some("MERGEABLE"), Some("UNSTABLE")), Merge::Clean);
-        assert_eq!(derive_merge(Some("UNKNOWN"), Some("UNKNOWN")), Merge::Clean);
-        // DIRTY means conflicts even while mergeability is still UNKNOWN or the field is missing.
-        assert_eq!(derive_merge(Some("UNKNOWN"), Some("DIRTY")), Merge::Conflicting);
-        assert_eq!(derive_merge(None, Some("DIRTY")), Merge::Conflicting);
-        assert_eq!(derive_merge(None, None), Merge::Clean);
-    }
-
-    #[test]
-    fn parse_state_maps_the_three_github_lifecycles() {
-        assert_eq!(parse_state("MERGED"), PrState::Merged);
-        assert_eq!(parse_state("CLOSED"), PrState::Closed);
-        assert_eq!(parse_state("OPEN"), PrState::Open);
-        assert_eq!(parse_state("anything-else"), PrState::Open); // default is the live case
-    }
-
-    #[test]
-    fn truncated_flips_when_any_capped_surface_has_a_next_page() {
-        let base = serde_json::json!({
-            "number": 1, "title": "t", "url": "u", "state": "OPEN", "isDraft": false,
-            "baseRefName": "main", "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
-            "commits": {"nodes": [{"commit": {"statusCheckRollup":
-                {"contexts": {"pageInfo": {"hasNextPage": false}, "nodes": []}}}}]},
-            "reviews": {"pageInfo": {"hasNextPage": false}, "nodes": []},
-            "comments": {"pageInfo": {"hasNextPage": false}, "nodes": []},
-            "reviewThreads": {"pageInfo": {"hasNextPage": false}, "nodes": []}
-        });
-        assert!(
-            !build_snapshot(&base, Sync::InSync).truncated,
-            "all pages complete → not truncated"
-        );
-        // The description parses when present and stays empty when GitHub returns null.
-        assert_eq!(build_snapshot(&base, Sync::InSync).body, "");
-        let mut with_body = base.clone();
-        with_body["body"] = serde_json::json!("## Summary\nfixes things");
-        assert_eq!(build_snapshot(&with_body, Sync::InSync).body, "## Summary\nfixes things");
-
-        // Comments and threads read `last:100`, so their "more exist" flag pages backward.
-        let mut comments_more = base.clone();
-        comments_more["comments"]["pageInfo"]["hasPreviousPage"] = serde_json::json!(true);
-        assert!(build_snapshot(&comments_more, Sync::InSync).truncated);
-
-        let mut threads_more = base.clone();
-        threads_more["reviewThreads"]["pageInfo"]["hasPreviousPage"] = serde_json::json!(true);
-        assert!(build_snapshot(&threads_more, Sync::InSync).truncated);
-
-        let mut checks_more = base.clone();
-        checks_more["commits"]["nodes"][0]["commit"]["statusCheckRollup"]["contexts"]["pageInfo"]
-            ["hasNextPage"] = serde_json::json!(true);
-        assert!(build_snapshot(&checks_more, Sync::InSync).truncated);
-
-        // `reviews` pages backward (last:100), so its "more exist" flag is `hasPreviousPage` —
-        // checking `hasNextPage` here (the old bug) would leave this surface never marked.
-        let mut reviews_more = base.clone();
-        reviews_more["reviews"]["pageInfo"]["hasPreviousPage"] = serde_json::json!(true);
-        assert!(build_snapshot(&reviews_more, Sync::InSync).truncated);
-    }
-
-    #[test]
-    fn checks_take_the_latest_run_per_name() {
-        let rollup = serde_json::json!([
-            {"__typename": "CheckRun", "name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"},
-            {"__typename": "CheckRun", "name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"},
-            {"__typename": "CheckRun", "name": "build", "status": "IN_PROGRESS"},
-            {"__typename": "CheckRun", "name": "lint", "status": "COMPLETED", "conclusion": "SKIPPED"},
-            {"__typename": "CheckRun", "name": "codeql", "status": "COMPLETED", "conclusion": "NEUTRAL"},
-            {"__typename": "StatusContext", "context": "deploy", "state": "PENDING"}
-        ]);
-        let checks = normalize_checks(&rollup);
-        assert_eq!(checks.len(), 5);
-        let tests = checks.iter().find(|c| c.name == "tests").unwrap();
-        assert_eq!(tests.status, CheckStatus::Success); // the re-run won
-        assert_eq!(checks.iter().find(|c| c.name == "build").unwrap().status, CheckStatus::Running);
-        // SKIPPED and NEUTRAL both fold to Skipped — neither fails nor blocks the rollup.
-        assert_eq!(checks.iter().find(|c| c.name == "lint").unwrap().status, CheckStatus::Skipped);
-        assert_eq!(
-            checks.iter().find(|c| c.name == "codeql").unwrap().status,
-            CheckStatus::Skipped
-        );
-        assert_eq!(
-            checks.iter().find(|c| c.name == "deploy").unwrap().status,
-            CheckStatus::Pending
-        );
-    }
-
-    #[test]
-    fn rollup_fails_on_any_failure_else_running_else_success() {
-        let snap = |statuses: &[CheckStatus]| PrSnapshot {
-            number: 1,
-            title: String::new(),
-            url: String::new(),
-            body: String::new(),
-            state: PrState::Open,
-            is_draft: false,
-            head_ref: String::new(),
-            head_is_fork: false,
-            base_ref: String::new(),
-            merge: Merge::Clean,
-            sync: Sync::InSync,
-            checks: statuses.iter().map(|&s| Check { name: "c".into(), status: s }).collect(),
-            comments: Vec::new(),
-            truncated: false,
-        };
-        assert_eq!(snap(&[]).checks_rollup(), None);
-        assert_eq!(
-            snap(&[CheckStatus::Success, CheckStatus::Success]).checks_rollup(),
-            Some(CheckStatus::Success)
-        );
-        assert_eq!(
-            snap(&[CheckStatus::Success, CheckStatus::Running]).checks_rollup(),
-            Some(CheckStatus::Running)
-        );
-        assert_eq!(
-            snap(&[CheckStatus::Running, CheckStatus::Failure]).checks_rollup(),
-            Some(CheckStatus::Failure)
-        );
-    }
 
     fn point(oid: &str, names: &[&str]) -> crate::git::PublicationPoint {
         crate::git::PublicationPoint {
@@ -1241,79 +718,6 @@ mod tests {
     }
 
     #[test]
-    fn absorbed_aliases_admit_only_an_exact_head_merged_pr() {
-        // The parked epilogue: the worktree sits on base history, so containment proves
-        // nothing — only a merged PR whose head IS the absorbed commit resolves.
-        let v = serde_json::json!({"data": {
-            "src": {
-                "p0": {"associatedPullRequests": {"nodes": [
-                    {"number": 82, "state": "MERGED", "headRefOid": "parked", "headRefName": "fix",
-                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": "2026-07-02T00:00:00Z",
-                     "baseRepository": {"id": "R1"}},
-                    {"number": 90, "state": "MERGED", "headRefOid": "other", "headRefName": "else",
-                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": "2026-07-03T00:00:00Z",
-                     "baseRepository": {"id": "R1"}},
-                    {"number": 91, "state": "OPEN", "headRefOid": "parked", "headRefName": "fix",
-                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": null,
-                     "baseRepository": {"id": "R1"}}
-                ]}}
-            },
-            "tgt": {"id": "R1"}
-        }});
-        let absorbed = vec!["parked".to_string()];
-        let a = parse_association(&v, &[], &absorbed, None, &[]);
-        // #90 contains the commit but its head is a stranger's; #91 is open — neither admits.
-        assert_eq!(a.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [82]);
-        assert!(a.open.is_empty());
-    }
-
-    fn assoc_node(number: u64, state: &str, head: &str) -> serde_json::Value {
-        serde_json::json!({"number": number, "state": state, "headRefOid": head,
-            "headRefName": "feat", "createdAt": "2026-07-01T00:00:00Z",
-            "mergedAt": null, "baseRepository": {"id": "R1"}})
-    }
-
-    #[test]
-    fn head_alias_admits_only_exact_head_matches_open_or_merged() {
-        // The exact-identity epilogue: the pinned HEAD nominates, so a PR whose head IS
-        // that commit admits — open or merged. A PR that merely contains it does not,
-        // and closed-unmerged PRs never associate on the forge at all.
-        let v = serde_json::json!({"data": {
-            "src": {"p0": {"associatedPullRequests": {"nodes": [
-                assoc_node(10, "MERGED", "tip"),
-                assoc_node(11, "OPEN", "tip"),
-                assoc_node(12, "CLOSED", "tip"),
-                assoc_node(13, "MERGED", "other"),
-                assoc_node(14, "OPEN", "other")
-            ]}}},
-            "tgt": {"id": "R1"}
-        }});
-        let a = parse_association(&v, &[], &[], Some("tip"), &[]);
-        assert_eq!(a.open.iter().map(|p| p.number).collect::<Vec<_>>(), [11]);
-        assert_eq!(a.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [10]);
-        assert!(a.closed.is_empty(), "the exact-identity path never fills closed");
-    }
-
-    #[test]
-    fn alias_index_classes_stay_aligned_with_all_three_sources_present() {
-        // One point, one absorbed candidate, and the head alias in one response: each
-        // index must land in its own admission class, not a neighbor's.
-        let v = serde_json::json!({"data": {
-            "src": {
-                "p0": {"associatedPullRequests": {"nodes": [assoc_node(20, "OPEN", "elsewhere")]}},
-                "p1": {"associatedPullRequests": {"nodes": [assoc_node(21, "MERGED", "parked")]}},
-                "p2": {"associatedPullRequests": {"nodes": [assoc_node(22, "MERGED", "tip")]}}
-            },
-            "tgt": {"id": "R1"}
-        }});
-        let points = vec![point("published", &[])];
-        let absorbed = vec!["parked".to_string()];
-        let a = parse_association(&v, &points, &absorbed, Some("tip"), &[]);
-        assert_eq!(a.open.iter().map(|p| p.number).collect::<Vec<_>>(), [20], "containment");
-        assert_eq!(a.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [21, 22], "exact");
-    }
-
-    #[test]
     fn the_head_nominates_only_when_flagged_and_not_already_a_point() {
         // The gate and the alias both route through this one filter, so a regression
         // that drops the nomination re-tightens the NoPr gate and fails here.
@@ -1323,75 +727,6 @@ mod tests {
         assert_eq!(nominated_head(&local), Some("tip"), "a flagged HEAD nominates alone");
         local.points = vec![point("tip", &["feat"])];
         assert_eq!(nominated_head(&local), None, "a point already carries the OID");
-    }
-
-    #[test]
-    fn association_query_aliases_points_and_closed_names_and_never_inlines_values() {
-        let points = vec![point("aaa", &[]), point("bbb", &["feat", "backup"])];
-        let closed = closed_aliases(&points);
-        assert_eq!(
-            closed
-                .iter()
-                .map(|(alias, var, i, name)| (alias.as_str(), var.as_str(), *i, name.as_str()))
-                .collect::<Vec<_>>(),
-            [("c1_0", "b1_0", 1, "feat"), ("c1_1", "b1_1", 1, "backup")]
-        );
-        let q = build_association_query(points.len(), &closed);
-        assert!(q.starts_with(
-            "query($so:String!,$sn:String!,$to:String!,$tn:String!,\
-             $p0:GitObjectID!,$p1:GitObjectID!,$b1_0:String!,$b1_1:String!)"
-        ));
-        assert!(q.contains("src:repository(owner:$so,name:$sn){p0:object(oid:$p0)"));
-        assert!(q.contains("associatedPullRequests(first:100)"));
-        assert!(q.contains("baseRepository{id}"));
-        assert!(q.contains("tgt:repository(owner:$to,name:$tn){id "));
-        assert!(q.contains("c1_0:pullRequests(headRefName:$b1_0, states:[CLOSED]"));
-        assert!(q.contains("c1_1:pullRequests(headRefName:$b1_1, states:[CLOSED]"));
-        // With no named point, the target block still carries `id` — never an empty
-        // selection set, which GitHub rejects as a parse error.
-        let bare = vec![point("aaa", &[])];
-        let q = build_association_query(bare.len(), &closed_aliases(&bare));
-        assert!(q.contains("tgt:repository(owner:$to,name:$tn){id }"));
-    }
-
-    #[test]
-    fn parse_association_splits_lifecycles_filters_by_repo_id_and_dedups() {
-        let v = serde_json::json!({"data": {
-            "src": {
-                "p0": {"associatedPullRequests": {"nodes": [
-                    {"number": 7, "state": "OPEN", "headRefOid": "abc", "headRefName": "feat-x",
-                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": null,
-                     "baseRepository": {"id": "R1"}},
-                    {"number": 8, "state": "MERGED", "headRefOid": "def", "headRefName": "feat-y",
-                     "createdAt": "2026-06-01T00:00:00Z", "mergedAt": "2026-06-02T00:00:00Z",
-                     "baseRepository": {"id": "R1"}},
-                    {"number": 9, "state": "OPEN", "headRefOid": "zzz", "headRefName": "other",
-                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": null,
-                     "baseRepository": {"id": "R-other"}}
-                ]}},
-                "p1": {"associatedPullRequests": {"nodes": [
-                    {"number": 7, "state": "OPEN", "headRefOid": "abc", "headRefName": "feat-x",
-                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": null,
-                     "baseRepository": {"id": "R1"}}
-                ]}}
-            },
-            "tgt": {
-                "id": "R1",
-                "c1_0": {"nodes": [
-                    {"number": 5, "headRefOid": "p1oid", "headRefName": "old-name",
-                     "createdAt": "2026-05-01T00:00:00Z"},
-                    {"number": 6, "headRefOid": "impostor", "headRefName": "old-name",
-                     "createdAt": "2026-05-02T00:00:00Z"}
-                ]}
-            }
-        }});
-        let points = vec![point("p0oid", &[]), point("p1oid", &["old-name"])];
-        let a = parse_association(&v, &points, &[], None, &closed_aliases(&points));
-        // Open #7 appears under both points but lands once; #9 based elsewhere is dropped.
-        assert_eq!(a.open.iter().map(|p| p.number).collect::<Vec<_>>(), [7]);
-        assert_eq!(a.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [8]);
-        // The closed lookup admits only an exact head match to the point.
-        assert_eq!(a.closed.iter().map(|p| p.number).collect::<Vec<_>>(), [5]);
     }
 
     #[test]
@@ -1449,88 +784,53 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_carries_the_head_ref_and_fork_marker() {
-        let node = serde_json::json!({
-            "number": 5, "title": "t", "url": "u", "state": "OPEN", "isDraft": false,
-            "headRefName": "persiyanov/feature", "isCrossRepository": true, "baseRefName": "main",
-            "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
-            "commits": {"nodes": []}, "reviews": {"nodes": []},
-            "comments": {"nodes": []}, "reviewThreads": {"nodes": []}
-        });
-        let s = build_snapshot(&node, Sync::InSync);
-        assert_eq!(s.head_ref, "persiyanov/feature");
-        assert!(s.head_is_fork);
-        // Absent fields default rather than fail — a mid-rollout API response degrades soft.
-        let bare = serde_json::json!({"number": 5});
-        let s = build_snapshot(&bare, Sync::InSync);
-        assert_eq!(s.head_ref, "");
-        assert!(!s.head_is_fork);
-    }
-
-    #[test]
-    fn comments_merge_three_surfaces_newest_first() {
-        let reviews = serde_json::json!([
-            {"author": {"login": "codex[bot]"}, "state": "COMMENTED", "body": "Codex review.", "submittedAt": "2026-06-27T10:00:00Z"}
-        ]);
-        let issues = serde_json::json!([
-            {"author": {"login": "persijano"}, "body": "watch the 404s", "createdAt": "2026-06-27T12:00:00Z"}
-        ]);
-        let threads = serde_json::json!([
-            {"isResolved": false, "isOutdated": true, "path": "a.py", "line": null,
-             "comments": {"totalCount": 2, "nodes": [{"author": {"login": "claude[bot]"}, "body": "SSRF", "createdAt": "2026-06-27T11:00:00Z"}]}}
-        ]);
-        let cs = merge_comments(&reviews, &issues, &threads);
-        assert_eq!(cs.len(), 3);
-        // Newest first across all three surfaces — pin the full order so a reversed or
-        // unstable comparator fails rather than passing on the endpoints alone.
+    fn rollup_fails_on_any_failure_else_running_else_success() {
+        let snap = |statuses: &[CheckStatus]| PrSnapshot {
+            number: 1,
+            title: String::new(),
+            url: String::new(),
+            body: String::new(),
+            state: PrState::Open,
+            is_draft: false,
+            head_ref: String::new(),
+            head_is_fork: false,
+            base_ref: String::new(),
+            merge: Merge::Clean,
+            sync: Sync::InSync,
+            checks: statuses.iter().map(|&s| Check { name: "c".into(), status: s }).collect(),
+            comments: Vec::new(),
+            truncated: false,
+        };
+        assert_eq!(snap(&[]).checks_rollup(), None);
         assert_eq!(
-            cs.iter().map(|c| c.created_at.as_str()).collect::<Vec<_>>(),
-            ["2026-06-27T12:00:00Z", "2026-06-27T11:00:00Z", "2026-06-27T10:00:00Z"]
+            snap(&[CheckStatus::Success, CheckStatus::Success]).checks_rollup(),
+            Some(CheckStatus::Success)
         );
-        assert_eq!(cs[0].author, "persijano");
-        assert_eq!(cs[0].kind, CommentKind::Comment);
-        assert!(!cs[0].author_is_bot);
-        assert_eq!(cs[1].kind, CommentKind::Finding);
-        assert_eq!(cs[2].kind, CommentKind::Review);
-        // The finding carries its thread state, an unanchored line, and one reply.
-        let f = cs.iter().find(|c| c.kind == CommentKind::Finding).unwrap();
-        assert_eq!(f.anchor, "a.py");
-        assert!(f.is_outdated);
-        assert_eq!(f.reply_count, 1);
+        assert_eq!(
+            snap(&[CheckStatus::Success, CheckStatus::Running]).checks_rollup(),
+            Some(CheckStatus::Running)
+        );
+        assert_eq!(
+            snap(&[CheckStatus::Running, CheckStatus::Failure]).checks_rollup(),
+            Some(CheckStatus::Failure)
+        );
     }
 
     #[test]
-    fn a_bots_prose_collapses_to_its_latest_a_humans_is_kept() {
-        let reviews = serde_json::json!([
-            {"author": {"login": "claude[bot]"}, "body": "old review", "submittedAt": "2026-06-27T09:00:00Z"},
-            {"author": {"login": "claude[bot]"}, "body": "new review", "submittedAt": "2026-06-27T10:00:00Z"},
-            {"author": {"login": "persijano"}, "body": "note one", "submittedAt": "2026-06-27T09:30:00Z"},
-            {"author": {"login": "persijano"}, "body": "note two", "submittedAt": "2026-06-27T09:45:00Z"}
-        ]);
-        let cs = merge_comments(&reviews, &serde_json::json!([]), &serde_json::json!([]));
-        let claude: Vec<_> = cs.iter().filter(|c| c.author == "claude[bot]").collect();
-        assert_eq!(claude.len(), 1); // only the latest bot review
-        assert_eq!(claude[0].body, "new review");
-        assert_eq!(cs.iter().filter(|c| c.author == "persijano").count(), 2); // both human notes
+    fn sync_leads_with_unpushed_and_tolerates_a_missing_head() {
+        assert_eq!(derive_sync(None), Sync::Unknown);
+        assert_eq!(derive_sync(Some((0, 0))), Sync::InSync);
+        assert_eq!(derive_sync(Some((2, 0))), Sync::Unpushed(2));
+        assert_eq!(derive_sync(Some((0, 3))), Sync::Behind(3));
+        assert_eq!(derive_sync(Some((2, 3))), Sync::Unpushed(2)); // diverged → unpushed leads
     }
 
     #[test]
-    fn a_bots_findings_are_each_kept_even_as_its_prose_collapses() {
-        // Inline findings anchor to distinct lines, so — unlike a bot's PR-level prose — they
-        // are never collapsed: two findings from the same bot both survive, the prose folds to one.
-        let reviews = serde_json::json!([
-            {"author": {"login": "claude[bot]"}, "body": "old prose", "submittedAt": "2026-06-27T09:00:00Z"},
-            {"author": {"login": "claude[bot]"}, "body": "new prose", "submittedAt": "2026-06-27T09:30:00Z"}
-        ]);
-        let threads = serde_json::json!([
-            {"isResolved": false, "isOutdated": false, "path": "a.py", "line": 10,
-             "comments": {"totalCount": 1, "nodes": [{"author": {"login": "claude[bot]"}, "body": "finding one", "createdAt": "2026-06-27T10:00:00Z"}]}},
-            {"isResolved": false, "isOutdated": false, "path": "b.py", "line": 20,
-             "comments": {"totalCount": 1, "nodes": [{"author": {"login": "claude[bot]"}, "body": "finding two", "createdAt": "2026-06-27T11:00:00Z"}]}}
-        ]);
-        let cs = merge_comments(&reviews, &serde_json::json!([]), &threads);
-        assert_eq!(cs.iter().filter(|c| c.kind == CommentKind::Finding).count(), 2);
-        assert_eq!(cs.iter().filter(|c| c.kind == CommentKind::Review).count(), 1); // prose collapsed
+    fn local_git_failures_degrade_to_the_git_error_view() {
+        assert_eq!(
+            PrView::from(GhError::LocalGit("rev-list failed".into())),
+            PrView::GitError("rev-list failed".into())
+        );
     }
 
     #[test]
@@ -1552,45 +852,5 @@ mod tests {
         assert_eq!(parse_iso("1970-01-01T00:00:00Z"), Some(0));
         assert_eq!(parse_iso("2000-02-29T00:00:00Z"), Some(951_782_400)); // a leap-day boundary
         assert_eq!(parse_iso("not-a-date"), None);
-    }
-
-    #[test]
-    fn sync_leads_with_unpushed_and_tolerates_a_missing_head() {
-        assert_eq!(derive_sync(None), Sync::Unknown);
-        assert_eq!(derive_sync(Some((0, 0))), Sync::InSync);
-        assert_eq!(derive_sync(Some((2, 0))), Sync::Unpushed(2));
-        assert_eq!(derive_sync(Some((0, 3))), Sync::Behind(3));
-        assert_eq!(derive_sync(Some((2, 3))), Sync::Unpushed(2)); // diverged → unpushed leads
-    }
-
-    #[test]
-    fn gh_failure_classifies_by_stderr_wording() {
-        assert_eq!(
-            classify_failure("gh auth login required", "github.example.com"),
-            GhError::NotAuthed("github.example.com".to_string())
-        );
-        assert_eq!(
-            classify_failure("You are not logged into any GitHub hosts", "github.com"),
-            GhError::NotAuthed("github.com".to_string())
-        );
-        assert_eq!(
-            classify_failure("HTTP 500 something", "github.com"),
-            GhError::Other("HTTP 500 something".into())
-        );
-        assert_eq!(
-            PrView::from(GhError::LocalGit("rev-list failed".into())),
-            PrView::GitError("rev-list failed".into())
-        );
-    }
-
-    #[test]
-    fn graphql_arguments_always_pin_the_canonical_host() {
-        let args = graphql_args(
-            "github.example.com",
-            "query($o:String!){viewer{login}}",
-            &[("o".to_string(), "owner".to_string())],
-        );
-        assert_eq!(&args[..4], ["api", "graphql", "--hostname", "github.example.com"]);
-        assert!(args.windows(2).any(|pair| pair == ["-f", "o=owner"]));
     }
 }

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 mod github;
+mod gitlab;
 
 /// What the `PR` tab shows: the resolved snapshot, or a degraded state with its own remedy.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -30,21 +31,21 @@ pub enum PrView {
     /// `HEAD` is detached, so there is no branch identity to query.
     Detached,
     /// Two or more open PRs contain the published work and no tiebreak decides; the
-    /// count, so the user knows to pick on GitHub.
+    /// count, so the user knows to pick on the forge.
     Ambiguous(usize),
-    /// `gh` is not on `PATH`.
-    NoGh,
-    /// `gh` is installed but not authenticated for this canonical host.
-    NotAuthed(String),
+    /// The target forge's CLI (`gh`/`glab`) is not on `PATH`.
+    NoCli(crate::git::Forge),
+    /// The forge CLI is installed but not authenticated for this canonical host.
+    NotAuthed(crate::git::Forge, String),
     /// Neither `upstream` nor `origin` names a supported hosted Git repository.
-    NeedsGitHubRemote,
-    /// The fallback `origin` names a hosted forge outside the supported GitHub hosts.
+    NeedsForgeRemote,
+    /// The fallback `origin` names a hosted forge outside the supported hosts.
     UnsupportedHost(String),
     /// The fallback `origin` names a supported host but not an owner/repository path.
     MalformedOrigin(String),
-    /// A local Git read failed before the GitHub fetch could start.
+    /// A local Git read failed before the forge fetch could start.
     GitError(String),
-    /// Any other `gh` failure (rate limit, offline, …); the app freezes the last good view.
+    /// Any other forge-CLI failure (rate limit, offline, …); the app freezes the last good view.
     Error(String),
 }
 
@@ -55,17 +56,20 @@ impl PrView {
     /// active `refresh` binding's hint key, so the advertised retry key follows a rebind.
     pub fn retry_remedy(&self, refresh: crate::keymap::Key) -> Option<String> {
         match self {
-            Self::NoGh => {
-                Some(format!("GitHub CLI not found. Install `gh`, then press {refresh}."))
-            }
-            Self::NotAuthed(host) => Some(format!(
-                "Not signed in to {host}. Run `gh auth login --hostname {host}`, then press {refresh}."
+            Self::NoCli(forge) => Some(format!(
+                "{} CLI not found. Install `{}`, then press {refresh}.",
+                forge.name(),
+                forge.cli()
+            )),
+            Self::NotAuthed(forge, host) => Some(format!(
+                "Not signed in to {host}. Run `{} auth login --hostname {host}`, then press {refresh}.",
+                forge.cli()
             )),
             Self::GitError(message) => {
                 Some(format!("Git read failed: {message}. Press {refresh} to retry."))
             }
             Self::Error(message) => {
-                Some(format!("GitHub unavailable: {message}. Press {refresh} to retry."))
+                Some(format!("Forge unavailable: {message}. Press {refresh} to retry."))
             }
             _ => None,
         }
@@ -274,20 +278,20 @@ fn run_cli(
 
 /// A classified forge-CLI failure, mapped to a [`PrView`] degraded state.
 #[derive(Debug, PartialEq, Eq)]
-enum GhError {
-    NoGh,
-    NotAuthed(String),
+enum CliError {
+    Missing(crate::git::Forge),
+    NotAuthed(crate::git::Forge, String),
     LocalGit(String),
     Other(String),
 }
 
-impl From<GhError> for PrView {
-    fn from(e: GhError) -> Self {
+impl From<CliError> for PrView {
+    fn from(e: CliError) -> Self {
         match e {
-            GhError::NoGh => PrView::NoGh,
-            GhError::NotAuthed(host) => PrView::NotAuthed(host),
-            GhError::LocalGit(message) => PrView::GitError(message),
-            GhError::Other(m) => PrView::Error(m),
+            CliError::Missing(forge) => PrView::NoCli(forge),
+            CliError::NotAuthed(forge, host) => PrView::NotAuthed(forge, host),
+            CliError::LocalGit(message) => PrView::GitError(message),
+            CliError::Other(m) => PrView::Error(m),
         }
     }
 }
@@ -328,7 +332,7 @@ fn fetch_input_inner(
     config: &crate::config::PluginConfig,
     verify_repository: bool,
 ) -> Result<PrFetchInput, PrInputError> {
-    let (repository, origin_repository) = crate::git::remote_identities(repo, config.github_host())
+    let (repository, origin_repository) = crate::git::remote_identities(repo, config.forge_hosts())
         .map_err(|error| PrInputError::TargetRead(error.0))?;
     let crate::git::RepositoryIdentity::Repository(target) = &repository else {
         return Ok(PrFetchInput {
@@ -340,7 +344,7 @@ fn fetch_input_inner(
     let local = match crate::git::pr_local(repo, base, config.base_branches()) {
         Ok(local) => local,
         Err(error) => {
-            let (current, _) = crate::git::remote_identities(repo, config.github_host())
+            let (current, _) = crate::git::remote_identities(repo, config.forge_hosts())
                 .map_err(|read_error| PrInputError::TargetRead(read_error.0))?;
             if current != repository {
                 return Err(PrInputError::TargetRead(
@@ -351,7 +355,7 @@ fn fetch_input_inner(
         }
     };
     let (repository, origin_repository) = if verify_repository {
-        crate::git::remote_identities(repo, config.github_host())
+        crate::git::remote_identities(repo, config.forge_hosts())
             .map_err(|error| PrInputError::TargetRead(error.0))?
     } else {
         (repository, origin_repository)
@@ -382,11 +386,11 @@ fn fetch_inner(
     repo: &Path,
     input: &PrFetchInput,
     cancelled: &AtomicBool,
-) -> Result<PrView, GhError> {
+) -> Result<PrView, CliError> {
     let repository = match &input.repository {
         crate::git::RepositoryIdentity::Repository(target) => target,
         crate::git::RepositoryIdentity::Missing | crate::git::RepositoryIdentity::Hostless => {
-            return Ok(PrView::NeedsGitHubRemote);
+            return Ok(PrView::NeedsForgeRemote);
         }
         crate::git::RepositoryIdentity::Unsupported(host) => {
             return Ok(PrView::UnsupportedHost(host.clone()));
@@ -408,6 +412,7 @@ fn fetch_inner(
         // (`specs/forge-host.md`).
         return Ok(PrView::NoPr);
     }
+    let forge = repository.forge();
     let target = FetchTarget {
         repo,
         host: repository.host(),
@@ -417,13 +422,22 @@ fn fetch_inner(
     };
     let source = select_source(input.origin_repository.as_ref(), repository);
     let head = nominated_head(&input.local);
-    let assoc = github::associate_points(
-        &target,
-        source,
-        &input.local.points,
-        &input.local.absorbed,
-        head,
-    )?;
+    let assoc = match forge {
+        crate::git::Forge::GitHub => github::associate_points(
+            &target,
+            source,
+            &input.local.points,
+            &input.local.absorbed,
+            head,
+        )?,
+        crate::git::Forge::GitLab => gitlab::associate_points(
+            &target,
+            source,
+            &input.local.points,
+            &input.local.absorbed,
+            head,
+        )?,
+    };
     let number = match pick_open(&assoc.open, input) {
         Pick::One(n) => n,
         Pick::Ambiguous(count) => {
@@ -436,22 +450,26 @@ fn fetch_inner(
             }
         },
     };
-    let detail = github::pr_detail(&target, number)?;
-    let node = &detail["data"]["repository"]["pullRequest"];
-    if node.is_null() {
+    let detail = match forge {
+        crate::git::Forge::GitHub => github::pr_detail(&target, number)?,
+        crate::git::Forge::GitLab => gitlab::pr_detail(&target, number)?,
+    };
+    let Some((node, pr_head)) = detail else {
         return Ok(PrView::NoPr);
-    }
+    };
     // Sync compares the fetch's pinned HEAD to the PR head, so a checkout or commit landing
     // mid-fetch never pairs one branch's PR with another branch's count.
-    let pr_head = node["headRefOid"].as_str().unwrap_or_default();
     let sync = match input.local.head_oid.as_deref() {
         Some(pin) if !pr_head.is_empty() => derive_sync(
-            crate::git::ahead_behind_oids(repo, pin, pr_head)
-                .map_err(|error| GhError::LocalGit(error.0))?,
+            crate::git::ahead_behind_oids(repo, pin, &pr_head)
+                .map_err(|error| CliError::LocalGit(error.0))?,
         ),
         _ => Sync::Unknown,
     };
-    Ok(PrView::Pr(Box::new(github::build_snapshot(node, sync))))
+    Ok(PrView::Pr(Box::new(match forge {
+        crate::git::Forge::GitHub => github::build_snapshot(&node, sync),
+        crate::git::Forge::GitLab => gitlab::build_snapshot(&node, sync),
+    })))
 }
 
 /// The local branch's position relative to the PR head, from `git`'s ahead/behind counts. A
@@ -698,14 +716,16 @@ mod tests {
         let gated = |input: &PrFetchInput| fetch(Path::new("."), input);
         let mut missing = input("head", vec![], None);
         missing.repository = crate::git::RepositoryIdentity::Missing;
-        assert_eq!(gated(&missing), PrView::NeedsGitHubRemote);
+        assert_eq!(gated(&missing), PrView::NeedsForgeRemote);
 
         let mut unsupported = input("head", vec![], None);
-        unsupported.repository = crate::git::RepositoryIdentity::Unsupported("gitlab.com".into());
-        assert_eq!(gated(&unsupported), PrView::UnsupportedHost("gitlab.com".into()));
+        unsupported.repository =
+            crate::git::RepositoryIdentity::Unsupported("bitbucket.org".into());
+        assert_eq!(gated(&unsupported), PrView::UnsupportedHost("bitbucket.org".into()));
 
         let repo = crate::git::RepositoryIdentity::Repository(
-            crate::git::RepoTarget::new("github.com", "owner", "repo").unwrap(),
+            crate::git::RepoTarget::new(crate::git::Forge::GitHub, "github.com", "owner", "repo")
+                .unwrap(),
         );
         let mut detached = input("head", vec![], None);
         detached.repository = repo.clone();
@@ -759,9 +779,12 @@ mod tests {
 
     #[test]
     fn source_selection_prefers_a_same_host_origin_else_the_target() {
-        let target = crate::git::RepoTarget::new("github.com", "acme", "widgets").unwrap();
-        let fork = crate::git::RepoTarget::new("github.com", "contributor", "widgets").unwrap();
-        let foreign = crate::git::RepoTarget::new("ghe.corp.test", "me", "widgets").unwrap();
+        let github = |host: &str, owner: &str, name: &str| {
+            crate::git::RepoTarget::new(crate::git::Forge::GitHub, host, owner, name).unwrap()
+        };
+        let target = github("github.com", "acme", "widgets");
+        let fork = github("github.com", "contributor", "widgets");
+        let foreign = github("ghe.corp.test", "me", "widgets");
         assert_eq!(select_source(Some(&fork), &target), &fork);
         assert_eq!(select_source(Some(&foreign), &target), &target);
         assert_eq!(select_source(None, &target), &target);
@@ -828,7 +851,7 @@ mod tests {
     #[test]
     fn local_git_failures_degrade_to_the_git_error_view() {
         assert_eq!(
-            PrView::from(GhError::LocalGit("rev-list failed".into())),
+            PrView::from(CliError::LocalGit("rev-list failed".into())),
             PrView::GitError("rev-list failed".into())
         );
     }

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -79,6 +79,8 @@ impl PrView {
 /// One pull request's state, read fresh from the forge each poll.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PrSnapshot {
+    /// The forge this snapshot was read from — names the remote surface in UI chrome.
+    pub forge: crate::git::Forge,
     pub number: u64,
     pub title: String,
     pub url: String,
@@ -98,7 +100,7 @@ pub struct PrSnapshot {
     pub checks: Vec<Check>,
     pub comments: Vec<Comment>,
     /// A capped surface (reviews/comments/threads/checks) had more rows than the 100-row fetch
-    /// returned — the lists shown are a prefix, not the whole set. Drives a "more on GitHub" marker.
+    /// returned — the lists shown are a prefix, not the whole set. Drives a "more on the forge" marker.
     pub truncated: bool,
 }
 
@@ -809,6 +811,7 @@ mod tests {
     #[test]
     fn rollup_fails_on_any_failure_else_running_else_success() {
         let snap = |statuses: &[CheckStatus]| PrSnapshot {
+            forge: crate::git::Forge::GitHub,
             number: 1,
             title: String::new(),
             url: String::new(),

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -287,6 +287,7 @@ pub(super) fn build_snapshot(node: &Value, sync: Sync) -> PrSnapshot {
         || more(&node["comments"])
         || more(&node["reviewThreads"]);
     PrSnapshot {
+        forge: Forge::GitHub,
         number: node["number"].as_u64().unwrap_or_default(),
         title: node["title"].as_str().unwrap_or_default().to_string(),
         url: node["url"].as_str().unwrap_or_default().to_string(),

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -1,0 +1,801 @@
+//! The GitHub backend: association, detail, and normalization through `gh` GraphQL calls.
+//!
+//! See `specs/forge-host.md`. Everything GitHub-shaped lives here — the GraphQL queries,
+//! the response JSON parsing, and `gh`'s stderr classification. The forge-agnostic
+//! resolution logic (gates, picks, sync, the snapshot model) stays in `super`.
+
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+
+use serde_json::Value;
+
+use super::{
+    AssocPr, Association, Check, CheckStatus, Comment, CommentKind, FetchTarget, GhError, Merge,
+    PrSnapshot, PrState, Sync,
+};
+
+/// Run explicitly targeted `gh` arguments in `repo` and return stdout or a classified failure.
+fn gh(repo: &Path, host: &str, args: &[&str], cancelled: &AtomicBool) -> Result<String, GhError> {
+    super::run_cli("gh", repo, args, cancelled).map_err(|failure| match failure {
+        super::CliFailure::Missing => GhError::NoGh,
+        super::CliFailure::Other(message) => GhError::Other(message),
+        super::CliFailure::Stderr(stderr) => classify_failure(&stderr, host),
+    })
+}
+
+/// Map a failed `gh`'s stderr to a degraded state by its wording — `gh` has no stable exit
+/// codes for these. An unrecognised failure is `Other` → a transient `Error` view.
+fn classify_failure(stderr: &str, host: &str) -> GhError {
+    let s = stderr.to_lowercase();
+    if s.contains("not logged") || s.contains("authentication") || s.contains("gh auth login") {
+        GhError::NotAuthed(host.to_owned())
+    } else {
+        GhError::Other(stderr.trim().to_string())
+    }
+}
+
+/// The closed-lookup aliases, one per `(point, tip name)` pair: `(alias, var, point index,
+/// name)`. Build, vars, and parse all enumerate through this one owner, so the alias ↔
+/// point pairing cannot drift between them. Capped at 8 pairs — a tip that many refs point
+/// at (post-release coincidences, mirror refs) must not balloon the query past API limits.
+fn closed_aliases(points: &[crate::git::PublicationPoint]) -> Vec<(String, String, usize, String)> {
+    points
+        .iter()
+        .enumerate()
+        .flat_map(|(i, point)| {
+            point
+                .names
+                .iter()
+                .enumerate()
+                .map(move |(j, name)| (format!("c{i}_{j}"), format!("b{i}_{j}"), i, name.clone()))
+        })
+        .take(8)
+        .collect()
+}
+
+/// Ask GitHub which PRs contain each publication point, in one aliased call against the
+/// `source` repository, with the closed-unmerged name lookup against the target riding
+/// along (`specs/forge-host.md`). Only PRs based on the target repository count.
+pub(super) fn associate_points(
+    target: &FetchTarget<'_>,
+    source: &crate::git::RepoTarget,
+    points: &[crate::git::PublicationPoint],
+    absorbed: &[String],
+    head: Option<&str>,
+) -> Result<Association, GhError> {
+    let closed = closed_aliases(points);
+    let query =
+        build_association_query(points.len() + absorbed.len() + head.iter().count(), &closed);
+    let mut vars = vec![
+        ("so".to_string(), source.owner().to_string()),
+        ("sn".to_string(), source.name().to_string()),
+        ("to".to_string(), target.owner.to_string()),
+        ("tn".to_string(), target.name.to_string()),
+    ];
+    for (i, oid) in points
+        .iter()
+        .map(|p| p.oid.as_str())
+        .chain(absorbed.iter().map(String::as_str))
+        .chain(head)
+        .enumerate()
+    {
+        vars.push((format!("p{i}"), oid.to_string()));
+    }
+    for (_, var, _, name) in &closed {
+        vars.push((var.clone(), name.clone()));
+    }
+    let v = graphql(target.repo, target.host, &query, &vars, target.cancelled)?;
+    Ok(parse_association(&v, points, absorbed, head, &closed))
+}
+
+/// The aliased association query: `p{i}: object(oid:$p{i})` per nominated OID — points,
+/// absorbed candidates, then the exact-identity `HEAD` — against the source repository,
+/// plus one closed-PR lookup per `(point, tip name)` pair against the target. The target block always carries `id` — the rename-proof base filter, and
+/// the reason the block is never an empty selection set. Values ride as variables, never
+/// in the query text.
+fn build_association_query(oids: usize, closed: &[(String, String, usize, String)]) -> String {
+    use std::fmt::Write;
+    let mut q = String::from("query($so:String!,$sn:String!,$to:String!,$tn:String!");
+    for i in 0..oids {
+        let _ = write!(q, ",$p{i}:GitObjectID!");
+    }
+    for (_, var, _, _) in closed {
+        let _ = write!(q, ",${var}:String!");
+    }
+    q.push_str("){src:repository(owner:$so,name:$sn){");
+    for i in 0..oids {
+        let _ = write!(
+            q,
+            "p{i}:object(oid:$p{i}){{... on Commit{{associatedPullRequests(first:100){{nodes{{\
+             number state headRefOid headRefName createdAt mergedAt \
+             baseRepository{{id}}}}}}}}}} "
+        );
+    }
+    q.push_str("} tgt:repository(owner:$to,name:$tn){id ");
+    for (alias, var, _, _) in closed {
+        let _ = write!(
+            q,
+            "{alias}:pullRequests(headRefName:${var}, states:[CLOSED], first:10, \
+             orderBy:{{field:CREATED_AT, direction:DESC}}){{nodes{{\
+             number headRefOid headRefName createdAt}}}} "
+        );
+    }
+    q.push_str("}}");
+    q
+}
+
+/// Split the association response by lifecycle. Association nodes keep only PRs whose base
+/// repository `id` equals the target's — ids survive renames and transfers, names do not.
+/// Nodes from `absorbed` aliases are admitted only as a merged PR whose head is exactly an
+/// absorbed commit — the parked epilogue. Nodes from the `head` alias are admitted only
+/// when their head is exactly the pinned `HEAD` — the exact-identity epilogue. Closed
+/// nodes keep only an exact head match to their point — identity, never a name
+/// (`specs/forge-host.md`). Duplicates collapse.
+fn parse_association(
+    v: &Value,
+    points: &[crate::git::PublicationPoint],
+    absorbed: &[String],
+    head: Option<&str>,
+    closed: &[(String, String, usize, String)],
+) -> Association {
+    let mut assoc = Association::default();
+    let target_id = v["data"]["tgt"]["id"].as_str().unwrap_or_default();
+    let pr_of = |node: &Value| -> Option<AssocPr> {
+        Some(AssocPr {
+            number: node["number"].as_u64()?,
+            head_oid: node["headRefOid"].as_str().unwrap_or_default().to_string(),
+            head_ref: node["headRefName"].as_str().unwrap_or_default().to_string(),
+            merged_at: node["mergedAt"].as_str().unwrap_or_default().to_string(),
+            created_at: node["createdAt"].as_str().unwrap_or_default().to_string(),
+        })
+    };
+    for i in 0..points.len() + absorbed.len() + head.iter().count() {
+        let from_absorbed = i >= points.len() && i < points.len() + absorbed.len();
+        let from_head = i >= points.len() + absorbed.len();
+        let nodes = &v["data"]["src"][format!("p{i}").as_str()]["associatedPullRequests"]["nodes"];
+        for node in nodes.as_array().into_iter().flatten() {
+            let base = node["baseRepository"]["id"].as_str().unwrap_or_default();
+            if base.is_empty() || base != target_id {
+                continue;
+            }
+            let Some(pr) = pr_of(node) else { continue };
+            if from_absorbed {
+                // An absorbed commit is base history, which proves nothing by containment.
+                // Only the exact parked epilogue is admissible: a merged PR whose head is
+                // an absorbed commit itself.
+                let exact = absorbed.iter().any(|oid| oid == &pr.head_oid);
+                if exact && node["state"].as_str() == Some("MERGED") {
+                    super::push_unique(&mut assoc.merged, pr);
+                }
+                continue;
+            }
+            if from_head {
+                // The pinned HEAD is not published, so containment proves nothing. Only
+                // exact identity admits: the worktree is parked on the PR's own head.
+                if Some(pr.head_oid.as_str()) != head {
+                    continue;
+                }
+            }
+            match node["state"].as_str() {
+                Some("OPEN") => super::push_unique(&mut assoc.open, pr),
+                Some("MERGED") => super::push_unique(&mut assoc.merged, pr),
+                _ => {}
+            }
+        }
+    }
+    for (alias, _, i, _) in closed {
+        let nodes = &v["data"]["tgt"][alias.as_str()]["nodes"];
+        for node in nodes.as_array().into_iter().flatten() {
+            let Some(pr) = pr_of(node) else { continue };
+            if pr.head_oid != points[*i].oid {
+                continue;
+            }
+            super::push_unique(&mut assoc.closed, pr);
+        }
+    }
+    assoc
+}
+
+/// All of one PR's state in a single direct GraphQL call — identity, mergeability, checks,
+/// reviews, plain comments, and review threads. Each list surface reads its newest 100 rows
+/// (`last:100`, flagged by `hasPreviousPage`) — ample for any real PR in a review sidebar —
+/// and flags a fuller surface so the UI can mark it, rather than paging to exhaustion
+/// (`specs/forge-host.md`). Checks keep `first:100`/`hasNextPage`.
+pub(super) fn pr_detail(target: &FetchTarget<'_>, number: u64) -> Result<Value, GhError> {
+    let q = build_detail_query(number);
+    let vars = vec![
+        ("o".to_string(), target.owner.to_string()),
+        ("n".to_string(), target.name.to_string()),
+    ];
+    graphql(target.repo, target.host, &q, &vars, target.cancelled)
+}
+
+/// Project one PR directly, including fork identity and capped check/comment surfaces.
+fn build_detail_query(number: u64) -> String {
+    format!(
+        "query($o:String!,$n:String!){{repository(owner:$o,name:$n){{\
+         pullRequest(number:{number}){{\
+         number title url body isDraft state mergeable mergeStateStatus baseRefName headRefName \
+         headRefOid isCrossRepository \
+         commits(last:1){{nodes{{commit{{statusCheckRollup{{contexts(first:100){{pageInfo{{hasNextPage}} nodes{{__typename \
+         ... on CheckRun{{name status conclusion}} ... on StatusContext{{context state}}}}}}}}}}}}}} \
+         reviews(last:100){{pageInfo{{hasPreviousPage}} nodes{{author{{login}} body submittedAt}}}} \
+         comments(last:100){{pageInfo{{hasPreviousPage}} nodes{{author{{login}} body createdAt}}}} \
+         reviewThreads(last:100){{pageInfo{{hasPreviousPage}} nodes{{isResolved isOutdated path line \
+         comments(first:1){{totalCount nodes{{author{{login}} body createdAt diffHunk}}}}}}}}}}}}}}"
+    )
+}
+
+/// Run a GraphQL `query` with `vars` and parse the response. Every variable is passed with
+/// `-f` (raw string) — `-F` type-coerces, so a branch literally named `123` would arrive
+/// as an Int and fail its `String!` declaration.
+fn graphql(
+    repo: &Path,
+    host: &str,
+    query: &str,
+    vars: &[(String, String)],
+    cancelled: &AtomicBool,
+) -> Result<Value, GhError> {
+    let args = graphql_args(host, query, vars);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let out = gh(repo, host, &arg_refs, cancelled)?;
+    serde_json::from_str(&out).map_err(|e| GhError::Other(e.to_string()))
+}
+
+fn graphql_args(host: &str, query: &str, vars: &[(String, String)]) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "api".to_string(),
+        "graphql".to_string(),
+        "--hostname".to_string(),
+        host.to_owned(),
+        "-f".to_string(),
+        format!("query={query}"),
+    ];
+    for (key, value) in vars {
+        args.push("-f".to_string());
+        args.push(format!("{key}={value}"));
+    }
+    args
+}
+
+// ---- Pure normalization (unit-tested) --------------------------------------------------
+
+/// Assemble the snapshot from the `gh pr view` JSON, the computed `sync`, and the merged comments.
+pub(super) fn build_snapshot(node: &Value, sync: Sync) -> PrSnapshot {
+    let contexts = &node["commits"]["nodes"][0]["commit"]["statusCheckRollup"]["contexts"];
+    let rollup = &contexts["nodes"];
+    // A surface whose page reports more in the direction it pages is a prefix, not the whole set.
+    // Each query asks only for its own flag — `hasPreviousPage` for the `last:` lists,
+    // `hasNextPage` for checks — so OR-ing both reads whichever applies; the absent one is false.
+    let more = |conn: &Value| {
+        conn["pageInfo"]["hasNextPage"].as_bool().unwrap_or(false)
+            || conn["pageInfo"]["hasPreviousPage"].as_bool().unwrap_or(false)
+    };
+    let truncated = more(contexts)
+        || more(&node["reviews"])
+        || more(&node["comments"])
+        || more(&node["reviewThreads"]);
+    PrSnapshot {
+        number: node["number"].as_u64().unwrap_or_default(),
+        title: node["title"].as_str().unwrap_or_default().to_string(),
+        url: node["url"].as_str().unwrap_or_default().to_string(),
+        body: node["body"].as_str().unwrap_or_default().to_string(),
+        state: parse_state(node["state"].as_str().unwrap_or("OPEN")),
+        is_draft: node["isDraft"].as_bool().unwrap_or(false),
+        head_ref: node["headRefName"].as_str().unwrap_or_default().to_string(),
+        head_is_fork: node["isCrossRepository"].as_bool().unwrap_or(false),
+        base_ref: node["baseRefName"].as_str().unwrap_or_default().to_string(),
+        merge: derive_merge(node["mergeable"].as_str(), node["mergeStateStatus"].as_str()),
+        sync,
+        checks: normalize_checks(rollup),
+        comments: merge_comments(
+            &node["reviews"]["nodes"],
+            &node["comments"]["nodes"],
+            &node["reviewThreads"]["nodes"],
+        ),
+        truncated,
+    }
+}
+
+fn parse_state(s: &str) -> PrState {
+    match s {
+        "MERGED" => PrState::Merged,
+        "CLOSED" => PrState::Closed,
+        _ => PrState::Open,
+    }
+}
+
+/// Fold GitHub's `mergeable` and `mergeStateStatus` into a [`Merge`]. Only the actionable
+/// blockers are surfaced: conflicts and a `blocked` required gate. Everything else — `clean`,
+/// `behind`, `unstable`, and still-`unknown` (computing) — folds into `Clean` (shows nothing).
+fn derive_merge(mergeable: Option<&str>, state: Option<&str>) -> Merge {
+    match (mergeable, state) {
+        (Some("CONFLICTING"), _) | (_, Some("DIRTY")) => Merge::Conflicting,
+        (_, Some("BLOCKED")) => Merge::Blocked,
+        _ => Merge::Clean,
+    }
+}
+
+/// The latest run per check name, normalised from check runs and commit statuses.
+fn normalize_checks(rollup: &Value) -> Vec<Check> {
+    let mut out: Vec<Check> = Vec::new();
+    for node in rollup.as_array().into_iter().flatten() {
+        let name =
+            node["name"].as_str().or_else(|| node["context"].as_str()).unwrap_or("").to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let status = check_status(node);
+        // Latest wins: a later array entry for the same name (a re-run) replaces the earlier.
+        if let Some(slot) = out.iter_mut().find(|c| c.name == name) {
+            *slot = Check { name, status };
+        } else {
+            out.push(Check { name, status });
+        }
+    }
+    out
+}
+
+/// Normalise one check node — a check run (`status`/`conclusion`) or a commit status (`state`)
+/// — to a [`CheckStatus`].
+fn check_status(node: &Value) -> CheckStatus {
+    // Check runs carry `status`/`conclusion`; commit statuses carry `state`.
+    if let Some(state) = node["state"].as_str() {
+        return match state {
+            "SUCCESS" => CheckStatus::Success,
+            "FAILURE" | "ERROR" => CheckStatus::Failure,
+            _ => CheckStatus::Pending,
+        };
+    }
+    match node["status"].as_str() {
+        Some("COMPLETED") => match node["conclusion"].as_str() {
+            Some("SUCCESS") => CheckStatus::Success,
+            Some("SKIPPED" | "NEUTRAL") => CheckStatus::Skipped,
+            // FAILURE / TIMED_OUT / CANCELLED / ACTION_REQUIRED / a missing conclusion all read
+            // as a failed check — something needs attention.
+            _ => CheckStatus::Failure,
+        },
+        Some("IN_PROGRESS") => CheckStatus::Running,
+        _ => CheckStatus::Pending,
+    }
+}
+
+/// Merge the three comment surfaces (GraphQL `reviews`, `comments`, and `reviewThreads` node
+/// arrays) into one newest-first list, keeping only a bot's latest PR-level post and each human's.
+fn merge_comments(reviews: &Value, issues: &Value, threads: &Value) -> Vec<Comment> {
+    let mut out: Vec<Comment> = Vec::new();
+
+    // Submitted reviews with a non-empty body (the PR-level `review` cards).
+    for r in reviews.as_array().into_iter().flatten() {
+        let body = r["body"].as_str().unwrap_or("").trim().to_string();
+        if body.is_empty() {
+            continue;
+        }
+        out.push(prose_comment(CommentKind::Review, &r["author"], body, r["submittedAt"].as_str()));
+    }
+
+    // Plain conversation comments (the `comment` cards).
+    for c in issues.as_array().into_iter().flatten() {
+        let body = c["body"].as_str().unwrap_or("").trim().to_string();
+        if body.is_empty() {
+            continue;
+        }
+        out.push(prose_comment(CommentKind::Comment, &c["author"], body, c["createdAt"].as_str()));
+    }
+
+    // Inline review threads (the `finding` cards), with resolved/outdated and replies.
+    for t in threads.as_array().into_iter().flatten() {
+        let root = &t["comments"]["nodes"][0];
+        let login = root["author"]["login"].as_str().unwrap_or("").to_string();
+        let path = t["path"].as_str().unwrap_or("");
+        let anchor = match t["line"].as_u64() {
+            Some(line) => format!("{path}:{line}"),
+            None => path.to_string(),
+        };
+        out.push(Comment {
+            kind: CommentKind::Finding,
+            author_is_bot: is_bot(&login),
+            author: login,
+            anchor,
+            body: root["body"].as_str().unwrap_or("").trim().to_string(),
+            snippet: root["diffHunk"].as_str().filter(|h| !h.is_empty()).map(str::to_string),
+            created_at: root["createdAt"].as_str().unwrap_or("").to_string(),
+            is_resolved: t["isResolved"].as_bool().unwrap_or(false),
+            is_outdated: t["isOutdated"].as_bool().unwrap_or(false),
+            reply_count: t["comments"]["totalCount"].as_u64().unwrap_or(1).saturating_sub(1) as u32,
+        });
+    }
+
+    super::dedup_bot_prose(&mut out);
+    // Newest first: ISO-8601 `…Z` strings sort lexically in chronological order.
+    out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    out
+}
+
+fn prose_comment(
+    kind: CommentKind,
+    user: &Value,
+    body: String,
+    created_at: Option<&str>,
+) -> Comment {
+    let login = user["login"].as_str().unwrap_or("").to_string();
+    let anchor = match kind {
+        CommentKind::Review => "review",
+        _ => "comment",
+    };
+    Comment {
+        kind,
+        author_is_bot: is_bot(&login),
+        author: login,
+        anchor: anchor.to_string(),
+        body,
+        snippet: None,
+        created_at: created_at.unwrap_or("").to_string(),
+        is_resolved: false,
+        is_outdated: false,
+        reply_count: 0,
+    }
+}
+
+/// Whether a GitHub login is an app/bot (`…[bot]`).
+fn is_bot(login: &str) -> bool {
+    login.ends_with("[bot]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn point(oid: &str, names: &[&str]) -> crate::git::PublicationPoint {
+        crate::git::PublicationPoint {
+            oid: oid.to_string(),
+            names: names.iter().map(|n| (*n).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn merge_surfaces_only_conflicts_and_blocked() {
+        assert_eq!(derive_merge(Some("CONFLICTING"), Some("DIRTY")), Merge::Conflicting);
+        assert_eq!(derive_merge(Some("MERGEABLE"), Some("BLOCKED")), Merge::Blocked);
+        // Everything non-actionable folds into Clean: clean, behind, unstable, still-computing.
+        assert_eq!(derive_merge(Some("MERGEABLE"), Some("CLEAN")), Merge::Clean);
+        assert_eq!(derive_merge(Some("MERGEABLE"), Some("BEHIND")), Merge::Clean);
+        assert_eq!(derive_merge(Some("MERGEABLE"), Some("UNSTABLE")), Merge::Clean);
+        assert_eq!(derive_merge(Some("UNKNOWN"), Some("UNKNOWN")), Merge::Clean);
+        // DIRTY means conflicts even while mergeability is still UNKNOWN or the field is missing.
+        assert_eq!(derive_merge(Some("UNKNOWN"), Some("DIRTY")), Merge::Conflicting);
+        assert_eq!(derive_merge(None, Some("DIRTY")), Merge::Conflicting);
+        assert_eq!(derive_merge(None, None), Merge::Clean);
+    }
+
+    #[test]
+    fn parse_state_maps_the_three_github_lifecycles() {
+        assert_eq!(parse_state("MERGED"), PrState::Merged);
+        assert_eq!(parse_state("CLOSED"), PrState::Closed);
+        assert_eq!(parse_state("OPEN"), PrState::Open);
+        assert_eq!(parse_state("anything-else"), PrState::Open); // default is the live case
+    }
+
+    #[test]
+    fn truncated_flips_when_any_capped_surface_has_a_next_page() {
+        let base = serde_json::json!({
+            "number": 1, "title": "t", "url": "u", "state": "OPEN", "isDraft": false,
+            "baseRefName": "main", "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+            "commits": {"nodes": [{"commit": {"statusCheckRollup":
+                {"contexts": {"pageInfo": {"hasNextPage": false}, "nodes": []}}}}]},
+            "reviews": {"pageInfo": {"hasNextPage": false}, "nodes": []},
+            "comments": {"pageInfo": {"hasNextPage": false}, "nodes": []},
+            "reviewThreads": {"pageInfo": {"hasNextPage": false}, "nodes": []}
+        });
+        assert!(
+            !build_snapshot(&base, Sync::InSync).truncated,
+            "all pages complete → not truncated"
+        );
+        // The description parses when present and stays empty when GitHub returns null.
+        assert_eq!(build_snapshot(&base, Sync::InSync).body, "");
+        let mut with_body = base.clone();
+        with_body["body"] = serde_json::json!("## Summary\nfixes things");
+        assert_eq!(build_snapshot(&with_body, Sync::InSync).body, "## Summary\nfixes things");
+
+        // Comments and threads read `last:100`, so their "more exist" flag pages backward.
+        let mut comments_more = base.clone();
+        comments_more["comments"]["pageInfo"]["hasPreviousPage"] = serde_json::json!(true);
+        assert!(build_snapshot(&comments_more, Sync::InSync).truncated);
+
+        let mut threads_more = base.clone();
+        threads_more["reviewThreads"]["pageInfo"]["hasPreviousPage"] = serde_json::json!(true);
+        assert!(build_snapshot(&threads_more, Sync::InSync).truncated);
+
+        let mut checks_more = base.clone();
+        checks_more["commits"]["nodes"][0]["commit"]["statusCheckRollup"]["contexts"]["pageInfo"]
+            ["hasNextPage"] = serde_json::json!(true);
+        assert!(build_snapshot(&checks_more, Sync::InSync).truncated);
+
+        // `reviews` pages backward (last:100), so its "more exist" flag is `hasPreviousPage` —
+        // checking `hasNextPage` here (the old bug) would leave this surface never marked.
+        let mut reviews_more = base.clone();
+        reviews_more["reviews"]["pageInfo"]["hasPreviousPage"] = serde_json::json!(true);
+        assert!(build_snapshot(&reviews_more, Sync::InSync).truncated);
+    }
+
+    #[test]
+    fn checks_take_the_latest_run_per_name() {
+        let rollup = serde_json::json!([
+            {"__typename": "CheckRun", "name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"},
+            {"__typename": "CheckRun", "name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"__typename": "CheckRun", "name": "build", "status": "IN_PROGRESS"},
+            {"__typename": "CheckRun", "name": "lint", "status": "COMPLETED", "conclusion": "SKIPPED"},
+            {"__typename": "CheckRun", "name": "codeql", "status": "COMPLETED", "conclusion": "NEUTRAL"},
+            {"__typename": "StatusContext", "context": "deploy", "state": "PENDING"}
+        ]);
+        let checks = normalize_checks(&rollup);
+        assert_eq!(checks.len(), 5);
+        let tests = checks.iter().find(|c| c.name == "tests").unwrap();
+        assert_eq!(tests.status, CheckStatus::Success); // the re-run won
+        assert_eq!(checks.iter().find(|c| c.name == "build").unwrap().status, CheckStatus::Running);
+        // SKIPPED and NEUTRAL both fold to Skipped — neither fails nor blocks the rollup.
+        assert_eq!(checks.iter().find(|c| c.name == "lint").unwrap().status, CheckStatus::Skipped);
+        assert_eq!(
+            checks.iter().find(|c| c.name == "codeql").unwrap().status,
+            CheckStatus::Skipped
+        );
+        assert_eq!(
+            checks.iter().find(|c| c.name == "deploy").unwrap().status,
+            CheckStatus::Pending
+        );
+    }
+
+    #[test]
+    fn absorbed_aliases_admit_only_an_exact_head_merged_pr() {
+        // The parked epilogue: the worktree sits on base history, so containment proves
+        // nothing — only a merged PR whose head IS the absorbed commit resolves.
+        let v = serde_json::json!({"data": {
+            "src": {
+                "p0": {"associatedPullRequests": {"nodes": [
+                    {"number": 82, "state": "MERGED", "headRefOid": "parked", "headRefName": "fix",
+                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": "2026-07-02T00:00:00Z",
+                     "baseRepository": {"id": "R1"}},
+                    {"number": 90, "state": "MERGED", "headRefOid": "other", "headRefName": "else",
+                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": "2026-07-03T00:00:00Z",
+                     "baseRepository": {"id": "R1"}},
+                    {"number": 91, "state": "OPEN", "headRefOid": "parked", "headRefName": "fix",
+                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": null,
+                     "baseRepository": {"id": "R1"}}
+                ]}}
+            },
+            "tgt": {"id": "R1"}
+        }});
+        let absorbed = vec!["parked".to_string()];
+        let a = parse_association(&v, &[], &absorbed, None, &[]);
+        // #90 contains the commit but its head is a stranger's; #91 is open — neither admits.
+        assert_eq!(a.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [82]);
+        assert!(a.open.is_empty());
+    }
+
+    fn assoc_node(number: u64, state: &str, head: &str) -> serde_json::Value {
+        serde_json::json!({"number": number, "state": state, "headRefOid": head,
+            "headRefName": "feat", "createdAt": "2026-07-01T00:00:00Z",
+            "mergedAt": null, "baseRepository": {"id": "R1"}})
+    }
+
+    #[test]
+    fn head_alias_admits_only_exact_head_matches_open_or_merged() {
+        // The exact-identity epilogue: the pinned HEAD nominates, so a PR whose head IS
+        // that commit admits — open or merged. A PR that merely contains it does not,
+        // and closed-unmerged PRs never associate on the forge at all.
+        let v = serde_json::json!({"data": {
+            "src": {"p0": {"associatedPullRequests": {"nodes": [
+                assoc_node(10, "MERGED", "tip"),
+                assoc_node(11, "OPEN", "tip"),
+                assoc_node(12, "CLOSED", "tip"),
+                assoc_node(13, "MERGED", "other"),
+                assoc_node(14, "OPEN", "other")
+            ]}}},
+            "tgt": {"id": "R1"}
+        }});
+        let a = parse_association(&v, &[], &[], Some("tip"), &[]);
+        assert_eq!(a.open.iter().map(|p| p.number).collect::<Vec<_>>(), [11]);
+        assert_eq!(a.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [10]);
+        assert!(a.closed.is_empty(), "the exact-identity path never fills closed");
+    }
+
+    #[test]
+    fn alias_index_classes_stay_aligned_with_all_three_sources_present() {
+        // One point, one absorbed candidate, and the head alias in one response: each
+        // index must land in its own admission class, not a neighbor's.
+        let v = serde_json::json!({"data": {
+            "src": {
+                "p0": {"associatedPullRequests": {"nodes": [assoc_node(20, "OPEN", "elsewhere")]}},
+                "p1": {"associatedPullRequests": {"nodes": [assoc_node(21, "MERGED", "parked")]}},
+                "p2": {"associatedPullRequests": {"nodes": [assoc_node(22, "MERGED", "tip")]}}
+            },
+            "tgt": {"id": "R1"}
+        }});
+        let points = vec![point("published", &[])];
+        let absorbed = vec!["parked".to_string()];
+        let a = parse_association(&v, &points, &absorbed, Some("tip"), &[]);
+        assert_eq!(a.open.iter().map(|p| p.number).collect::<Vec<_>>(), [20], "containment");
+        assert_eq!(a.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [21, 22], "exact");
+    }
+
+    #[test]
+    fn association_query_aliases_points_and_closed_names_and_never_inlines_values() {
+        let points = vec![point("aaa", &[]), point("bbb", &["feat", "backup"])];
+        let closed = closed_aliases(&points);
+        assert_eq!(
+            closed
+                .iter()
+                .map(|(alias, var, i, name)| (alias.as_str(), var.as_str(), *i, name.as_str()))
+                .collect::<Vec<_>>(),
+            [("c1_0", "b1_0", 1, "feat"), ("c1_1", "b1_1", 1, "backup")]
+        );
+        let q = build_association_query(points.len(), &closed);
+        assert!(q.starts_with(
+            "query($so:String!,$sn:String!,$to:String!,$tn:String!,\
+             $p0:GitObjectID!,$p1:GitObjectID!,$b1_0:String!,$b1_1:String!)"
+        ));
+        assert!(q.contains("src:repository(owner:$so,name:$sn){p0:object(oid:$p0)"));
+        assert!(q.contains("associatedPullRequests(first:100)"));
+        assert!(q.contains("baseRepository{id}"));
+        assert!(q.contains("tgt:repository(owner:$to,name:$tn){id "));
+        assert!(q.contains("c1_0:pullRequests(headRefName:$b1_0, states:[CLOSED]"));
+        assert!(q.contains("c1_1:pullRequests(headRefName:$b1_1, states:[CLOSED]"));
+        // With no named point, the target block still carries `id` — never an empty
+        // selection set, which GitHub rejects as a parse error.
+        let bare = vec![point("aaa", &[])];
+        let q = build_association_query(bare.len(), &closed_aliases(&bare));
+        assert!(q.contains("tgt:repository(owner:$to,name:$tn){id }"));
+    }
+
+    #[test]
+    fn parse_association_splits_lifecycles_filters_by_repo_id_and_dedups() {
+        let v = serde_json::json!({"data": {
+            "src": {
+                "p0": {"associatedPullRequests": {"nodes": [
+                    {"number": 7, "state": "OPEN", "headRefOid": "abc", "headRefName": "feat-x",
+                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": null,
+                     "baseRepository": {"id": "R1"}},
+                    {"number": 8, "state": "MERGED", "headRefOid": "def", "headRefName": "feat-y",
+                     "createdAt": "2026-06-01T00:00:00Z", "mergedAt": "2026-06-02T00:00:00Z",
+                     "baseRepository": {"id": "R1"}},
+                    {"number": 9, "state": "OPEN", "headRefOid": "zzz", "headRefName": "other",
+                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": null,
+                     "baseRepository": {"id": "R-other"}}
+                ]}},
+                "p1": {"associatedPullRequests": {"nodes": [
+                    {"number": 7, "state": "OPEN", "headRefOid": "abc", "headRefName": "feat-x",
+                     "createdAt": "2026-07-01T00:00:00Z", "mergedAt": null,
+                     "baseRepository": {"id": "R1"}}
+                ]}}
+            },
+            "tgt": {
+                "id": "R1",
+                "c1_0": {"nodes": [
+                    {"number": 5, "headRefOid": "p1oid", "headRefName": "old-name",
+                     "createdAt": "2026-05-01T00:00:00Z"},
+                    {"number": 6, "headRefOid": "impostor", "headRefName": "old-name",
+                     "createdAt": "2026-05-02T00:00:00Z"}
+                ]}
+            }
+        }});
+        let points = vec![point("p0oid", &[]), point("p1oid", &["old-name"])];
+        let a = parse_association(&v, &points, &[], None, &closed_aliases(&points));
+        // Open #7 appears under both points but lands once; #9 based elsewhere is dropped.
+        assert_eq!(a.open.iter().map(|p| p.number).collect::<Vec<_>>(), [7]);
+        assert_eq!(a.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [8]);
+        // The closed lookup admits only an exact head match to the point.
+        assert_eq!(a.closed.iter().map(|p| p.number).collect::<Vec<_>>(), [5]);
+    }
+
+    #[test]
+    fn snapshot_carries_the_head_ref_and_fork_marker() {
+        let node = serde_json::json!({
+            "number": 5, "title": "t", "url": "u", "state": "OPEN", "isDraft": false,
+            "headRefName": "persiyanov/feature", "isCrossRepository": true, "baseRefName": "main",
+            "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+            "commits": {"nodes": []}, "reviews": {"nodes": []},
+            "comments": {"nodes": []}, "reviewThreads": {"nodes": []}
+        });
+        let s = build_snapshot(&node, Sync::InSync);
+        assert_eq!(s.head_ref, "persiyanov/feature");
+        assert!(s.head_is_fork);
+        // Absent fields default rather than fail — a mid-rollout API response degrades soft.
+        let bare = serde_json::json!({"number": 5});
+        let s = build_snapshot(&bare, Sync::InSync);
+        assert_eq!(s.head_ref, "");
+        assert!(!s.head_is_fork);
+    }
+
+    #[test]
+    fn comments_merge_three_surfaces_newest_first() {
+        let reviews = serde_json::json!([
+            {"author": {"login": "codex[bot]"}, "state": "COMMENTED", "body": "Codex review.", "submittedAt": "2026-06-27T10:00:00Z"}
+        ]);
+        let issues = serde_json::json!([
+            {"author": {"login": "persijano"}, "body": "watch the 404s", "createdAt": "2026-06-27T12:00:00Z"}
+        ]);
+        let threads = serde_json::json!([
+            {"isResolved": false, "isOutdated": true, "path": "a.py", "line": null,
+             "comments": {"totalCount": 2, "nodes": [{"author": {"login": "claude[bot]"}, "body": "SSRF", "createdAt": "2026-06-27T11:00:00Z"}]}}
+        ]);
+        let cs = merge_comments(&reviews, &issues, &threads);
+        assert_eq!(cs.len(), 3);
+        // Newest first across all three surfaces — pin the full order so a reversed or
+        // unstable comparator fails rather than passing on the endpoints alone.
+        assert_eq!(
+            cs.iter().map(|c| c.created_at.as_str()).collect::<Vec<_>>(),
+            ["2026-06-27T12:00:00Z", "2026-06-27T11:00:00Z", "2026-06-27T10:00:00Z"]
+        );
+        assert_eq!(cs[0].author, "persijano");
+        assert_eq!(cs[0].kind, CommentKind::Comment);
+        assert!(!cs[0].author_is_bot);
+        assert_eq!(cs[1].kind, CommentKind::Finding);
+        assert_eq!(cs[2].kind, CommentKind::Review);
+        // The finding carries its thread state, an unanchored line, and one reply.
+        let f = cs.iter().find(|c| c.kind == CommentKind::Finding).unwrap();
+        assert_eq!(f.anchor, "a.py");
+        assert!(f.is_outdated);
+        assert_eq!(f.reply_count, 1);
+    }
+
+    #[test]
+    fn a_bots_prose_collapses_to_its_latest_a_humans_is_kept() {
+        let reviews = serde_json::json!([
+            {"author": {"login": "claude[bot]"}, "body": "old review", "submittedAt": "2026-06-27T09:00:00Z"},
+            {"author": {"login": "claude[bot]"}, "body": "new review", "submittedAt": "2026-06-27T10:00:00Z"},
+            {"author": {"login": "persijano"}, "body": "note one", "submittedAt": "2026-06-27T09:30:00Z"},
+            {"author": {"login": "persijano"}, "body": "note two", "submittedAt": "2026-06-27T09:45:00Z"}
+        ]);
+        let cs = merge_comments(&reviews, &serde_json::json!([]), &serde_json::json!([]));
+        let claude: Vec<_> = cs.iter().filter(|c| c.author == "claude[bot]").collect();
+        assert_eq!(claude.len(), 1); // only the latest bot review
+        assert_eq!(claude[0].body, "new review");
+        assert_eq!(cs.iter().filter(|c| c.author == "persijano").count(), 2); // both human notes
+    }
+
+    #[test]
+    fn a_bots_findings_are_each_kept_even_as_its_prose_collapses() {
+        // Inline findings anchor to distinct lines, so — unlike a bot's PR-level prose — they
+        // are never collapsed: two findings from the same bot both survive, the prose folds to one.
+        let reviews = serde_json::json!([
+            {"author": {"login": "claude[bot]"}, "body": "old prose", "submittedAt": "2026-06-27T09:00:00Z"},
+            {"author": {"login": "claude[bot]"}, "body": "new prose", "submittedAt": "2026-06-27T09:30:00Z"}
+        ]);
+        let threads = serde_json::json!([
+            {"isResolved": false, "isOutdated": false, "path": "a.py", "line": 10,
+             "comments": {"totalCount": 1, "nodes": [{"author": {"login": "claude[bot]"}, "body": "finding one", "createdAt": "2026-06-27T10:00:00Z"}]}},
+            {"isResolved": false, "isOutdated": false, "path": "b.py", "line": 20,
+             "comments": {"totalCount": 1, "nodes": [{"author": {"login": "claude[bot]"}, "body": "finding two", "createdAt": "2026-06-27T11:00:00Z"}]}}
+        ]);
+        let cs = merge_comments(&reviews, &serde_json::json!([]), &threads);
+        assert_eq!(cs.iter().filter(|c| c.kind == CommentKind::Finding).count(), 2);
+        assert_eq!(cs.iter().filter(|c| c.kind == CommentKind::Review).count(), 1); // prose collapsed
+    }
+
+    #[test]
+    fn gh_failure_classifies_by_stderr_wording() {
+        assert_eq!(
+            classify_failure("gh auth login required", "github.example.com"),
+            GhError::NotAuthed("github.example.com".to_string())
+        );
+        assert_eq!(
+            classify_failure("You are not logged into any GitHub hosts", "github.com"),
+            GhError::NotAuthed("github.com".to_string())
+        );
+        assert_eq!(
+            classify_failure("HTTP 500 something", "github.com"),
+            GhError::Other("HTTP 500 something".into())
+        );
+    }
+
+    #[test]
+    fn graphql_arguments_always_pin_the_canonical_host() {
+        let args = graphql_args(
+            "github.example.com",
+            "query($o:String!){viewer{login}}",
+            &[("o".to_string(), "owner".to_string())],
+        );
+        assert_eq!(&args[..4], ["api", "graphql", "--hostname", "github.example.com"]);
+        assert!(args.windows(2).any(|pair| pair == ["-f", "o=owner"]));
+    }
+}

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -10,27 +10,28 @@ use std::sync::atomic::AtomicBool;
 use serde_json::Value;
 
 use super::{
-    AssocPr, Association, Check, CheckStatus, Comment, CommentKind, FetchTarget, GhError, Merge,
+    AssocPr, Association, Check, CheckStatus, CliError, Comment, CommentKind, FetchTarget, Merge,
     PrSnapshot, PrState, Sync,
 };
+use crate::git::Forge;
 
 /// Run explicitly targeted `gh` arguments in `repo` and return stdout or a classified failure.
-fn gh(repo: &Path, host: &str, args: &[&str], cancelled: &AtomicBool) -> Result<String, GhError> {
+fn gh(repo: &Path, host: &str, args: &[&str], cancelled: &AtomicBool) -> Result<String, CliError> {
     super::run_cli("gh", repo, args, cancelled).map_err(|failure| match failure {
-        super::CliFailure::Missing => GhError::NoGh,
-        super::CliFailure::Other(message) => GhError::Other(message),
+        super::CliFailure::Missing => CliError::Missing(Forge::GitHub),
+        super::CliFailure::Other(message) => CliError::Other(message),
         super::CliFailure::Stderr(stderr) => classify_failure(&stderr, host),
     })
 }
 
 /// Map a failed `gh`'s stderr to a degraded state by its wording — `gh` has no stable exit
 /// codes for these. An unrecognised failure is `Other` → a transient `Error` view.
-fn classify_failure(stderr: &str, host: &str) -> GhError {
+fn classify_failure(stderr: &str, host: &str) -> CliError {
     let s = stderr.to_lowercase();
     if s.contains("not logged") || s.contains("authentication") || s.contains("gh auth login") {
-        GhError::NotAuthed(host.to_owned())
+        CliError::NotAuthed(Forge::GitHub, host.to_owned())
     } else {
-        GhError::Other(stderr.trim().to_string())
+        CliError::Other(stderr.trim().to_string())
     }
 }
 
@@ -62,7 +63,7 @@ pub(super) fn associate_points(
     points: &[crate::git::PublicationPoint],
     absorbed: &[String],
     head: Option<&str>,
-) -> Result<Association, GhError> {
+) -> Result<Association, CliError> {
     let closed = closed_aliases(points);
     let query =
         build_association_query(points.len() + absorbed.len() + head.iter().count(), &closed);
@@ -200,14 +201,24 @@ fn parse_association(
 /// reviews, plain comments, and review threads. Each list surface reads its newest 100 rows
 /// (`last:100`, flagged by `hasPreviousPage`) — ample for any real PR in a review sidebar —
 /// and flags a fuller surface so the UI can mark it, rather than paging to exhaustion
-/// (`specs/forge-host.md`). Checks keep `first:100`/`hasNextPage`.
-pub(super) fn pr_detail(target: &FetchTarget<'_>, number: u64) -> Result<Value, GhError> {
+/// (`specs/forge-host.md`). Checks keep `first:100`/`hasNextPage`. Returns the PR node and
+/// its head OID, or `None` when the PR vanished between the association and this read.
+pub(super) fn pr_detail(
+    target: &FetchTarget<'_>,
+    number: u64,
+) -> Result<Option<(Value, String)>, CliError> {
     let q = build_detail_query(number);
     let vars = vec![
         ("o".to_string(), target.owner.to_string()),
         ("n".to_string(), target.name.to_string()),
     ];
-    graphql(target.repo, target.host, &q, &vars, target.cancelled)
+    let mut v = graphql(target.repo, target.host, &q, &vars, target.cancelled)?;
+    let node = v["data"]["repository"]["pullRequest"].take();
+    if node.is_null() {
+        return Ok(None);
+    }
+    let head = node["headRefOid"].as_str().unwrap_or_default().to_string();
+    Ok(Some((node, head)))
 }
 
 /// Project one PR directly, including fork identity and capped check/comment surfaces.
@@ -235,11 +246,11 @@ fn graphql(
     query: &str,
     vars: &[(String, String)],
     cancelled: &AtomicBool,
-) -> Result<Value, GhError> {
+) -> Result<Value, CliError> {
     let args = graphql_args(host, query, vars);
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
     let out = gh(repo, host, &arg_refs, cancelled)?;
-    serde_json::from_str(&out).map_err(|e| GhError::Other(e.to_string()))
+    serde_json::from_str(&out).map_err(|e| CliError::Other(e.to_string()))
 }
 
 fn graphql_args(host: &str, query: &str, vars: &[(String, String)]) -> Vec<String> {
@@ -776,15 +787,15 @@ mod tests {
     fn gh_failure_classifies_by_stderr_wording() {
         assert_eq!(
             classify_failure("gh auth login required", "github.example.com"),
-            GhError::NotAuthed("github.example.com".to_string())
+            CliError::NotAuthed(Forge::GitHub, "github.example.com".to_string())
         );
         assert_eq!(
             classify_failure("You are not logged into any GitHub hosts", "github.com"),
-            GhError::NotAuthed("github.com".to_string())
+            CliError::NotAuthed(Forge::GitHub, "github.com".to_string())
         );
         assert_eq!(
             classify_failure("HTTP 500 something", "github.com"),
-            GhError::Other("HTTP 500 something".into())
+            CliError::Other("HTTP 500 something".into())
         );
     }
 

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -1,0 +1,648 @@
+//! The GitLab backend: association through REST commit lookups, detail through one GraphQL
+//! call, all via `glab`.
+//!
+//! See `specs/forge-host.md`. Everything GitLab-shaped lives here — the REST paths, the
+//! GraphQL detail query, the response JSON parsing, and `glab`'s stderr classification. The
+//! forge-agnostic resolution logic (gates, picks, sync, the snapshot model) stays in `super`.
+
+use std::path::Path;
+use std::sync::atomic::AtomicBool;
+
+use serde_json::Value;
+
+use super::{
+    AssocPr, Association, Check, CheckStatus, CliError, Comment, CommentKind, FetchTarget, Merge,
+    PrSnapshot, PrState, Sync,
+};
+use crate::git::Forge;
+
+/// Run explicitly targeted `glab` arguments in `repo` and return stdout or a classified failure.
+fn glab(
+    repo: &Path,
+    host: &str,
+    args: &[&str],
+    cancelled: &AtomicBool,
+) -> Result<String, CliError> {
+    super::run_cli("glab", repo, args, cancelled).map_err(|failure| match failure {
+        super::CliFailure::Missing => CliError::Missing(Forge::GitLab),
+        super::CliFailure::Other(message) => CliError::Other(message),
+        super::CliFailure::Stderr(stderr) => classify_failure(&stderr, host),
+    })
+}
+
+/// Map a failed `glab`'s stderr to a degraded state by its wording — `glab` has no stable
+/// exit codes for these. An unrecognised failure is `Other` → a transient `Error` view.
+fn classify_failure(stderr: &str, host: &str) -> CliError {
+    let s = stderr.to_lowercase();
+    if s.contains("glab auth login") || s.contains("unauthorized") || s.contains("http 401") {
+        CliError::NotAuthed(Forge::GitLab, host.to_owned())
+    } else {
+        CliError::Other(stderr.trim().to_string())
+    }
+}
+
+/// Run one REST GET through `glab api`, hostname-pinned, and parse the JSON body.
+fn rest(repo: &Path, host: &str, path: &str, cancelled: &AtomicBool) -> Result<Value, CliError> {
+    let out = glab(repo, host, &["api", path, "--hostname", host], cancelled)?;
+    serde_json::from_str(&out).map_err(|e| CliError::Other(e.to_string()))
+}
+
+/// Run one REST GET where a 404 is a clean absence — an unknown commit or a hidden project —
+/// never a failure (`specs/forge-host.md`).
+fn rest_absent_ok(
+    repo: &Path,
+    host: &str,
+    path: &str,
+    cancelled: &AtomicBool,
+) -> Result<Option<Value>, CliError> {
+    match rest(repo, host, path, cancelled) {
+        Ok(v) => Ok(Some(v)),
+        Err(CliError::Other(message)) if message.contains("HTTP 404") => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Run one GraphQL query through `glab api graphql`, hostname-pinned. Variables ride as
+/// `-f` fields — `glab` folds every non-`query` field into the GraphQL variables.
+fn graphql(
+    repo: &Path,
+    host: &str,
+    query: &str,
+    vars: &[(String, String)],
+    cancelled: &AtomicBool,
+) -> Result<Value, CliError> {
+    let mut args: Vec<String> = vec![
+        "api".to_string(),
+        "graphql".to_string(),
+        "--hostname".to_string(),
+        host.to_owned(),
+        "-f".to_string(),
+        format!("query={query}"),
+    ];
+    for (key, value) in vars {
+        args.push("-f".to_string());
+        args.push(format!("{key}={value}"));
+    }
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let out = glab(repo, host, &arg_refs, cancelled)?;
+    serde_json::from_str(&out).map_err(|e| CliError::Other(e.to_string()))
+}
+
+/// Percent-encode one URL path or query component (the RFC 3986 unreserved set is kept).
+/// A project's full path rides in the URL, so its `/` separators must encode.
+fn percent_encode(component: &str) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(component.len());
+    for byte in component.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => {
+                let _ = write!(out, "%{byte:02X}");
+            }
+        }
+    }
+    out
+}
+
+/// One REST MR row → the pick-relevant fields. GitLab's MR number is its `iid`; `sha` is
+/// the MR head.
+fn mr_of(node: &Value) -> Option<AssocPr> {
+    Some(AssocPr {
+        number: node["iid"].as_u64()?,
+        head_oid: node["sha"].as_str().unwrap_or_default().to_string(),
+        head_ref: node["source_branch"].as_str().unwrap_or_default().to_string(),
+        merged_at: node["merged_at"].as_str().unwrap_or_default().to_string(),
+        created_at: node["created_at"].as_str().unwrap_or_default().to_string(),
+    })
+}
+
+/// Which admission class an OID lookup belongs to (`specs/forge-host.md` "Resolution").
+#[derive(Clone, Copy)]
+enum OidClass<'a> {
+    /// A publication point: containment admits open and merged MRs.
+    Point,
+    /// An absorbed candidate: only a merged MR whose head is exactly an absorbed commit.
+    Absorbed(&'a [String]),
+    /// The pinned `HEAD`: only an MR whose head is exactly this commit.
+    Head(&'a str),
+}
+
+/// Admit one commit lookup's MR rows into the association under its class's rule. Only MRs
+/// based on the target project count — the numeric id survives renames and transfers.
+fn admit_commit_mrs(assoc: &mut Association, rows: &Value, target_id: u64, class: OidClass<'_>) {
+    for node in rows.as_array().into_iter().flatten() {
+        if node["target_project_id"].as_u64() != Some(target_id) {
+            continue;
+        }
+        let Some(mr) = mr_of(node) else { continue };
+        if let OidClass::Absorbed(absorbed) = class {
+            // An absorbed commit is base history, which proves nothing by containment.
+            // Only the exact parked epilogue admits: a merged MR whose head is an
+            // absorbed commit itself.
+            let exact = absorbed.iter().any(|oid| oid == &mr.head_oid);
+            if exact && node["state"].as_str() == Some("merged") {
+                super::push_unique(&mut assoc.merged, mr);
+            }
+            continue;
+        }
+        if let OidClass::Head(head) = class
+            && mr.head_oid != head
+        {
+            // The pinned HEAD is not published, so containment proves nothing. Only
+            // exact identity admits: the worktree is parked on the MR's own head.
+            continue;
+        }
+        match node["state"].as_str() {
+            Some("opened") => super::push_unique(&mut assoc.open, mr),
+            Some("merged") => super::push_unique(&mut assoc.merged, mr),
+            _ => {}
+        }
+    }
+}
+
+/// Ask GitLab which MRs contain each publication point — one REST commit lookup per
+/// nominated OID against the `source` project, with the closed-unmerged name lookup
+/// against the target riding along (`specs/forge-host.md`). GitLab's GraphQL schema has
+/// no commit→MRs field, so the association reads REST where GitHub reads one aliased
+/// GraphQL call.
+pub(super) fn associate_points(
+    target: &FetchTarget<'_>,
+    source: &crate::git::RepoTarget,
+    points: &[crate::git::PublicationPoint],
+    absorbed: &[String],
+    head: Option<&str>,
+) -> Result<Association, CliError> {
+    // The target's numeric project id is the rename-proof base filter, one read per fetch.
+    // A hidden or vanished target proves nothing — the empty association degrades to the
+    // calm empty state, exactly like GitHub's null target repository.
+    let target_path = percent_encode(&format!("{}/{}", target.owner, target.name));
+    let project = rest_absent_ok(
+        target.repo,
+        target.host,
+        &format!("projects/{target_path}"),
+        target.cancelled,
+    )?;
+    let Some(target_id) = project.as_ref().and_then(|p| p["id"].as_u64()) else {
+        return Ok(Association::default());
+    };
+    let source_path = percent_encode(&format!("{}/{}", source.owner(), source.name()));
+    let mut assoc = Association::default();
+    for (i, oid) in points
+        .iter()
+        .map(|p| p.oid.as_str())
+        .chain(absorbed.iter().map(String::as_str))
+        .chain(head)
+        .enumerate()
+    {
+        let class = if i < points.len() {
+            OidClass::Point
+        } else if i < points.len() + absorbed.len() {
+            OidClass::Absorbed(absorbed)
+        } else {
+            OidClass::Head(oid)
+        };
+        let path =
+            format!("projects/{source_path}/repository/commits/{oid}/merge_requests?per_page=100");
+        let Some(rows) = rest_absent_ok(target.repo, target.host, &path, target.cancelled)? else {
+            // The commit is unknown to the source project — stale local refs, not failure.
+            continue;
+        };
+        admit_commit_mrs(&mut assoc, &rows, target_id, class);
+    }
+    // The closed-unmerged epilogue: one lookup per `(point, tip name)` pair against the
+    // target, capped at 8 pairs like the GitHub aliases. Only an exact head match admits.
+    let pairs: Vec<(usize, &str)> = points
+        .iter()
+        .enumerate()
+        .flat_map(|(i, point)| point.names.iter().map(move |name| (i, name.as_str())))
+        .take(8)
+        .collect();
+    for (i, name) in pairs {
+        let path = format!(
+            "projects/{target_path}/merge_requests?state=closed&source_branch={}\
+             &order_by=created_at&sort=desc&per_page=10",
+            percent_encode(name)
+        );
+        let Some(rows) = rest_absent_ok(target.repo, target.host, &path, target.cancelled)? else {
+            continue;
+        };
+        for node in rows.as_array().into_iter().flatten() {
+            let Some(mr) = mr_of(node) else { continue };
+            if mr.head_oid != points[i].oid {
+                continue;
+            }
+            super::push_unique(&mut assoc.closed, mr);
+        }
+    }
+    Ok(assoc)
+}
+
+/// Project one MR directly: identity, merge status, the head pipeline's jobs, and every
+/// discussion's root note with its reply count. Discussions carry both the MR-level notes
+/// and the inline findings; `first:100` caps each surface and `hasNextPage` flags a fuller
+/// one (`specs/forge-host.md`).
+const DETAIL_QUERY: &str = "query($path:ID!,$iid:String!){project(fullPath:$path){\
+     mergeRequest(iid:$iid){\
+     iid title webUrl description state draft sourceBranch targetBranch \
+     diffHeadSha conflicts detailedMergeStatus \
+     sourceProject{id} targetProject{id} \
+     headPipeline{jobs(retried:false,first:100){pageInfo{hasNextPage} nodes{name status}}} \
+     discussions(first:100){pageInfo{hasNextPage} nodes{resolved \
+     notes(first:1){count nodes{system body createdAt author{username bot} \
+     position{filePath newLine oldLine}}}}}}}}";
+
+/// One MR's state in a single GraphQL call. Returns the MR node and its head OID, or
+/// `None` when the MR vanished between the association and this read.
+pub(super) fn pr_detail(
+    target: &FetchTarget<'_>,
+    number: u64,
+) -> Result<Option<(Value, String)>, CliError> {
+    let vars = vec![
+        ("path".to_string(), format!("{}/{}", target.owner, target.name)),
+        ("iid".to_string(), number.to_string()),
+    ];
+    let mut v = graphql(target.repo, target.host, DETAIL_QUERY, &vars, target.cancelled)?;
+    let node = v["data"]["project"]["mergeRequest"].take();
+    if node.is_null() {
+        return Ok(None);
+    }
+    let head = node["diffHeadSha"].as_str().unwrap_or_default().to_string();
+    Ok(Some((node, head)))
+}
+
+// ---- Pure normalization (unit-tested) --------------------------------------------------
+
+/// Assemble the snapshot from the GraphQL MR node and the computed `sync`.
+pub(super) fn build_snapshot(node: &Value, sync: Sync) -> PrSnapshot {
+    let jobs = &node["headPipeline"]["jobs"];
+    let more = |conn: &Value| conn["pageInfo"]["hasNextPage"].as_bool().unwrap_or(false);
+    let truncated = more(jobs) || more(&node["discussions"]);
+    let source_project = node["sourceProject"]["id"].as_str().unwrap_or_default();
+    let target_project = node["targetProject"]["id"].as_str().unwrap_or_default();
+    PrSnapshot {
+        // GraphQL returns `iid` as a string.
+        number: node["iid"].as_str().and_then(|iid| iid.parse().ok()).unwrap_or_default(),
+        title: node["title"].as_str().unwrap_or_default().to_string(),
+        url: node["webUrl"].as_str().unwrap_or_default().to_string(),
+        body: node["description"].as_str().unwrap_or_default().to_string(),
+        state: parse_state(node["state"].as_str().unwrap_or("opened")),
+        is_draft: node["draft"].as_bool().unwrap_or(false),
+        head_ref: node["sourceBranch"].as_str().unwrap_or_default().to_string(),
+        // A fork MR's source project differs from the target; a deleted source counts too.
+        head_is_fork: source_project != target_project,
+        base_ref: node["targetBranch"].as_str().unwrap_or_default().to_string(),
+        merge: derive_merge(
+            node["conflicts"].as_bool().unwrap_or(false),
+            node["detailedMergeStatus"].as_str(),
+        ),
+        sync,
+        checks: normalize_checks(&jobs["nodes"]),
+        comments: merge_comments(&node["discussions"]["nodes"]),
+        truncated,
+    }
+}
+
+fn parse_state(s: &str) -> PrState {
+    match s {
+        "merged" => PrState::Merged,
+        "closed" => PrState::Closed,
+        _ => PrState::Open,
+    }
+}
+
+/// Fold GitLab's `conflicts` and `detailedMergeStatus` into a [`Merge`]. Only the
+/// actionable blockers surface: conflicts, and the approval/discussion/policy gates a
+/// reviewer acts on. Everything else — mergeable, still-checking, a running pipeline,
+/// need-rebase — folds into `Clean` (shows nothing), mirroring the GitHub fold.
+fn derive_merge(conflicts: bool, status: Option<&str>) -> Merge {
+    if conflicts || status == Some("CONFLICT") {
+        return Merge::Conflicting;
+    }
+    match status {
+        Some(
+            "BLOCKED_STATUS"
+            | "DISCUSSIONS_NOT_RESOLVED"
+            | "EXTERNAL_STATUS_CHECKS"
+            | "JIRA_ASSOCIATION"
+            | "NOT_APPROVED"
+            | "POLICIES_DENIED"
+            | "REQUESTED_CHANGES",
+        ) => Merge::Blocked,
+        _ => Merge::Clean,
+    }
+}
+
+/// The latest job per name from the head pipeline. `retried:false` already excludes
+/// superseded runs; a duplicate name still resolves to the last row.
+fn normalize_checks(jobs: &Value) -> Vec<Check> {
+    let mut out: Vec<Check> = Vec::new();
+    for node in jobs.as_array().into_iter().flatten() {
+        let name = node["name"].as_str().unwrap_or("").to_string();
+        if name.is_empty() {
+            continue;
+        }
+        let status = check_status(node["status"].as_str().unwrap_or(""));
+        if let Some(slot) = out.iter_mut().find(|c| c.name == name) {
+            *slot = Check { name, status };
+        } else {
+            out.push(Check { name, status });
+        }
+    }
+    out
+}
+
+/// One `CiJobStatus` → a [`CheckStatus`]. A manual gate is a skip, not a failure; a
+/// canceled job reads as failed — something needs attention, like GitHub's cancelled
+/// conclusion.
+fn check_status(status: &str) -> CheckStatus {
+    match status {
+        "SUCCESS" => CheckStatus::Success,
+        "FAILED" | "CANCELED" | "CANCELING" => CheckStatus::Failure,
+        "RUNNING" => CheckStatus::Running,
+        "SKIPPED" | "MANUAL" => CheckStatus::Skipped,
+        // CREATED / PENDING / PREPARING / SCHEDULED / WAITING_* — queued work.
+        _ => CheckStatus::Pending,
+    }
+}
+
+/// One newest-first list from the discussion roots: a positioned root is an inline
+/// `finding`, an unpositioned one a plain `comment`. System notes (assignments, review
+/// requests) are noise, not review input. GitLab has no GitHub-style review body, so the
+/// `review` kind never occurs here. A bot's MR-level posts collapse to its latest, like on
+/// GitHub; the bot flag is GitLab's own account marker, which covers service-account bots
+/// whatever their username.
+fn merge_comments(discussions: &Value) -> Vec<Comment> {
+    let mut out: Vec<Comment> = Vec::new();
+    for d in discussions.as_array().into_iter().flatten() {
+        let root = &d["notes"]["nodes"][0];
+        if root["system"].as_bool().unwrap_or(false) {
+            continue;
+        }
+        let body = root["body"].as_str().unwrap_or("").trim().to_string();
+        if body.is_empty() {
+            continue;
+        }
+        let author = &root["author"];
+        let login = author["username"].as_str().unwrap_or("").to_string();
+        let author_is_bot = author["bot"].as_bool().unwrap_or(false);
+        let created_at = root["createdAt"].as_str().unwrap_or("").to_string();
+        let position = &root["position"];
+        if let Some(path) = position["filePath"].as_str() {
+            let line = position["newLine"].as_u64().or_else(|| position["oldLine"].as_u64());
+            out.push(Comment {
+                kind: CommentKind::Finding,
+                author_is_bot,
+                author: login,
+                anchor: match line {
+                    Some(line) => format!("{path}:{line}"),
+                    None => path.to_string(),
+                },
+                body,
+                // GitLab returns no diff hunk with a note.
+                snippet: None,
+                created_at,
+                is_resolved: d["resolved"].as_bool().unwrap_or(false),
+                // GitLab exposes no outdated flag on a discussion; never guessed.
+                is_outdated: false,
+                reply_count: d["notes"]["count"].as_u64().unwrap_or(1).saturating_sub(1) as u32,
+            });
+        } else {
+            out.push(Comment {
+                kind: CommentKind::Comment,
+                author_is_bot,
+                author: login,
+                anchor: "comment".to_string(),
+                body,
+                snippet: None,
+                created_at,
+                is_resolved: false,
+                is_outdated: false,
+                reply_count: 0,
+            });
+        }
+    }
+    super::dedup_bot_prose(&mut out);
+    // Newest first: ISO-8601 `…Z` strings sort lexically in chronological order.
+    out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_surfaces_only_conflicts_and_reviewer_actionable_blockers() {
+        assert_eq!(derive_merge(true, Some("MERGEABLE")), Merge::Conflicting);
+        assert_eq!(derive_merge(false, Some("CONFLICT")), Merge::Conflicting);
+        assert_eq!(derive_merge(false, Some("NOT_APPROVED")), Merge::Blocked);
+        assert_eq!(derive_merge(false, Some("DISCUSSIONS_NOT_RESOLVED")), Merge::Blocked);
+        assert_eq!(derive_merge(false, Some("POLICIES_DENIED")), Merge::Blocked);
+        // Everything non-actionable folds into Clean: mergeable, checking, CI, rebase.
+        assert_eq!(derive_merge(false, Some("MERGEABLE")), Merge::Clean);
+        assert_eq!(derive_merge(false, Some("CHECKING")), Merge::Clean);
+        assert_eq!(derive_merge(false, Some("CI_STILL_RUNNING")), Merge::Clean);
+        assert_eq!(derive_merge(false, Some("NEED_REBASE")), Merge::Clean);
+        assert_eq!(derive_merge(false, Some("NOT_OPEN")), Merge::Clean);
+        assert_eq!(derive_merge(false, None), Merge::Clean);
+    }
+
+    #[test]
+    fn parse_state_maps_the_gitlab_lifecycles() {
+        assert_eq!(parse_state("merged"), PrState::Merged);
+        assert_eq!(parse_state("closed"), PrState::Closed);
+        assert_eq!(parse_state("opened"), PrState::Open);
+        assert_eq!(parse_state("locked"), PrState::Open); // transient mid-merge → live
+    }
+
+    #[test]
+    fn job_statuses_fold_to_check_statuses() {
+        let jobs = serde_json::json!([
+            {"name": "tests", "status": "SUCCESS"},
+            {"name": "build", "status": "RUNNING"},
+            {"name": "deploy", "status": "MANUAL"},
+            {"name": "lint", "status": "SKIPPED"},
+            {"name": "e2e", "status": "FAILED"},
+            {"name": "scan", "status": "CANCELED"},
+            {"name": "later", "status": "SCHEDULED"}
+        ]);
+        let checks = normalize_checks(&jobs);
+        let status = |name: &str| checks.iter().find(|c| c.name == name).unwrap().status;
+        assert_eq!(status("tests"), CheckStatus::Success);
+        assert_eq!(status("build"), CheckStatus::Running);
+        // A manual gate neither fails nor blocks the rollup.
+        assert_eq!(status("deploy"), CheckStatus::Skipped);
+        assert_eq!(status("lint"), CheckStatus::Skipped);
+        assert_eq!(status("e2e"), CheckStatus::Failure);
+        assert_eq!(status("scan"), CheckStatus::Failure);
+        assert_eq!(status("later"), CheckStatus::Pending);
+    }
+
+    fn detail_node() -> Value {
+        serde_json::json!({
+            "iid": "81", "title": "t", "webUrl": "u", "description": "## Summary",
+            "state": "opened", "draft": true, "sourceBranch": "feat/x", "targetBranch": "main",
+            "diffHeadSha": "abc", "conflicts": false, "detailedMergeStatus": "MERGEABLE",
+            "sourceProject": {"id": "gid://gitlab/Project/1"},
+            "targetProject": {"id": "gid://gitlab/Project/1"},
+            "headPipeline": {"jobs": {"pageInfo": {"hasNextPage": false}, "nodes": []}},
+            "discussions": {"pageInfo": {"hasNextPage": false}, "nodes": []}
+        })
+    }
+
+    #[test]
+    fn snapshot_parses_the_string_iid_and_carries_identity() {
+        let s = build_snapshot(&detail_node(), Sync::InSync);
+        assert_eq!(s.number, 81);
+        assert_eq!(s.body, "## Summary");
+        assert_eq!(s.state, PrState::Open);
+        assert!(s.is_draft);
+        assert_eq!(s.head_ref, "feat/x");
+        assert_eq!(s.base_ref, "main");
+        assert!(!s.head_is_fork);
+        assert!(!s.truncated);
+        // Absent fields default rather than fail — a mid-rollout API response degrades soft.
+        let bare = serde_json::json!({"iid": "5"});
+        let s = build_snapshot(&bare, Sync::InSync);
+        assert_eq!(s.number, 5);
+        assert_eq!(s.head_ref, "");
+    }
+
+    #[test]
+    fn a_differing_or_deleted_source_project_marks_the_fork() {
+        let mut fork = detail_node();
+        fork["sourceProject"]["id"] = serde_json::json!("gid://gitlab/Project/2");
+        assert!(build_snapshot(&fork, Sync::InSync).head_is_fork);
+        let mut deleted = detail_node();
+        deleted["sourceProject"] = serde_json::Value::Null;
+        assert!(build_snapshot(&deleted, Sync::InSync).head_is_fork);
+    }
+
+    #[test]
+    fn truncated_flips_when_jobs_or_discussions_have_a_next_page() {
+        let mut jobs_more = detail_node();
+        jobs_more["headPipeline"]["jobs"]["pageInfo"]["hasNextPage"] = serde_json::json!(true);
+        assert!(build_snapshot(&jobs_more, Sync::InSync).truncated);
+        let mut discussions_more = detail_node();
+        discussions_more["discussions"]["pageInfo"]["hasNextPage"] = serde_json::json!(true);
+        assert!(build_snapshot(&discussions_more, Sync::InSync).truncated);
+    }
+
+    #[test]
+    fn discussions_split_into_findings_and_comments_and_skip_system_noise() {
+        let discussions = serde_json::json!([
+            {"resolved": false, "notes": {"count": 1, "nodes": [
+                {"system": true, "body": "assigned to @sean", "createdAt": "2026-07-21T10:00:00Z",
+                 "author": {"username": "sean", "bot": false}, "position": null}]}},
+            {"resolved": true, "notes": {"count": 3, "nodes": [
+                {"system": false, "body": "off-by-one here", "createdAt": "2026-07-21T11:00:00Z",
+                 "author": {"username": "reviewer", "bot": false},
+                 "position": {"filePath": "src/a.rs", "newLine": 10, "oldLine": null}}]}},
+            {"resolved": false, "notes": {"count": 1, "nodes": [
+                {"system": false, "body": "please add a changelog entry", "createdAt": "2026-07-21T12:00:00Z",
+                 "author": {"username": "reviewer", "bot": false}, "position": null}]}}
+        ]);
+        let cs = merge_comments(&discussions);
+        assert_eq!(cs.len(), 2, "the system note is dropped");
+        // Newest first across both kinds.
+        assert_eq!(cs[0].kind, CommentKind::Comment);
+        assert_eq!(cs[0].anchor, "comment");
+        let f = &cs[1];
+        assert_eq!(f.kind, CommentKind::Finding);
+        assert_eq!(f.anchor, "src/a.rs:10");
+        assert!(f.is_resolved);
+        assert!(!f.is_outdated, "GitLab has no outdated flag; never guessed");
+        assert_eq!(f.reply_count, 2);
+        assert_eq!(f.snippet, None, "GitLab returns no diff hunk");
+    }
+
+    #[test]
+    fn a_service_accounts_prose_collapses_by_the_bot_flag_not_its_name() {
+        // GitLab bots carry no `[bot]` suffix — renovate runs as `group_…_bot_…` — so the
+        // account's own `bot` marker drives the collapse.
+        let note = |body: &str, at: &str| {
+            serde_json::json!({"resolved": false, "notes": {"count": 1, "nodes": [
+                {"system": false, "body": body, "createdAt": at,
+                 "author": {"username": "group_17406_bot_1", "bot": true}, "position": null}]}})
+        };
+        let discussions = serde_json::json!([
+            note("old status", "2026-07-21T09:00:00Z"),
+            note("new status", "2026-07-21T10:00:00Z")
+        ]);
+        let cs = merge_comments(&discussions);
+        assert_eq!(cs.len(), 1, "only the bot's latest MR-level post survives");
+        assert_eq!(cs[0].body, "new status");
+        assert!(cs[0].author_is_bot);
+    }
+
+    #[test]
+    fn commit_rows_admit_by_class_and_filter_on_the_target_project() {
+        let row = |iid: u64, state: &str, sha: &str, project: u64| {
+            serde_json::json!({"iid": iid, "state": state, "sha": sha,
+                "source_branch": "feat", "merged_at": null, "created_at": "2026-07-01T00:00:00Z",
+                "target_project_id": project})
+        };
+        let rows = serde_json::json!([
+            row(7, "opened", "abc", 1),
+            row(8, "merged", "def", 1),
+            row(9, "opened", "zzz", 2), // based elsewhere → dropped
+            row(7, "opened", "abc", 1)  // duplicate → collapses
+        ]);
+        let mut assoc = Association::default();
+        admit_commit_mrs(&mut assoc, &rows, 1, OidClass::Point);
+        assert_eq!(assoc.open.iter().map(|p| p.number).collect::<Vec<_>>(), [7]);
+        assert_eq!(assoc.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [8]);
+
+        // The absorbed class admits only a merged MR whose head IS the absorbed commit.
+        let rows = serde_json::json!([
+            row(10, "merged", "parked", 1),
+            row(11, "merged", "other", 1),
+            row(12, "opened", "parked", 1)
+        ]);
+        let absorbed = vec!["parked".to_string()];
+        let mut assoc = Association::default();
+        admit_commit_mrs(&mut assoc, &rows, 1, OidClass::Absorbed(&absorbed));
+        assert_eq!(assoc.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [10]);
+        assert!(assoc.open.is_empty());
+
+        // The head class admits only an exact head match, open or merged.
+        let rows = serde_json::json!([
+            row(13, "merged", "tip", 1),
+            row(14, "opened", "tip", 1),
+            row(15, "opened", "other", 1)
+        ]);
+        let mut assoc = Association::default();
+        admit_commit_mrs(&mut assoc, &rows, 1, OidClass::Head("tip"));
+        assert_eq!(assoc.open.iter().map(|p| p.number).collect::<Vec<_>>(), [14]);
+        assert_eq!(assoc.merged.iter().map(|p| p.number).collect::<Vec<_>>(), [13]);
+    }
+
+    #[test]
+    fn nested_namespaces_and_branch_names_percent_encode() {
+        assert_eq!(percent_encode("group/sub/repo"), "group%2Fsub%2Frepo");
+        assert_eq!(percent_encode("feat/kms-signing"), "feat%2Fkms-signing");
+        assert_eq!(percent_encode("release-1.0_x~y"), "release-1.0_x~y");
+        assert_eq!(percent_encode("a b#c"), "a%20b%23c");
+    }
+
+    #[test]
+    fn glab_failure_classifies_by_stderr_wording() {
+        assert_eq!(
+            classify_failure(
+                "To get started with GitLab CLI, please run: glab auth login",
+                "gitlab.example.test"
+            ),
+            CliError::NotAuthed(Forge::GitLab, "gitlab.example.test".to_string())
+        );
+        assert_eq!(
+            classify_failure("glab: 401 Unauthorized (HTTP 401)", "gitlab.com"),
+            CliError::NotAuthed(Forge::GitLab, "gitlab.com".to_string())
+        );
+        assert_eq!(
+            classify_failure("HTTP 500 something", "gitlab.com"),
+            CliError::Other("HTTP 500 something".into())
+        );
+    }
+}

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -282,6 +282,7 @@ pub(super) fn build_snapshot(node: &Value, sync: Sync) -> PrSnapshot {
     let source_project = node["sourceProject"]["id"].as_str().unwrap_or_default();
     let target_project = node["targetProject"]["id"].as_str().unwrap_or_default();
     PrSnapshot {
+        forge: Forge::GitLab,
         // GraphQL returns `iid` as a string.
         number: node["iid"].as_str().and_then(|iid| iid.parse().ok()).unwrap_or_default(),
         title: node["title"].as_str().unwrap_or_default().to_string(),

--- a/src/git.rs
+++ b/src/git.rs
@@ -64,22 +64,64 @@ pub fn toplevel(path: &Path) -> Option<PathBuf> {
     git_line(path, &["rev-parse", "--show-toplevel"]).map(PathBuf::from)
 }
 
-/// A canonical GitHub API and repository target.
+/// Which forge a canonical host belongs to — decides the CLI and API dialect.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Forge {
+    GitHub,
+    GitLab,
+}
+
+impl Forge {
+    /// The user-facing forge name.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::GitHub => "GitHub",
+            Self::GitLab => "GitLab",
+        }
+    }
+
+    /// The CLI this forge is read through.
+    pub fn cli(self) -> &'static str {
+        match self {
+            Self::GitHub => "gh",
+            Self::GitLab => "glab",
+        }
+    }
+}
+
+/// The configured self-managed hosts, one per forge kind (`specs/forge-host.md`).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ForgeHosts<'a> {
+    pub github: Option<&'a str>,
+    pub gitlab: Option<&'a str>,
+}
+
+/// A canonical forge API and repository target.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RepoTarget {
+    forge: Forge,
     host: String,
     owner: String,
     name: String,
 }
 
 impl RepoTarget {
-    /// Build one canonical repository target from a hostname and GitHub owner/name pair.
-    pub(crate) fn new(host: &str, owner: &str, name: &str) -> Option<Self> {
+    /// Build one canonical repository target from a hostname and owner/name pair. A GitHub
+    /// owner is one path segment; a GitLab owner is the full namespace path, whose groups
+    /// may nest (`a/b/c`).
+    pub(crate) fn new(forge: Forge, host: &str, owner: &str, name: &str) -> Option<Self> {
         let host = host.to_ascii_lowercase();
-        (crate::config::valid_host_syntax(&host)
-            && valid_repository_component(owner)
-            && valid_repository_component(name))
-        .then(|| Self { host, owner: owner.to_owned(), name: name.to_owned() })
+        let owner_valid = match forge {
+            Forge::GitHub => valid_repository_component(owner),
+            Forge::GitLab => owner.split('/').all(valid_repository_component),
+        };
+        (crate::config::valid_host_syntax(&host) && owner_valid && valid_repository_component(name))
+            .then(|| Self { forge, host, owner: owner.to_owned(), name: name.to_owned() })
+    }
+
+    /// The forge this target is read through.
+    pub fn forge(&self) -> Forge {
+        self.forge
     }
 
     /// The lowercase canonical forge hostname.
@@ -87,12 +129,12 @@ impl RepoTarget {
         &self.host
     }
 
-    /// The repository owner used at the GitHub API boundary.
+    /// The repository owner used at the forge API boundary — the full namespace path on GitLab.
     pub fn owner(&self) -> &str {
         &self.owner
     }
 
-    /// The repository name used at the GitHub API boundary.
+    /// The repository name used at the forge API boundary.
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -124,8 +166,8 @@ enum RemoteTransport {
     Unsupported,
 }
 
-/// Classify one repository URL against GitHub.com and the configured Enterprise host.
-fn classify_remote(url: &str, enterprise: Option<&str>) -> RepositoryIdentity {
+/// Classify one repository URL against the built-in hosts and the configured self-managed hosts.
+fn classify_remote(url: &str, hosts: ForgeHosts<'_>) -> RepositoryIdentity {
     let Some((transport, host, path, has_port)) = split_remote(url) else {
         return RepositoryIdentity::Hostless;
     };
@@ -138,25 +180,44 @@ fn classify_remote(url: &str, enterprise: Option<&str>) -> RepositoryIdentity {
     {
         return RepositoryIdentity::Unsupported(host);
     }
-    let Some(canonical) = canonical_supported_host(&host, enterprise) else {
+    let Some((canonical, forge)) = canonical_supported_host(&host, hosts) else {
         return RepositoryIdentity::Unsupported(host);
     };
     let path = path.trim_matches('/');
     let path = path.strip_suffix(".git").unwrap_or(path);
-    let mut parts = path.split('/');
-    let (Some(owner), Some(name), None) = (parts.next(), parts.next(), parts.next()) else {
-        return RepositoryIdentity::Malformed(canonical);
+    let (owner, name) = match forge {
+        // A GitHub identity is exactly `owner/repository`.
+        Forge::GitHub => {
+            let mut parts = path.split('/');
+            match (parts.next(), parts.next(), parts.next()) {
+                (Some(owner), Some(name), None) => (owner, name),
+                _ => return RepositoryIdentity::Malformed(canonical),
+            }
+        }
+        // GitLab groups nest, so the namespace is every segment before the repository name.
+        Forge::GitLab => match path.rsplit_once('/') {
+            Some((namespace, name)) => (namespace, name),
+            None => return RepositoryIdentity::Malformed(canonical),
+        },
     };
-    match RepoTarget::new(&canonical, owner, name) {
+    match RepoTarget::new(forge, &canonical, owner, name) {
         Some(target) => RepositoryIdentity::Repository(target),
         None => RepositoryIdentity::Malformed(canonical),
     }
 }
 
-/// Return the exact GitHub.com or configured Enterprise host, lowercased.
-fn canonical_supported_host(host: &str, enterprise: Option<&str>) -> Option<String> {
+/// Return the exact supported host, lowercased, with its forge: `github.com` / `gitlab.com`
+/// built in, plus the configured self-managed host of each forge.
+fn canonical_supported_host(host: &str, hosts: ForgeHosts<'_>) -> Option<(String, Forge)> {
     let host = host.to_ascii_lowercase();
-    (host == "github.com" || enterprise == Some(host.as_str())).then_some(host)
+    let forge = if host == "github.com" || hosts.github == Some(host.as_str()) {
+        Forge::GitHub
+    } else if host == "gitlab.com" || hosts.gitlab == Some(host.as_str()) {
+        Forge::GitLab
+    } else {
+        return None;
+    };
+    Some((host, forge))
 }
 
 /// Split a Git remote URL into transport, host, and path for scheme and scp-style forms.
@@ -444,10 +505,10 @@ fn beyond_all_bases(repo: &Path, oid: &str, bases: &[String]) -> Result<bool, Gi
 /// association source, not the whole read.
 pub(crate) fn remote_identities(
     repo: &Path,
-    github_host: Option<&str>,
+    hosts: ForgeHosts<'_>,
 ) -> Result<(RepositoryIdentity, Option<RepoTarget>), GitFail> {
-    let upstream = remote_identity(repo, "upstream", github_host)?;
-    let origin = remote_identity(repo, "origin", github_host);
+    let upstream = remote_identity(repo, "upstream", hosts)?;
+    let origin = remote_identity(repo, "origin", hosts);
     let origin_target = match &origin {
         Ok(RepositoryIdentity::Repository(target)) => Some(target.clone()),
         _ => None,
@@ -462,14 +523,14 @@ pub(crate) fn remote_identities(
 fn remote_identity(
     repo: &Path,
     remote: &str,
-    github_host: Option<&str>,
+    hosts: ForgeHosts<'_>,
 ) -> Result<RepositoryIdentity, GitFail> {
     let args = ["remote", "get-url", "--", remote];
     let out = run_git(repo, &args)?;
     if out.status.success() {
         let url = std::str::from_utf8(&out.stdout)
             .map_err(|_| GitFail(format!("git remote get-url {remote}: invalid UTF-8")))?;
-        return Ok(classify_remote(url.trim(), github_host));
+        return Ok(classify_remote(url.trim(), hosts));
     }
     let stderr = String::from_utf8_lossy(&out.stderr);
     if stderr.to_lowercase().contains("no such remote") {
@@ -920,124 +981,178 @@ fn parse_name_status(out: &str) -> Vec<(ChangeKind, String, Option<String>)> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ChangeKind, RepoTarget, RepositoryIdentity, classify_remote, parse_name_status,
-        parse_numstat,
+        ChangeKind, Forge, ForgeHosts, RepoTarget, RepositoryIdentity, classify_remote,
+        parse_name_status, parse_numstat,
     };
+
+    fn none() -> ForgeHosts<'static> {
+        ForgeHosts::default()
+    }
+
+    fn github(host: &'static str) -> ForgeHosts<'static> {
+        ForgeHosts { github: Some(host), gitlab: None }
+    }
+
+    fn gitlab(host: &'static str) -> ForgeHosts<'static> {
+        ForgeHosts { github: None, gitlab: Some(host) }
+    }
 
     #[test]
     fn repository_identity_parses_github_and_enterprise_remote_forms() {
         let repo = |host: &str, owner: &str, name: &str| {
-            RepositoryIdentity::Repository(RepoTarget::new(host, owner, name).unwrap())
+            RepositoryIdentity::Repository(
+                RepoTarget::new(Forge::GitHub, host, owner, name).unwrap(),
+            )
         };
         // HTTPS, with and without `.git` and a trailing slash.
         assert_eq!(
-            classify_remote("https://github.com/owner/repo.git", None),
+            classify_remote("https://github.com/owner/repo.git", none()),
             repo("github.com", "owner", "repo")
         );
         assert_eq!(
-            classify_remote("https://github.com/owner/repo", None),
+            classify_remote("https://github.com/owner/repo", none()),
             repo("github.com", "owner", "repo")
         );
         assert_eq!(
-            classify_remote("https://github.com/owner/repo/", None),
+            classify_remote("https://github.com/owner/repo/", none()),
             repo("github.com", "owner", "repo")
         );
         // scp-like SSH, and the `ssh://` scheme form with a port.
         assert_eq!(
-            classify_remote("git@github.com:owner/repo.git", None),
+            classify_remote("git@github.com:owner/repo.git", none()),
             repo("github.com", "owner", "repo")
         );
         assert_eq!(
-            classify_remote("ssh://git@github.com/owner/repo.git", None),
+            classify_remote("ssh://git@github.com/owner/repo.git", none()),
             repo("github.com", "owner", "repo")
         );
         assert_eq!(
-            classify_remote("ssh://git@github.com:22/owner/repo.git", None),
+            classify_remote("ssh://git@github.com:22/owner/repo.git", none()),
             repo("github.com", "owner", "repo")
         );
         assert_eq!(
-            classify_remote("git://github.com/owner/repo", None),
+            classify_remote("git://github.com/owner/repo", none()),
             repo("github.com", "owner", "repo")
         );
         assert_eq!(
             classify_remote(
                 "https://github.company.com/owner/repo.git",
-                Some("github.company.com")
+                github("github.company.com")
             ),
             repo("github.company.com", "owner", "repo")
         );
     }
 
     #[test]
+    fn repository_identity_parses_gitlab_remote_forms_with_nested_namespaces() {
+        let repo = |host: &str, owner: &str, name: &str| {
+            RepositoryIdentity::Repository(
+                RepoTarget::new(Forge::GitLab, host, owner, name).unwrap(),
+            )
+        };
+        assert_eq!(
+            classify_remote("https://gitlab.com/owner/repo.git", none()),
+            repo("gitlab.com", "owner", "repo")
+        );
+        // Groups nest: everything before the repository name is the namespace.
+        assert_eq!(
+            classify_remote("git@gitlab.com:group/sub/team/repo.git", none()),
+            repo("gitlab.com", "group/sub/team", "repo")
+        );
+        assert_eq!(
+            classify_remote(
+                "https://gitlab.example.test/a/b/c/d/repo.git",
+                gitlab("gitlab.example.test")
+            ),
+            repo("gitlab.example.test", "a/b/c/d", "repo")
+        );
+        // A GitLab path still needs a namespace and a repository name.
+        assert_eq!(
+            classify_remote("https://gitlab.com/repo-only", none()),
+            RepositoryIdentity::Malformed("gitlab.com".to_string())
+        );
+        assert_eq!(
+            classify_remote("https://gitlab.com", none()),
+            RepositoryIdentity::Malformed("gitlab.com".to_string())
+        );
+        // A self-managed GitLab host is unsupported until configured.
+        assert_eq!(
+            classify_remote("https://gitlab.example.test/group/repo.git", none()),
+            RepositoryIdentity::Unsupported("gitlab.example.test".to_string())
+        );
+    }
+
+    #[test]
     fn repository_identity_rejects_aliases_and_keeps_failure_states_distinct() {
         assert_eq!(
-            classify_remote("git@github.com-work:owner/repo.git", None),
+            classify_remote("git@github.com-work:owner/repo.git", none()),
             RepositoryIdentity::Unsupported("github.com-work".to_string())
         );
         assert_eq!(
             classify_remote(
                 "git@github.company.com-work:owner/repo.git",
-                Some("github.company.com")
+                github("github.company.com")
             ),
             RepositoryIdentity::Unsupported("github.company.com-work".to_string())
         );
         assert_eq!(
-            classify_remote("https://github.com-attacker/owner/repo", None),
+            classify_remote("https://github.com-attacker/owner/repo", none()),
             RepositoryIdentity::Unsupported("github.com-attacker".to_string())
         );
         assert_eq!(
             classify_remote(
                 "https://github.company.com-work/owner/repo",
-                Some("github.company.com")
+                github("github.company.com")
             ),
             RepositoryIdentity::Unsupported("github.company.com-work".to_string())
         );
         assert_eq!(
-            classify_remote("git@gitlab.com:owner/repo.git", Some("github.company.com")),
-            RepositoryIdentity::Unsupported("gitlab.com".to_string())
+            classify_remote("git@bitbucket.org:owner/repo.git", github("github.company.com")),
+            RepositoryIdentity::Unsupported("bitbucket.org".to_string())
         );
         assert_eq!(
-            classify_remote("https://github.com/owner", None),
+            classify_remote("https://github.com/owner", none()),
             RepositoryIdentity::Malformed("github.com".to_string())
         );
         assert_eq!(
-            classify_remote("https://github.com", None),
+            classify_remote("https://github.com", none()),
             RepositoryIdentity::Malformed("github.com".to_string())
-        );
-        assert_eq!(
-            classify_remote("https://gitlab.com", None),
-            RepositoryIdentity::Unsupported("gitlab.com".to_string())
         );
         assert_eq!(
             classify_remote(
                 "https://github.company.com:8443/owner/repo.git",
-                Some("github.company.com")
+                github("github.company.com")
             ),
             RepositoryIdentity::Unsupported("github.company.com".to_string())
         );
-        assert_eq!(classify_remote("/tmp/repo", None), RepositoryIdentity::Hostless);
-        assert_eq!(classify_remote("file:///tmp/repo", None), RepositoryIdentity::Hostless);
+        assert_eq!(classify_remote("/tmp/repo", none()), RepositoryIdentity::Hostless);
+        assert_eq!(classify_remote("file:///tmp/repo", none()), RepositoryIdentity::Hostless);
         assert_eq!(
-            classify_remote("file://github.com/owner/repo", None),
+            classify_remote("file://github.com/owner/repo", none()),
             RepositoryIdentity::Unsupported("github.com".to_string())
         );
         assert_eq!(
-            classify_remote("ftp://github.com/owner/repo", None),
+            classify_remote("ftp://github.com/owner/repo", none()),
             RepositoryIdentity::Unsupported("github.com".to_string())
         );
     }
 
     #[test]
     fn repository_target_enforces_its_canonical_shape() {
-        let target = RepoTarget::new("GitHub.COM", "owner", "repo").unwrap();
+        let target = RepoTarget::new(Forge::GitHub, "GitHub.COM", "owner", "repo").unwrap();
         assert_eq!(target.host(), "github.com");
         assert_eq!(target.owner(), "owner");
         assert_eq!(target.name(), "repo");
-        assert!(RepoTarget::new("bad host", "owner", "repo").is_none());
-        assert!(RepoTarget::new("github.com", ".", "repo").is_none());
-        assert!(RepoTarget::new("github.com", "owner/name", "repo").is_none());
-        assert!(RepoTarget::new("github.com", "owner", "bad\nname").is_none());
-        assert!(RepoTarget::new("github.com", "owner", "bad\u{202e}name").is_none());
+        assert!(RepoTarget::new(Forge::GitHub, "bad host", "owner", "repo").is_none());
+        assert!(RepoTarget::new(Forge::GitHub, "github.com", ".", "repo").is_none());
+        assert!(RepoTarget::new(Forge::GitHub, "github.com", "owner/name", "repo").is_none());
+        assert!(RepoTarget::new(Forge::GitHub, "github.com", "owner", "bad\nname").is_none());
+        assert!(RepoTarget::new(Forge::GitHub, "github.com", "owner", "bad\u{202e}name").is_none());
+        // A GitLab namespace admits nesting; each segment still validates.
+        assert!(RepoTarget::new(Forge::GitLab, "gitlab.com", "group/sub", "repo").is_some());
+        assert!(RepoTarget::new(Forge::GitLab, "gitlab.com", "group//sub", "repo").is_none());
+        assert!(RepoTarget::new(Forge::GitLab, "gitlab.com", "group/..", "repo").is_none());
+        assert!(RepoTarget::new(Forge::GitLab, "gitlab.com", "group", "sub/repo").is_none());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1084,7 +1084,9 @@ fn reconcile_plugin_config(
 
     let bases_changed = previous.base_branches() != current.base_branches();
     let file_changed = bases_changed || previous.theme() != current.theme();
-    let pr_changed = bases_changed || previous.github_host() != current.github_host();
+    let pr_changed = bases_changed
+        || previous.github_host() != current.github_host()
+        || previous.gitlab_host() != current.gitlab_host();
     if pr_changed {
         pr.config_changed(app.tab == crate::app::Tab::Pr);
     }
@@ -1150,6 +1152,7 @@ fn apply_plugin_config_observation(
                 let current = app.plugin_config().expect("ready config");
                 if current.base_branches() != next.base_branches()
                     || current.github_host() != next.github_host()
+                    || current.gitlab_host() != next.gitlab_host()
                 {
                     *epoch = epoch.wrapping_add(1);
                 }
@@ -1666,7 +1669,7 @@ mod refresh_tests {
     fn input_with(host: &str, owner: &str, name: &str, head: &str) -> PrFetchInput {
         PrFetchInput {
             repository: RepositoryIdentity::Repository(
-                crate::git::RepoTarget::new(host, owner, name).unwrap(),
+                crate::git::RepoTarget::new(crate::git::Forge::GitHub, host, owner, name).unwrap(),
             ),
             origin_repository: None,
             local: crate::git::PrLocalState {
@@ -2035,7 +2038,13 @@ mod refresh_tests {
             &mut app,
             &mut coordinator,
             Err(crate::forge::PrInputError::BranchState {
-                target: crate::git::RepoTarget::new("github.com", "acme", "widgets").unwrap(),
+                target: crate::git::RepoTarget::new(
+                    crate::git::Forge::GitHub,
+                    "github.com",
+                    "acme",
+                    "widgets"
+                )
+                .unwrap(),
                 message: "HEAD read failed".to_string(),
             }),
             0,
@@ -2058,7 +2067,13 @@ mod refresh_tests {
             &mut app,
             &mut coordinator,
             Err(crate::forge::PrInputError::BranchState {
-                target: crate::git::RepoTarget::new("github.com", "other", "widgets").unwrap(),
+                target: crate::git::RepoTarget::new(
+                    crate::git::Forge::GitHub,
+                    "github.com",
+                    "other",
+                    "widgets"
+                )
+                .unwrap(),
                 message: "HEAD read failed".to_string(),
             }),
             0,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2786,20 +2786,20 @@ fn pr_empty_msg(view: &forge::PrView, refresh: crate::keymap::Key) -> String {
         forge::PrView::Ambiguous(n) => {
             format!("Found {n} open PRs containing this work. Keep one open, then press {refresh}.")
         }
-        forge::PrView::NoGh
-        | forge::PrView::NotAuthed(_)
+        forge::PrView::NoCli(_)
+        | forge::PrView::NotAuthed(_, _)
         | forge::PrView::GitError(_)
         | forge::PrView::Error(_) => {
             unreachable!("retry failures returned above")
         }
-        forge::PrView::NeedsGitHubRemote => {
-            "PRs need a GitHub remote named upstream or origin.".into()
+        forge::PrView::NeedsForgeRemote => {
+            "PRs need a GitHub or GitLab remote named upstream or origin.".into()
         }
         forge::PrView::UnsupportedHost(host) => {
-            format!("Unsupported host: {host}. Using GitHub Enterprise? Set `github_host`.")
+            format!("Unsupported host: {host}. Self-managed? Set `github_host` or `gitlab_host`.")
         }
         forge::PrView::MalformedOrigin(host) => {
-            format!("The origin remote must point to a GitHub owner/repository on {host}.")
+            format!("The origin remote must point to a repository path on {host}.")
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2442,10 +2442,10 @@ fn pr_state_line(s: &forge::PrSnapshot) -> String {
     }
     parts.push(checks_summary(s));
     parts.push(format!("{} comments", s.comments.len()));
-    // A capped surface means the lists are a prefix; point at GitHub for the rest rather than
-    // showing the partial counts as if complete (specs/forge-host.md).
+    // A capped surface means the lists are a prefix; point at the forge for the rest rather
+    // than showing the partial counts as if complete (specs/forge-host.md).
     if s.truncated {
-        parts.push("+more on GitHub ↗".into());
+        parts.push(format!("+more on {} ↗", s.forge.name()));
     }
     parts.join(" · ")
 }
@@ -2733,9 +2733,10 @@ fn render_pr_read(frame: &mut Frame, app: &App, area: Rect) {
         body_meta = Some((offset, rendered));
         if cm.reply_count > 0 {
             let plural = if cm.reply_count == 1 { "reply" } else { "replies" };
+            let forge = app.pr_snapshot().map_or("the forge", |s| s.forge.name());
             lines.push(Line::raw(""));
             lines.push(Line::from(Span::styled(
-                format!("↳ {} {plural} — open on GitHub to read", cm.reply_count),
+                format!("↳ {} {plural} — open on {forge} to read", cm.reply_count),
                 Style::default().fg(p.overlay0),
             )));
         }

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -2743,7 +2743,10 @@ fn same_input_failure_preserves_any_visible_pr_snapshot_and_remedy() {
     let no_pr = PrView::NoPr;
     app.apply_pr(no_pr.clone());
 
-    app.apply_pr(PrView::NotAuthed("github.example.com".to_string()));
+    app.apply_pr(PrView::NotAuthed(
+        herdr_reviewr::git::Forge::GitHub,
+        "github.example.com".to_string(),
+    ));
 
     assert_eq!(app.pr, no_pr);
     assert_eq!(
@@ -3175,7 +3178,10 @@ fn the_pr_remedy_names_the_rebound_refresh_key() {
     app.set_plugin_config(config);
     app.apply_pr(PrView::NoPr);
 
-    app.apply_pr(PrView::NotAuthed("github.example.com".to_string()));
+    app.apply_pr(PrView::NotAuthed(
+        herdr_reviewr::git::Forge::GitHub,
+        "github.example.com".to_string(),
+    ));
 
     assert!(
         app.pr_notice().is_some_and(|notice| notice.ends_with("then press R.")),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -89,6 +89,7 @@ pub fn typed(app: &mut App, text: &str) {
 pub fn pr_snapshot() -> herdr_reviewr::forge::PrSnapshot {
     use herdr_reviewr::forge::{Merge, PrSnapshot, PrState, Sync};
     PrSnapshot {
+        forge: herdr_reviewr::git::Forge::GitHub,
         number: 1,
         title: "t".into(),
         body: String::new(),

--- a/tests/pr_candidates.rs
+++ b/tests/pr_candidates.rs
@@ -77,7 +77,7 @@ fn an_unusable_upstream_falls_back_to_origin() {
     repo.git(&["remote", "add", "upstream", repo.path().to_str().unwrap()]);
     assert_target(&selected().repository, "github.com", "acme", "widgets");
 
-    repo.git(&["remote", "set-url", "upstream", "https://gitlab.com/other/widgets.git"]);
+    repo.git(&["remote", "set-url", "upstream", "https://bitbucket.org/other/widgets.git"]);
     assert_target(&selected().repository, "github.com", "acme", "widgets");
 
     repo.git(&["remote", "set-url", "upstream", "https://github.com/acme"]);
@@ -112,6 +112,31 @@ fn a_github_com_prefixed_host_is_only_supported_when_configured_literally() {
     let config = plugin_config_in(config_dir.path()).unwrap();
     let input = fetch_input(repo.path(), None, &config).unwrap();
     assert_target(&input.repository, "github.com-work", "enterprise", "widgets");
+}
+
+#[test]
+fn a_gitlab_origin_resolves_with_its_nested_namespace() {
+    let repo = worktree();
+    repo.git(&["remote", "set-url", "origin", "https://gitlab.com/group/sub/widgets.git"]);
+    let input = fetch_input(repo.path(), None, &defaults()).unwrap();
+    assert_target(&input.repository, "gitlab.com", "group/sub", "widgets");
+
+    // A self-managed GitLab host resolves only when configured, like GitHub Enterprise.
+    repo.git(&["remote", "set-url", "origin", "git@gitlab.example.test:a/b/c/widgets.git"]);
+    let input = fetch_input(repo.path(), None, &defaults()).unwrap();
+    assert!(
+        matches!(&input.repository, RepositoryIdentity::Unsupported(host) if host == "gitlab.example.test")
+    );
+
+    let config_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        config_dir.path().join("config.toml"),
+        "gitlab_host = \"gitlab.example.test\"\n",
+    )
+    .unwrap();
+    let config = plugin_config_in(config_dir.path()).unwrap();
+    let input = fetch_input(repo.path(), None, &config).unwrap();
+    assert_target(&input.repository, "gitlab.example.test", "a/b/c", "widgets");
 }
 
 #[test]

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -666,7 +666,10 @@ fn pr_empty_states_are_calm_and_keep_the_ambiguity_count() {
     app.pr = PrView::GitError("git remote get-url upstream failed".to_string());
     let out = render(&app);
     assert!(out.contains("Git read failed"), "local failures stay factual:\n{out}");
-    assert!(!out.contains("GitHub unavailable"), "a local failure is not blamed on GitHub:\n{out}");
+    assert!(
+        !out.contains("Forge unavailable"),
+        "a local failure is not blamed on the forge:\n{out}"
+    );
 }
 
 #[test]

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1514,7 +1514,10 @@ fn a_short_narrow_pr_pane_keeps_the_retry_action_and_one_body_row() {
     app.set_tab(Tab::Pr).unwrap();
     app.pr =
         PrView::Pr(Box::new(PrSnapshot { body: "steady body".into(), ..common::pr_snapshot() }));
-    app.apply_pr(PrView::NotAuthed("github.example.com".to_string()));
+    app.apply_pr(PrView::NotAuthed(
+        herdr_reviewr::git::Forge::GitHub,
+        "github.example.com".to_string(),
+    ));
 
     let out = dump(&render_size(&app, 30, 7));
     assert!(out.contains("Not signed"), "the failure state remains visible:\n{out}");


### PR DESCRIPTION
## What

Adds functionality of displaying PR's from gitlab - by default public gitlab url - or with configuration any standalone gitlab instance.
Fits in with existing pattern for github - delegating to cli (glab) - same schema internally etc.
