### PR TITLE
Open the selected file in an editor from the Files pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **`e` opens a file in your editor from the Files pane.** On a file row in either file tab, `e`
+  opens it full-screen in the editor from the new `editor` config key (or `$EDITOR`); closing it
+  refreshes the file list and diff. Inert on a directory row. `e` on the diff pane is unchanged —
+  it still edits the comment under the cursor.
+
 ## [0.29.0] — 2026-08-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The keys below are defaults. You can rebind every action, even to several keys a
 | `Ctrl+U` `Ctrl+D` | Move a half-page |
 | `Tab` | Switch focus |
 | `→` `←` | Expand / collapse, or scroll sideways |
+| `e` | Open file in editor (Files pane) — see [Editor](#editor) |
 | `/` | Search files and code |
 | `Ctrl+F` | Find in file |
 | `w` | Toggle line wrap |
@@ -218,6 +219,7 @@ toggle_placement = "overlay"
 toggle_direction = "down"
 auto_open = false
 github_host = "github.example.com"
+editor = "code --wait"
 
 [keybindings]
 comment = ["c", "ㅊ"]
@@ -273,6 +275,19 @@ base_branches = ["develop", "main", "master"]
 
 `--base <ref>` wins over the list and takes any rev (a branch, a tag, a SHA). When nothing in
 the list resolves, the branch `origin/HEAD` names is the fallback.
+
+### Editor
+
+`e` on a file row in the Files pane (Changes or All files) opens it full-screen in your editor:
+
+```toml
+editor = "code --wait"
+```
+
+Unset, it falls back to `$EDITOR`. Neither set, `e` reports a status error and opens nothing.
+The command is split on whitespace and the file path appended. No shell is involved. `e` does
+nothing on a directory row. `e` on the diff pane still edits the comment under the cursor.
+Closing the editor refreshes the file list and diff.
 
 ### Keybindings
 

--- a/specs/config.md
+++ b/specs/config.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-07-10
-Last edited: 2026-07-31
+Last edited: 2026-08-02
 ---
 
 # Configuration
@@ -23,6 +23,7 @@ auto_open = false
 github_host = "github.example.com"
 gitlab_host = "git.corp.example"
 azure_devops_host = "tfs.corp.example"
+editor = "code --wait"
 
 [keybindings]
 comment = ["c", "ㅊ"]
@@ -30,19 +31,20 @@ select  = ["v", "ㅍ"]
 find    = ["ctrl+f"]
 ```
 
-| key                  | value                                                                              |
-| -------------------- | ---------------------------------------------------------------------------------- |
-| `theme`              | one name from the theme set in `theme.md`                                          |
-| `base_branches`      | non-empty array of non-empty branch names, `origin/` and `refs/` prefixes accepted |
-| `default_scope`      | `uncommitted`, `branch`, or `last-turn`                                            |
-| `navigator_position` | `right`, `left`, `top`, or `bottom`                                                |
-| `toggle_placement`   | `split`, `overlay`, `zoomed`, or `tab`                                             |
-| `toggle_direction`   | `right` or `down`                                                                  |
-| `auto_open`          | boolean                                                                            |
-| `github_host`        | bare hostname other than `github.com`                                              |
-| `gitlab_host`        | bare hostname other than `gitlab.com`                                              |
-| `azure_devops_host`  | bare hostname other than `dev.azure.com`                                           |
-| `keybindings`        | table of actions from the keymap in `input.md`, each a non-empty array of keys     |
+| key                  | value                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------------- |
+| `theme`              | one name from the theme set in `theme.md`                                                      |
+| `base_branches`      | non-empty array of non-empty branch names, `origin/` and `refs/` prefixes accepted             |
+| `default_scope`      | `uncommitted`, `branch`, or `last-turn`                                                        |
+| `navigator_position` | `right`, `left`, `top`, or `bottom`                                                            |
+| `toggle_placement`   | `split`, `overlay`, `zoomed`, or `tab`                                                         |
+| `toggle_direction`   | `right` or `down`                                                                              |
+| `auto_open`          | boolean                                                                                        |
+| `github_host`        | bare hostname other than `github.com`                                                          |
+| `gitlab_host`        | bare hostname other than `gitlab.com`                                                          |
+| `azure_devops_host`  | bare hostname other than `dev.azure.com`                                                       |
+| `editor`             | non-empty string: the editor command, split on whitespace, the file path appended (`input.md`) |
+| `keybindings`        | table of actions from the keymap in `input.md`, each a non-empty array of keys                 |
 
 `--resolve-plugin-config` prints the validated config as JSON, every key included, the keymap resolved.
 

--- a/specs/input.md
+++ b/specs/input.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-07-17
-Last edited: 2026-07-31
+Last edited: 2026-08-02
 ---
 
 # Input
@@ -169,7 +169,7 @@ Row 1's primary and actions follow the cursor:
 | a commented line                         | `e edit`                       | `d delete · n/N jump`             |
 | a fold                                   | `→ expand fold`                | —                                 |
 | an open markdown preview                 | `m source`                     | —                                 |
-| a file (file list)                       | `tab diff`                     | `z hide`                          |
+| a file (file list)                       | `tab diff`                     | `e edit file · z hide`            |
 | a collapsed directory                    | `→ expand`                     | `z hide`                          |
 | an expanded directory                    | `← collapse`                   | `z hide`                          |
 | nothing to review (awaiting turn)        | `u/b/t scope`                  | `r refresh`                       |
@@ -184,6 +184,18 @@ Row 1's primary and actions follow the cursor:
 - `?` (the `keys` action) toggles the expansion in `Normal` mode only. It is text in the comment editor and the search and find inputs, and inert in the comments list and the agent picker.
 - The changed-file count and line totals live in the header. The footer carries only the comment count, inside `s send N`.
 - On `PR` row 1 carries the PR state line and `o open ↗` per `pr-tab.md`, and `?` expands to the rest.
+
+### Open in editor
+
+On a file row in the file list, `e` opens that file in an editor. The editor takes the whole
+screen. reviewr's own display returns when it exits. Inert on a directory row. Inert on the diff
+pane too, where `e` edits the comment under the cursor instead (see above).
+
+The editor command is `config.md`'s `editor` key, or `$EDITOR` when unset. Neither set reports a
+status error and opens nothing.
+
+Closing the editor refreshes the file list and diff, so an edit made there becomes visible. The
+cursor and scroll position hold (`overview.md` Continuity).
 
 ### Comment editor
 

--- a/specs/input.md
+++ b/specs/input.md
@@ -188,14 +188,14 @@ Row 1's primary and actions follow the cursor:
 ### Open in editor
 
 On a file row in the file list, `e` opens that file in an editor. The editor takes the whole
-screen. reviewr's own display returns when it exits. Inert on a directory row. Inert on the diff
-pane too, where `e` edits the comment under the cursor instead (see above).
+screen. reviewr's own display returns when it exits.
 
-The editor command is `config.md`'s `editor` key, or `$EDITOR` when unset. Neither set reports a
-status error and opens nothing.
-
-Closing the editor refreshes the file list and diff, so an edit made there becomes visible. The
-cursor and scroll position hold (`overview.md` Continuity).
+- `e` is inert on a directory row. On the diff pane, `e` still edits the comment under the cursor
+  instead (see Footer).
+- The editor command is the configured `editor` key, or `$EDITOR` when unset (`config.md`).
+  Neither set reports a status error and opens nothing.
+- Closing the editor refreshes the file list and diff. The cursor and scroll position hold
+  (`overview.md` Continuity).
 
 ### Comment editor
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -320,6 +320,9 @@ pub enum FooterAction {
     MovePage,
     ExpandDir,
     CollapseDir,
+    /// Open the file under the cursor in an editor (Files pane, `specs/input.md` "Open in
+    /// editor"). Shares the `edit` key with `EditComment`, offered in a different context.
+    OpenEditor,
     /// Open the search screen — offered in every context, on every tab (specs/search.md).
     Search,
     /// Open the in-file find band — offered wherever the read pane has content
@@ -531,6 +534,10 @@ pub struct App {
     /// The world refresh request awaiting dispatch, if any; the event loop hands it to
     /// the worker after the frame paints (specs/tui.md).
     pub world_request: Option<crate::world::WorldRequest>,
+    /// The absolute path of a file the Files pane asked to open in an editor; the event loop
+    /// owns the terminal, so it services this after the frame paints — suspending, spawning,
+    /// resuming, then requesting a world refresh (specs/input.md "Open in editor").
+    pub editor_request: Option<PathBuf>,
     /// The search overlay's state while `mode == Mode::Search`, `None` otherwise.
     pub search: Option<SearchOverlay>,
     /// Set by every query edit (and the open); the event loop dispatches the query to the
@@ -674,6 +681,7 @@ impl App {
             reveal_pr_nav: std::cell::Cell::new(true),
             pr_pending: None,
             world_request: None,
+            editor_request: None,
             search: None,
             search_dirty: false,
             search_track: None,
@@ -2347,6 +2355,15 @@ impl App {
             && self.visible.get(self.diff_cursor).and_then(Row::fold_anchor).is_some()
     }
 
+    /// Request the file under the cursor open in an editor (`e`, Files pane). A no-op on a
+    /// directory row — deferred to the event loop, which owns the terminal
+    /// (specs/input.md "Open in editor").
+    pub fn request_open_editor(&mut self) {
+        if let Some(entry) = self.current_entry() {
+            self.editor_request = Some(self.repo.join(&entry.path));
+        }
+    }
+
     /// Expand the directory under the cursor (`→`); a no-op if it is a file or already open.
     pub fn expand_dir(&mut self) {
         if self.plugin_config().is_none() {
@@ -3327,6 +3344,9 @@ impl App {
                 _ => {
                     out.push((A::TogglePane, Primary)); // tab into the diff to review
                     pane_is_primary = true;
+                    if self.current_entry().is_some() {
+                        out.push((A::OpenEditor, Do));
+                    }
                 }
             }
             // The files pane's calm row 1 has the room for the hide key (specs/input.md).

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,7 +81,7 @@ pub(crate) fn canonical_base(entry: &str) -> String {
         .to_string()
 }
 
-const PLUGIN_CONFIG_KEYS: [&str; 11] = [
+const PLUGIN_CONFIG_KEYS: [&str; 12] = [
     "theme",
     "base_branches",
     "default_scope",
@@ -92,6 +92,7 @@ const PLUGIN_CONFIG_KEYS: [&str; 11] = [
     "github_host",
     "gitlab_host",
     "azure_devops_host",
+    "editor",
     "keybindings",
 ];
 
@@ -182,6 +183,7 @@ pub struct PluginConfig {
     github_host: Option<String>,
     gitlab_host: Option<String>,
     azure_devops_host: Option<String>,
+    editor: Option<String>,
     keymap: crate::keymap::Keymap,
 }
 
@@ -198,6 +200,7 @@ impl Default for PluginConfig {
             github_host: None,
             gitlab_host: None,
             azure_devops_host: None,
+            editor: None,
             keymap: crate::keymap::Keymap::default(),
         }
     }
@@ -255,6 +258,12 @@ impl PluginConfig {
         }
     }
 
+    /// The `editor` key: the command `e` opens a file with in the Files pane, whitespace-split,
+    /// the path appended (`specs/input.md` "Open in editor").
+    pub fn editor(&self) -> Option<&str> {
+        self.editor.as_deref()
+    }
+
     /// The resolved keymap: the defaults with this snapshot's `[keybindings]` applied.
     pub fn keymap(&self) -> &crate::keymap::Keymap {
         &self.keymap
@@ -282,6 +291,7 @@ impl PluginConfig {
             "github_host": self.github_host,
             "gitlab_host": self.gitlab_host,
             "azure_devops_host": self.azure_devops_host,
+            "editor": self.editor,
             "keybindings": keybindings,
         })
     }
@@ -506,6 +516,13 @@ fn parse_plugin_config(path: &Path) -> Result<PluginConfig, PluginConfigError> {
                 ),
             ));
         }
+    }
+    if let Some(value) = table.get("editor") {
+        let editor = string_value(path, "editor", value, "a non-empty string")?;
+        if editor.trim().is_empty() {
+            return Err(value_error(path, "editor", "a non-empty string"));
+        }
+        config.editor = Some(editor.to_owned());
     }
     if let Some(value) = table.get("keybindings") {
         config.keymap = parse_keybindings(path, value)?;
@@ -756,6 +773,7 @@ mod tests {
         assert_eq!(config.toggle_direction(), ToggleDirection::Right);
         assert!(config.auto_open());
         assert_eq!(config.github_host(), None);
+        assert_eq!(config.editor(), None);
     }
 
     #[test]
@@ -772,6 +790,7 @@ mod tests {
                 "toggle_direction = \"down\"\n",
                 "auto_open = false\n",
                 "github_host = \"GitHub.Example.COM\"\n",
+                "editor = \"code --wait\"\n",
             ),
         )
         .unwrap();
@@ -785,6 +804,7 @@ mod tests {
         assert_eq!(config.toggle_direction(), ToggleDirection::Down);
         assert!(!config.auto_open());
         assert_eq!(config.github_host(), Some("github.example.com"));
+        assert_eq!(config.editor(), Some("code --wait"));
     }
 
     #[test]
@@ -844,6 +864,9 @@ mod tests {
             // Any organization label matches the built-in wildcard (`specs/config.md`).
             ("azure_devops_host = \"foo.visualstudio.com\"\n", "`azure_devops_host`"),
             ("github_host = \"bar.visualstudio.com\"\n", "`github_host`"),
+            ("editor = \"\"\n", "`editor`"),
+            ("editor = \"   \"\n", "`editor`"),
+            ("editor = 1\n", "`editor`"),
         ];
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.toml");
@@ -1066,6 +1089,7 @@ mod tests {
         assert_eq!(object["toggle_direction"], "right");
         assert_eq!(object["auto_open"], true);
         assert!(object["github_host"].is_null());
+        assert!(object["editor"].is_null());
         let keybindings = object["keybindings"].as_object().unwrap();
         assert_eq!(
             keybindings.len(),

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,0 +1,90 @@
+//! Spawn the user's editor for "open in editor" (Files pane, `e`).
+//!
+//! See `specs/config.md` (`editor`) and `specs/input.md` ("Open in editor"). No shell ever
+//! runs: the command is whitespace-split into argv, so a config value is never interpreted as
+//! shell syntax.
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+/// The editor command, resolved: the configured value, else `$EDITOR`. `None` when neither is
+/// set (`specs/config.md`).
+#[must_use]
+pub fn resolve_editor(configured: Option<&str>) -> Option<String> {
+    configured
+        .map(str::to_string)
+        .or_else(|| std::env::var("EDITOR").ok().filter(|v| !v.trim().is_empty()))
+}
+
+/// Split `editor` into a program and its arguments, `path` appended as the final argument.
+/// `None` when `editor` has no non-whitespace content.
+fn argv(editor: &str, path: &Path) -> Option<(String, Vec<OsString>)> {
+    let mut words = editor.split_whitespace();
+    let program = words.next()?.to_string();
+    let mut args: Vec<OsString> = words.map(OsString::from).collect();
+    args.push(path.as_os_str().to_owned());
+    Some((program, args))
+}
+
+/// Run `editor`'s argv against `path`, inheriting this process's stdio and waiting on it
+/// synchronously. The caller (`lib.rs`) leaves the alternate screen and raw mode first and
+/// restores both after — this only spawns and waits. A non-zero exit is not treated as a
+/// failure: many editors exit non-zero on a cancelled save, and the file may still have
+/// changed, so the caller refreshes regardless.
+pub fn run_editor(editor: &str, path: &Path) -> Result<()> {
+    let (program, args) = argv(editor, path).context("`editor` is empty")?;
+    Command::new(&program)
+        .args(&args)
+        .status()
+        .with_context(|| format!("spawning editor {program:?}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{argv, resolve_editor, run_editor};
+    use std::path::Path;
+
+    #[test]
+    fn argv_splits_the_command_and_appends_the_path() {
+        let (program, args) = argv("code --wait", Path::new("/tmp/a.rs")).unwrap();
+        assert_eq!(program, "code");
+        assert_eq!(args, vec!["--wait", "/tmp/a.rs"]);
+    }
+
+    #[test]
+    fn argv_is_none_for_an_empty_command() {
+        assert!(argv("   ", Path::new("/tmp/a.rs")).is_none());
+    }
+
+    #[test]
+    fn configured_value_wins_over_the_environment() {
+        assert_eq!(resolve_editor(Some("code --wait")), Some("code --wait".to_string()));
+    }
+
+    #[test]
+    fn spawns_the_configured_program_against_the_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("a.txt");
+        std::fs::write(&file, "").unwrap();
+        assert!(run_editor("true", &file).is_ok());
+    }
+
+    #[test]
+    fn a_missing_program_is_a_spawn_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("a.txt");
+        std::fs::write(&file, "").unwrap();
+        let error = run_editor("definitely-not-a-real-editor-binary", &file).unwrap_err();
+        assert!(error.to_string().contains("definitely-not-a-real-editor-binary"));
+    }
+
+    #[test]
+    fn empty_editor_string_is_an_error() {
+        let error = run_editor("   ", Path::new("a.txt")).unwrap_err();
+        assert!(error.to_string().contains("empty"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod azure_devops;
 pub mod browser;
 pub mod config;
 pub mod diff;
+pub mod exec;
 pub mod export;
 pub mod file_list;
 pub mod forge;
@@ -172,6 +173,42 @@ fn app_for(cfg: &Config, initial_config: &Result<PluginConfig, config::PluginCon
             app.set_config_error(error.to_string());
             app
         }
+    }
+}
+
+/// Open `path` in the resolved editor as a full-screen takeover (`specs/input.md` "Open in
+/// editor"): leave the alternate screen and terminal modes, spawn and wait, then restore them
+/// exactly as `run` set them up initially. A missing `editor`/`$EDITOR` never touches the
+/// terminal at all. Either way the caller's next frame repaints from a cleared screen.
+fn open_in_editor(
+    terminal: &mut DefaultTerminal,
+    app: &mut App,
+    kbd: bool,
+    path: &std::path::Path,
+) {
+    let configured = app.plugin_config().and_then(PluginConfig::editor);
+    let Some(editor) = exec::resolve_editor(configured) else {
+        app.status = "no editor: set `editor` in config.toml or $EDITOR".to_string();
+        return;
+    };
+
+    restore_terminal(kbd);
+    let result = exec::run_editor(&editor, path);
+    *terminal = ratatui::init();
+    let _ = execute!(io::stdout(), EnableMouseCapture, EnableBracketedPaste);
+    if kbd {
+        let _ = execute!(
+            io::stdout(),
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        );
+    }
+    let _ = terminal.clear();
+
+    match result {
+        // The file may have changed; the world refresh rebuilds the diff cache off the new
+        // content hash, the same path a poll takes for the agent's own edits (`world.rs`).
+        Ok(()) => app.request_world_refresh(false, false),
+        Err(e) => app.status = format!("error: {e}"),
     }
 }
 
@@ -1125,6 +1162,9 @@ fn event_loop(
                     _ => {}
                 }
             }
+            if let Some(path) = app.editor_request.take() {
+                open_in_editor(terminal, app, kbd, &path);
+            }
             if app.should_quit {
                 break;
             }
@@ -1584,6 +1624,10 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             // the diff focused — otherwise `delete` would silently drop a comment under an
             // off-screen cursor. (The comments-list overlay targets the highlighted row instead.)
             K::Edit if app.focus == Focus::Diff => app.start_edit(),
+            // Off the diff, `edit` instead opens the file under the cursor in an editor — inert
+            // on a directory row, which `request_open_editor` itself guards (specs/input.md
+            // "Open in editor").
+            K::Edit if app.focus == Focus::Files => app.request_open_editor(),
             K::Delete if app.focus == Focus::Diff => app.delete_comment(),
             K::Send => app.send_to_agent(),
             K::Copy => {
@@ -1595,7 +1639,9 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             K::Search => app.open_search(),
             K::Find => app.open_find(),
             K::Keys => app.toggle_keys(),
-            // `edit`/`delete` off the diff, and `open-pr` off the `PR` tab, are inert.
+            // `delete` off the diff, and `open-pr` off the `PR` tab, are inert. `edit` is
+            // handled by the two focus arms above; this arm is unreachable for it but required
+            // for exhaustiveness.
             K::Edit | K::Delete | K::OpenPr => {}
         }
         return Ok(());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1443,6 +1443,7 @@ fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
         A::MovePage => ("PageUp PageDown".into(), ""),
         A::ExpandDir => ("→".into(), "expand"),
         A::CollapseDir => ("←".into(), "collapse"),
+        A::OpenEditor => (hint(K::Edit), "edit file"),
         A::TogglePane => {
             return ("tab".into(), if app.focus == Focus::Files { "diff" } else { "files" }.into());
         }

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -666,6 +666,97 @@ fn editing_a_comment_surfaces_its_file_from_a_collapsed_directory() {
     assert!(matches!(app.mode, Mode::Composing { editing: Some(_) }));
 }
 
+#[test]
+fn open_editor_targets_the_file_row_and_is_inert_on_a_directory() {
+    let r = Repo::init();
+    r.write("src/a.rs", "one\n");
+    r.write("src/b.rs", "one\n");
+    r.commit_all("init");
+    r.write("src/a.rs", "two\n");
+    r.write("src/b.rs", "two\n");
+    let mut app = app_on(&r);
+    app.focus = Focus::Files;
+
+    // A directory row: `request_open_editor` is inert.
+    app.file_cursor = app.file_rows.iter().position(|r| r.dir_path() == Some("src")).unwrap();
+    app.request_open_editor();
+    assert_eq!(app.editor_request, None, "a directory row requests nothing");
+
+    // A file row: the request carries the file's absolute path.
+    app.file_cursor = file_row(&app, "src/a.rs");
+    app.request_open_editor();
+    assert_eq!(app.editor_request, Some(r.path().join("src/a.rs")));
+}
+
+#[test]
+fn open_editor_works_the_same_way_on_the_all_files_tab() {
+    use herdr_reviewr::app::Tab;
+
+    let r = Repo::init();
+    r.write("src/a.rs", "one\n");
+    r.write("src/b.rs", "one\n");
+    r.commit_all("init");
+    let mut app = app_on(&r);
+    enter_tab(&mut app, Tab::AllFiles);
+    app.focus = Focus::Files;
+
+    // A directory row: inert, same as on Changes. `All files` opens collapsed
+    // (`specs/file-list.md`), so `src` starts as its own row here, unlike on Changes.
+    app.file_cursor = app.file_rows.iter().position(|r| r.dir_path() == Some("src")).unwrap();
+    app.request_open_editor();
+    assert_eq!(app.editor_request, None, "a directory row requests nothing on All files either");
+    app.expand_dir();
+
+    // A file row: same absolute-path request as on Changes.
+    app.file_cursor = file_row(&app, "src/a.rs");
+    app.request_open_editor();
+    assert_eq!(app.editor_request, Some(r.path().join("src/a.rs")));
+    assert!(
+        app.footer_bands().iter().any(|&(a, _)| a == FooterAction::OpenEditor),
+        "the footer offers it on All files too"
+    );
+}
+
+#[test]
+fn returning_from_an_external_edit_refreshes_the_open_diff() {
+    let r = Repo::init();
+    r.write("a.rs", "alpha\n");
+    r.commit_all("init");
+    r.write("a.rs", "beta\n");
+    let mut app = app_on(&r);
+    assert_eq!(app.diff_path.as_deref(), Some("a.rs"));
+    assert!(app.visible.iter().any(|row| row.text() == "beta"), "the initial diff shows beta");
+
+    // Simulate an external editor changing the file on disk, then the same refresh the event
+    // loop requests once the editor closes (`request_open_editor`'s contract, `specs/input.md`
+    // "Open in editor").
+    r.write("a.rs", "gamma\n");
+    app.request_world_refresh(false, false);
+    common::land_world(&mut app);
+
+    assert!(app.visible.iter().any(|row| row.text() == "gamma"), "the diff reflects the edit");
+}
+
+#[test]
+fn the_footer_offers_open_editor_only_on_a_file_row() {
+    let r = Repo::init();
+    r.write("src/a.rs", "one\n");
+    r.write("src/b.rs", "one\n");
+    r.commit_all("init");
+    r.write("src/a.rs", "two\n");
+    r.write("src/b.rs", "two\n");
+    let mut app = app_on(&r);
+    app.focus = Focus::Files;
+    let has_open_editor =
+        |a: &App| a.footer_bands().iter().any(|&(x, _)| x == FooterAction::OpenEditor);
+
+    app.file_cursor = app.file_rows.iter().position(|r| r.dir_path() == Some("src")).unwrap();
+    assert!(!has_open_editor(&app), "a directory row offers no open-editor action");
+
+    app.file_cursor = file_row(&app, "src/a.rs");
+    assert!(has_open_editor(&app), "a file row offers open-editor");
+}
+
 /// Expand the fold under the cursor with synthetic geometry (these tests don't render).
 fn expand_fold(app: &mut App) {
     let heights = vec![1usize; app.visible.len()];
@@ -3188,6 +3279,40 @@ fn mouse(app: &mut App, keymap: &Keymap, kind: MouseEventKind) {
     let heights = vec![1usize; app.visible.len()];
     let event = MouseEvent { kind, column: 10, row: 10, modifiers: KeyModifiers::NONE };
     handle_mouse(app, event, area, &heights, keymap).unwrap();
+}
+
+#[test]
+fn e_dispatches_by_focus_edit_comment_or_open_editor() {
+    let r = Repo::init();
+    r.write("src/a.rs", "one\n");
+    r.write("src/b.rs", "one\n");
+    r.commit_all("init");
+    r.write("src/a.rs", "two\n");
+    r.write("src/b.rs", "two\n");
+    let mut app = app_on(&r);
+    let keymap = Keymap::default();
+
+    // Files pane, on the file row: `e` requests the editor.
+    app.focus = Focus::Files;
+    app.file_cursor = file_row(&app, "src/a.rs");
+    press(&mut app, &keymap, KeyCode::Char('e'));
+    assert_eq!(app.editor_request, Some(r.path().join("src/a.rs")));
+
+    // Files pane, on the directory row: `e` does nothing.
+    app.editor_request = None;
+    app.file_cursor = app.file_rows.iter().position(|row| row.dir_path() == Some("src")).unwrap();
+    press(&mut app, &keymap, KeyCode::Char('e'));
+    assert_eq!(app.editor_request, None, "a directory row requests nothing");
+
+    // Diff pane, on a commented line: `e` still edits the comment (unchanged behavior).
+    app.select_file(file_row(&app, "src/a.rs")).unwrap();
+    comment_on(&mut app, '+', "note");
+    press(&mut app, &keymap, KeyCode::Char('e'));
+    assert!(
+        matches!(app.mode, Mode::Composing { editing: Some(_) }),
+        "e still edits the comment on the diff"
+    );
+    assert_eq!(app.editor_request, None, "the diff-pane edit never requests the editor");
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`e` does nothing when the cursor is on a file row in the Files pane (`Changes` or `All files`). Fixing a typo or checking something in an editor means leaving reviewr, finding the file yourself, and coming back.

## Fix

`e` on a file row now opens that file in an editor, full-screen. Closing it refreshes the file list and diff, so an edit made there is visible without a manual `r`. Inert on a directory row.

The editor is a new `editor` config key, falling back to `$EDITOR`. Neither set, `e` reports a status error rather than doing nothing silently.

`e` on the diff pane is unchanged: it still edits the comment under the cursor. `e` already resolves to one keymap action; the existing diff-pane arm is untouched, and a new Files-pane arm handles the file-list case, so no `[keybindings]` rebind and no collision.

## Coverage

- Spec: `specs/input.md` ("Open in editor" section, footer table row) and `specs/config.md` (`editor` key), landed with the code.
- Tests: `src/exec.rs` (argv building, editor resolution, real-subprocess spawn success/failure), `src/config.rs` (parsing and validation). Integration (`tests/app_flow.rs`): inert on a directory row and correct on a file row on both `Changes` and `All files`, footer offers it only on a file row, `e` still dispatches to comment-edit on the diff pane through the same `handle_key` entry point, and a world refresh after an external edit rebuilds the *open* diff's content, not only the navigator.
- Manual: a PTY-driven smoke test against the real binary with a scripted `$EDITOR` confirmed the terminal actually leaves the alternate screen (the editor's own output reaches it), reviewr repaints cleanly on return, and `q` still quits. Also QA-installed into a real herdr pane and exercised by hand.
- `CHANGELOG.md` has a bullet under `## [Unreleased]`.
- `just ci` is green (fmt-check, lint, test, release build).
- No runtime-relevant perf path touched (reload/render/git/highlight unaffected) — no PTY benchmark needed.