### PR TITLE
Agent picker: choose which agent an ambiguous Send goes to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Agent picker on an ambiguous send.** When a worktree holds several agents, `Send` now opens a
+  picker to choose which one receives the comments, instead of refusing and pointing at the
+  clipboard. Each row shows the agent's name or kind, its tab label when that adds information, its
+  status, and what it is working on. `↑`/`↓` choose, `enter` sends, `esc` cancels. A single agent
+  still sends directly and no agent still refuses. This keeps the send on the herdr socket, which
+  works over SSH/mosh where the clipboard copy does not.
+
 ## [0.24.1] — 2026-07-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ One persistent pane, pointed at a git worktree:
 - **Line comments** — select a range, write a note. It stays visible as a card under the code,
   never hidden behind a marker.
 - **Send** — one keystroke drops every comment into the agent's input as
-  `path:start-end — comment`. Add context, hit enter.
+  `path:start-end — comment`. Add context, hit enter. With several agents in the worktree, a
+  picker asks which one — so the notes go over the herdr socket, not a clipboard that breaks over
+  SSH/mosh.
 - **File viewer** — the whole worktree, any file's current content in the pane.
 - **Search** — `/` from any tab opens one screen over the worktree: fuzzy file names and live
   code grep, powered by [fff](https://github.com/dmtrKovalenko/fff).
@@ -145,7 +147,7 @@ The keys below are defaults. You can rebind every action, even to several keys a
 | `e` `d` | Edit / delete the comment under the cursor |
 | `n` `N` | Jump to the next / previous comment |
 | `l` | List every comment |
-| `s` | Send all comments to the agent |
+| `s` | Send all comments to the agent (or pick one when several are in the worktree) |
 | `y` | Copy all comments to the clipboard |
 | `esc` | Clear the selection |
 

--- a/docs/herdr-api-notes.md
+++ b/docs/herdr-api-notes.md
@@ -71,9 +71,12 @@ command = "persiyanov.reviewr.toggle"   # <plugin_id>.<action_id> — plugin_id 
 
 ## Resolve the agent / send comments
 
-`herdr agent list` → `{"result":{"agents":[ {pane_id, tab_id, workspace_id, agent_status, ...} ]}}`.
-- Send target = the agent in the sidebar's `HERDR_TAB_ID`, else the sole agent in its `HERDR_WORKSPACE_ID`.
+`herdr agent list` → `{"result":{"agents":[ {pane_id, tab_id, workspace_id, agent_status, name?, terminal_title_stripped?, ...} ]}}`.
+- One candidate in the sidebar's `HERDR_TAB_ID` (else its `HERDR_WORKSPACE_ID`) sends directly. Several candidates open the agent picker to choose one. None refuses (`specs/herdr-host.md`).
+- The picker labels each row with `name` (usually absent), the agent kind, its `agent_status`, its `terminal_title_stripped`, and the tab label (below). All but the kind degrade to empty if the field is absent.
 - **Caveat:** the reviewr pane itself is listed as an agent — exclude `HERDR_PANE_ID` or the real agent looks ambiguous.
+
+`herdr tab list --workspace <ws>` → `{"result":{"tabs":[ {tab_id, label?} ]}}`. Joined on `tab_id` to label picker rows; best-effort, so a missing label or a failed call just drops that row's tab note.
 
 ```
 herdr pane send-text <agent_pane> "<literal text>"   # writes input, no Enter

--- a/docs/plans/2026-07-24-agent-select-dialog/plan.md
+++ b/docs/plans/2026-07-24-agent-select-dialog/plan.md
@@ -1,0 +1,345 @@
+# Agent select dialog on ambiguous Send — Delivery Plan
+
+**Specs:** ../../../specs/ — the living reference this plan delivers
+**Base:** `origin/main` (ahead of the 0.20.1 release: has `Search`/`Find` modes and the
+`footer_bands`/`Band` footer). Fork: `shumkov/herdr-reviewr` (remote `fork`).
+
+## Problem
+
+`Send` (`s`) resolves its target with `pick` in `src/herdr.rs`: the sole agent in the
+sidebar's tab, else the sole agent in its workspace. Zero **or several** candidates
+refuse the send (`HH-SOLE-OR-REFUSE`) with *"several agents here — copy to the clipboard
+instead."* The reviewer is then forced onto `Copy`, which writes the OS clipboard on the
+machine the binary runs on. Over `mosh` (Warp → mosh → herdr on a remote Mac), that is
+the *remote* clipboard; a local paste pulls the *local* clipboard, so the comments never
+reach the agent (no OSC 52; "No clipboard over SSH" is an explicit non-goal in
+`herdr-host.md`). The fix is to keep the reviewer on **Send** — which writes straight
+into the agent pane over the herdr socket and never touches a clipboard — even with
+several agents in scope.
+
+## Goal
+
+When `Send` resolves to **several** candidate agents, open a modal **agent picker**
+listing those agents; the reviewer chooses one; every comment is sent to that agent's
+pane (write input, then focus), consumed on success — exactly as a one-agent send today.
+Zero candidates still refuses with the clipboard hint; exactly one still sends directly.
+
+## Definition of Done
+
+- `Send` with **one** resolved agent behaves exactly as today (direct send, no picker).
+- `Send` with **several** candidates opens the picker instead of refusing.
+- `Send` with **zero** candidates reports *"no agent here — copy to the clipboard
+  instead"* and opens no picker. (Status wording note: today this renders with an
+  `agent failed:` prefix because the zero case flows through `export`; the new path sets
+  the status directly and drops the prefix — a deliberate micro-change, noted in the spec.)
+- `Send` with **no comments** still reports *"no comments to send"* and never opens the
+  picker (the empty-store check precedes agent resolution).
+- In the picker: the highlight moves through the `down`/`up` **bindings** (default `j`/`k`
+  and the fixed `↓`/`↑`), `Enter` sends every comment to the highlighted agent and closes,
+  `Esc` cancels and keeps every comment. No new rebindable action is added, so the keymap
+  and `CFG-KEY-UNIQUE` are untouched — the picker *acts through the existing bindings*,
+  exactly as the comments list does (`input.md`).
+- The picker never lists the reviewer's own pane (`HH-NOT-SELF`) or a non-agent pane
+  (`HH-AGENT-PANES`); it lists **exactly** the ambiguous candidate set.
+- Each row identifies its agent at the **pane** level — agent ≠ tab (a tab can hold several
+  agents, or an agent plus a shell), and confirmed live: agent `name` is `∅` on nearly all
+  agents, pane `label` is `∅` on every agent pane (only plugin panes set it), and `cwd` is
+  identical within a worktree. The row is composed and **omits every empty part**:
+  `{name or kind} · {tab-label, shown only when it differs from the kind} · {status} — {title}`
+  (title = `terminal_title_stripped`, the live "what it's working on"). No pane id is shown;
+  `pane_id` is retained **internally** as the send target. The tab label needs a second
+  `herdr tab list --workspace <ws>` call joined on `tab_id` (cheap, synchronous between
+  frames like the agent list). Two agents identical in kind, tab-label, and title render as
+  look-alike rows but remain distinct selections addressing their own panes.
+- A send whose chosen agent has since vanished fails gracefully: comments stay, the error
+  shows, **the picker closes** (the reviewer re-presses `Send` for a fresh list).
+- **Turn tracking is unchanged.** `last-turn` still resolves only the *sole* agent; an
+  ambiguous or absent agent still pauses tracking. The picker never changes which agent
+  turn tracking follows (`resolved_agent_status`: `One → Some`, `Many`/`None → None`).
+- Continuity (O6): a background world poll while the picker is open never moves the
+  highlight or the frozen diff underneath — the picker is a centered-popup modal, handled
+  like the comments list at the diff-freeze and mouse-capture sites.
+- Specs updated with the code: `herdr-host.md` and `input.md` only (see Specs Touched for
+  why `overview.md`/`tui.md`/`config.md`/`review-model.md` need no edit). `CHANGELOG.md`
+  and `README.md` note the new behavior.
+
+## Design
+
+### Resolution: One / Many / None (pure) — `src/herdr.rs`
+
+- Extend the `AgentPane` serde struct with `name: Option<String>` and
+  `terminal_title_stripped: Option<String>`. The struct has no `deny_unknown_fields` and
+  already ignores many live fields, so adding two typed `Option`s is safe; missing → `None`.
+- Replace `Refusal` + the borrow-returning `pick_agent` with a three-way `pick`:
+
+  ```rust
+  enum Pick<'a> { One(&'a AgentPane), Many(Vec<&'a AgentPane>), None }
+  ```
+
+  **Preserve today's boundary exactly** (the `in_tab.is_empty()` guard, `herdr.rs`
+  current ~113): a sole tab agent → `One` (`HH-TAB-WINS`); else decide on the **widest
+  non-empty** candidate set — workspace candidates when non-empty, else the tab
+  candidates: one → `One`, several → `Many(those)`, and `None` **only when both the tab
+  and workspace candidate sets are empty**. This keeps the existing test
+  `two_tab_agents_refuse_as_several_even_without_a_workspace_id` (two tab agents, no
+  workspace id) classifying as ambiguous → picker, not `None`. `Many` therefore carries
+  exactly the ambiguous set — the picker lists precisely those.
+- `resolve_send_target() -> Result<SendTarget>` = `agent_list()` then `pick`, mapped to an
+  **owned, transient** result `send_to_agent` destructures immediately (the app stores the
+  chosen `agent_choices`, never the `SendTarget`; `Pick` stays borrowed so the turn-tracking
+  poll path never allocates throwaway `AgentChoice`s). Only the `Many` branch does the extra
+  work: a single `tab list --workspace <ws>` call builds a `tab_id → label` map used to fill
+  each choice's `tab_label` (the `One` and `None` branches skip it):
+
+  ```rust
+  pub enum SendTarget { One(String), Many(Vec<AgentChoice>), None }
+
+  #[derive(Clone, Debug, PartialEq, Eq)]   // Debug required: App is #[derive(Debug)]
+  pub struct AgentChoice {
+      pub pane_id: String,           // internal send target — never displayed
+      pub kind: String,              // the `agent` field: "claude"/"codex"
+      pub name: Option<String>,      // agent session name — usually None
+      pub tab_label: Option<String>, // from the tab-list join; shown only when != kind
+      pub status: Status,
+      pub title: String,             // terminal_title_stripped ("" if absent)
+  }
+  ```
+  Row build (in `ui.rs`): lead with `name` if `Some`, else `kind`; append `tab_label` when
+  it is `Some` and `!= kind`; then `status`; then `title` if non-empty — each separated by
+  ` · ` / ` — `, empties skipped.
+- `resolved_agent_status()` (turn tracking; sole caller `world.rs`): map `Pick::One →
+  Some(status)`, `Many`/`None → None` — provably equivalent to today's
+  `pick_agent(...).ok().map(...)`. **No behavior change.**
+- Remove `resolve_agent_pane` (its only production caller is the old `Agent` target).
+
+### Export target: address a specific pane — `src/export.rs`
+
+- Replace the internally-resolving `Agent` unit struct with a pane-addressed target:
+
+  ```rust
+  pub struct Agent { pub pane: String }   // export = herdr::send_text(&pane, text) then focus
+  ```
+
+  `label`/`success_message` unchanged (they ignore the pane). Resolution leaves the
+  target; the caller resolves, then builds `Agent { pane }`. `Clipboard` untouched. The
+  existing `Agent.success_message(..)` unit test is updated to construct `Agent { pane: .. }`.
+
+### App: the picker modal — `src/app.rs`
+
+- New **unit** variant `Mode::SelectAgent` (so the existing `== Mode::X` comparisons keep
+  compiling; the data-in-variant fallback is dropped). Backing state as sibling fields to
+  `list_cursor`: `agent_choices: Vec<AgentChoice>`, `agent_cursor: usize`.
+- `send_to_agent(&mut self)` — the entry point `s` and the header `Send` click call:
+  1. `store.is_empty()` → status *"no comments to send"*, return (picker never opens empty).
+  2. `resolve_send_target()`:
+     - `Ok(One(pane))` → `self.export(&Agent { pane })` (today's direct send).
+     - `Ok(Many(choices))` → open the picker inline: `agent_choices = choices`,
+       `agent_cursor = 0`, `mode = SelectAgent` (no separate `begin_agent_pick` — one caller).
+     - `Ok(None)` → status *"no agent here — copy to the clipboard instead"* (comments kept).
+     - `Err(e)` → status *"agent failed: {e}"* (herdr CLI unreachable; comments kept).
+- `agent_move(delta)` — highlight movement, guarded on `SelectAgent` && non-empty, via `step`.
+- `confirm_agent_pick(&mut self)` — `Enter`: take the highlighted `AgentChoice`;
+  `self.export(&Agent { pane })`; then `close_modal()` **unconditionally**. (Do not lean on
+  `export`'s store-empty tail: on a failed send the store isn't consumed, so that tail
+  would leave the picker open — the DoD requires it to close on failure.)
+- **Cancel needs no method:** the picker's `Esc` calls `close_modal()` directly (mirroring
+  the comments-list `Esc → close_list`). The flip to `Normal` *is* the entire cancel;
+  `agent_choices` is inert outside `SelectAgent` and reset by the next open, so there is
+  nothing to clear.
+- Rename the shared `close_list()` → `close_modal()`, flipping `List` **or** `SelectAgent`
+  back to `Normal` (today `close_list` no-ops unless `mode == List`; widen to both). It
+  touches only `mode`, so consume-on-success and comment retention are untouched. Callers:
+  the `export` success tail, the comments-list `Esc`/`Comments` handlers, and the picker `Esc`.
+
+This adds **three** App methods — `send_to_agent`, `agent_move`, `confirm_agent_pick` — not five.
+- **Modal-behavior sites — only two gain `SelectAgent`** (the picker behaves like the
+  comments-list popup, *not* like the body-replacing `Search`/`Find` screens). Add a tiny
+  `fn popup_modal(&self) -> bool { matches!(self.mode, Mode::List | Mode::SelectAgent) }`
+  and use it at:
+  - the reconcile **diff-freeze** guard (`app.rs` current ~950: `!self.composing() &&
+    self.mode != Mode::List`) → `!self.composing() && !self.popup_modal()`. Without this a
+    landing poll shifts the frozen diff under the picker (O6 violation).
+  - the **mouse-capture** guard (`lib.rs` current ~1593: `app.composing() || app.mode ==
+    Mode::List`) → `app.composing() || app.popup_modal()`.
+
+  **Leave the List-*semantic* `==`/`!=` guards unchanged** — they compile as-is and already
+  exclude `SelectAgent`: `target_comment`, the `start_edit`/`delete_comment` preview guards,
+  `list_move`, the `footer_bands` List arm (the picker gets its own arm), and the List
+  key-dispatch block. Extending any of these to the picker would be a bug.
+
+  **But three `match` sites are wildcard-less and exhaustive, so adding the `SelectAgent`
+  variant forces a new arm — a behavioral no-op, the same compile-forced edit as the two new
+  `FooterAction` glyph arms:** `active_field` and `pending_location` add `SelectAgent` to
+  their existing `=> None` arm (the picker has no editable field and no pending comment
+  location), and `carry_authored_state_from` (config recovery) adds it to the no-op `{}` arm
+  (so a recovered `SelectAgent` is *not* preserved and falls to `Normal`, per S1). These are
+  "leave the behavior alone" but not "leave the code alone" — the arm must be named.
+- **Config recovery: do NOT preserve `SelectAgent`.** The recovery arm preserves only
+  `List | Composing`; leaving `SelectAgent` out lets a recovered app fall to `Normal`
+  with comments intact (the store is already carried) — the user re-presses `Send`. This
+  avoids a recovered `SelectAgent` with an empty `agent_choices` painting a 0-row picker,
+  and means `tui.md`'s recovery sentence stays true (no spec edit there).
+
+### Dispatch — `src/lib.rs`
+
+- Route all three `Send` entry points through `send_to_agent()`: Normal `K::Send`
+  (current ~1489), List-mode `K::Send` (current ~1449), and the header `HeaderHit::Send`
+  click (current ~1680). The `use crate::export::Agent` import stays (still builds
+  `Agent { pane }`). `Clipboard` sites untouched.
+- New `if app.mode == Mode::SelectAgent { … }` block before the generic dispatch,
+  mirroring the `Mode::List`/`Mode::Search`/`Mode::Find` blocks:
+  - `Enter` → `confirm_agent_pick`
+  - `Esc` → `cancel_agent_pick`
+  - `K::Down`/fixed `Down` → `agent_move(1)`; `K::Up`/fixed `Up` → `agent_move(-1)`
+    (routing through the resolved actions, so `j`/`k` track any rebind — matching the
+    comments-list precedent)
+  - everything else inert
+- Mouse: `popup_modal()` captures the mouse (inert), so the picker is covered by the
+  updated `lib.rs` guard above.
+
+### Footer + rendering — `src/app.rs`, `src/ui.rs`
+
+- `FooterAction`: add `ConfirmAgent` (`↵ send`) and `ChooseAgent` (`↑↓ choose`); reuse the
+  existing `Cancel` (`esc cancel`). The glyph map (`ui.rs`) has no wildcard arm, so both
+  need an arm there or it won't compile. `footer_bands()` gains
+  `Mode::SelectAgent => vec![(ConfirmAgent, Primary), (Cancel, Do), (ChooseAgent, Do)]`
+  (using `Band`, not the old `Tier`).
+- `render_agent_picker(frame, app, area)` mirrors `render_comments_list`: a
+  `centered(area, 80, 60)` popup, `Clear`, bordered block titled `Send to agent (N)`, one
+  `selectable_row` per choice built per the row rule above — **name-or-kind** (bold accent),
+  then `tab_label` when `Some` and `!= kind` (dim), then status (colored: idle/done dim,
+  working accent, blocked red), then the dim, truncated `title` after ` — `, every empty part
+  skipped. No pane id is drawn. `render` calls it when `mode == SelectAgent`. Popup visuals
+  are code-only (the comments-list popup is too — no `tui.md` edit).
+
+### Why a modal picker (alternatives rejected)
+
+- A **config-set default agent** can't track agents that come and go per worktree and
+  silently sends to the wrong one.
+- **Cycling agents on a key** hides the choice set and identities; a list showing each
+  agent's title is legible at a glance.
+- The modal reuses the proven `Mode::List` popup pattern, inheriting diff-freeze and
+  mouse-capture with minimal new surface.
+
+## Specs Touched
+
+| Spec | What this plan realizes | Gate |
+| --- | --- | --- |
+| `herdr-host.md` | `### Sending to the agent`: rewrite the lead prose to the three-way outcome (one → send, several → pick, none → refuse). Retire `HH-SOLE-OR-REFUSE` and `HH-REFUSE-SAYS-CLIPBOARD`; introduce `HH-ZERO-REFUSE` (no candidate → status names the clipboard), `HH-ONE-SENDS`, `HH-MANY-PICK` (the picker lists **exactly** the ambiguous candidates, `HH-NOT-SELF`/`HH-AGENT-PANES`-filtered), `HH-PICK-SENDS-CHOSEN` (the send addresses the **highlighted pane**, not a re-resolved target), `HH-PICK-CANCEL-KEEPS` (cancelling **sends nothing**). Reaffirm turn tracking cites the surviving `HH-AGENT-PANES`/`HH-NOT-SELF`/`HH-TAB-WINS`. Note the zero-case status prefix drop. | Draft → Current |
+| `input.md` | Add the agent picker as a local mode that **acts through the `down`/`up` bindings**, sends on `enter`, cancels on `esc` (mirror the line-21 comments-list sentence, not a "fixed keys" claim). Extend the enumerated local-mode sentences to include the picker: the own-one-row-footer set (~172), the "inert in the comments list" line (~173), and the navigator-actions-inert-in-local-modes line (~62). | Draft → Current |
+
+Retired invariant codes are not reused (per `specs/CLAUDE.md`: retire, never repurpose).
+
+**Deliberately NOT touched (conformance, not edits):**
+- `overview.md` — has no mode map (modes live in `src/app.rs`); its "mid-gesture frozen"
+  invariant (O6) already generalizes over modals without naming each one. No edit.
+- `tui.md` — the comments-list popup is code-only, so the picker popup is too; and because
+  the picker is **not** preserved across config recovery, the recovery sentence (~line 87)
+  stays true. No edit.
+- `config.md` — no `[keybindings]` action added; `CFG-KEY-UNIQUE`/form invariants unaffected.
+- `review-model.md` — delegates pane-finding to `herdr-host.md`; consume-on-success stays
+  its contract (the new invariants don't restate it). No edit.
+
+## Out of Scope
+
+- **Copy from the picker** (Esc then `y` still copies); the picker stays single-purpose.
+- **Mouse click-to-select in the picker** — captured/inert, matching `Mode::List`.
+- **Per-comment routing to different agents** — Send stays all-or-nothing to one agent.
+- **Config default / auto-pick a primary agent** — rejected above.
+- **OSC 52 / remote clipboard** — the picker removes the need; separate concern.
+- **Persisting the last-picked agent** — the comment store is in-memory by design (O3).
+
+## Likely Files
+
+- `src/herdr.rs` — `AgentPane` fields; `Pick`; `resolve_send_target` (+ the `Many`-only
+  `tab list` join for `tab_label`); `SendTarget`; `AgentChoice`; `resolved_agent_status`
+  remap; drop `resolve_agent_pane`; tests.
+- `src/export.rs` — `Agent { pane }`; test fix.
+- `src/app.rs` — `Mode::SelectAgent` + fields; `send_to_agent`/`agent_move`/
+  `confirm_agent_pick`; `close_list`→`close_modal`; `popup_modal`; footer arm;
+  diff-freeze guard; the three compile-forced no-op arms; tests.
+- `src/lib.rs` — Send call sites → `send_to_agent`; `SelectAgent` key block; mouse-capture
+  guard.
+- `src/ui.rs` — `render_agent_picker`; `ConfirmAgent`/`ChooseAgent` glyphs.
+- `specs/herdr-host.md`, `specs/input.md`; `CHANGELOG.md`, `README.md`.
+
+## Execution Plan
+
+1. [ ] `herdr.rs`: `AgentPane` fields; `Pick` + pure classifier preserving the
+       `in_tab.is_empty()` boundary; `resolve_send_target`/`SendTarget`/`AgentChoice`
+       (derive `Debug`; `Many` branch joins `tab list` for `tab_label`); remap
+       `resolved_agent_status`; drop `resolve_agent_pane`. Unit tests: One/Many/None across
+       tab/workspace scope, the two-tab-no-ws case stays ambiguous, self + non-agent
+       exclusion, `Many` carries the exact set, the row-compose helper (name/kind/tab/title,
+       empties omitted, tab==kind collapsed).
+2. [ ] `export.rs`: `Agent { pane }`; fix the `success_message` test.
+3. [ ] `app.rs`: `Mode::SelectAgent` + fields; the three methods
+       (`send_to_agent`/`agent_move`/`confirm_agent_pick`); `close_list`→`close_modal`;
+       `popup_modal`; footer arm; diff-freeze guard; the three compile-forced no-op arms
+       (`active_field`, `pending_location`, `carry_authored_state_from`). Unit tests:
+       empty-store precedence, `Many` → mode+choices, `None`/`Err` → status (no picker),
+       confirm closes on both success and failure, Esc → Normal + comments kept,
+       `agent_move` clamps.
+4. [ ] `lib.rs`: route Send → `send_to_agent`; `SelectAgent` key block; mouse-capture guard.
+5. [ ] `ui.rs`: `render_agent_picker`; footer glyphs.
+6. [ ] Specs: `herdr-host.md`, `input.md`. `CHANGELOG.md`, `README.md`.
+7. [ ] `just ci` (fmt-check, lint, test, release build). Sanity-run the bench once
+       (no reload/render/git/highlight hot-path change expected).
+8. [ ] `just qa-install`; drive live in a worktree with several agents.
+
+## Verification
+
+- **Done:** in a worktree with ≥2 agents, write comments, `s` → picker lists the agents
+  with titles; `↑/↓` + `Enter` drops the comments into the chosen agent's input and
+  focuses it; `Esc` keeps them. One-agent and zero-agent worktrees behave as before.
+- **Tight:** row-check the diff against the Likely Files / Execution Plan; nothing beyond
+  the picker; confirm no un-listed `Mode::List` site gained `SelectAgent`.
+- **Invariants:**
+
+| Ref | Bound to | Signal |
+| --- | --- | --- |
+| `HH-ONE-SENDS` | one workspace agent | direct send, no picker |
+| `HH-MANY-PICK` | ≥2 candidates | picker opens listing exactly them |
+| `HH-ZERO-REFUSE` | no candidate | clipboard-hint status, no picker |
+| two-tab-no-ws | 2 tab agents, no `HERDR_WORKSPACE_ID` | still ambiguous → picker, not `None` |
+| `HH-NOT-SELF`/`HH-AGENT-PANES` | reviewer pane + a plain shell present | neither appears |
+| `HH-PICK-SENDS-CHOSEN` | Enter on a row | comments land in that pane, consumed |
+| `HH-PICK-CANCEL-KEEPS` | Esc | comments preserved, mode Normal |
+| vanished agent | agent closed before Enter | error status, comments kept, picker closes |
+| empty-store precedence | `s` with no comments | "no comments to send", no picker |
+| turn tracking | several agents present | `last-turn` still paused (no auto-pick) |
+| continuity | world poll while picker open | highlight + diff undisturbed |
+| config recovery | invalid→valid config while picker open | falls to Normal, comments intact |
+
+## Review findings folded (spec-review gate)
+
+Three independent reviewers ran to completion against current `main` (two initial runs
+misfired and were re-spawned); their must-fixes are incorporated above:
+
+- **Feasibility (FEASIBLE-WITH-FIXES):** M1 preserve the `in_tab.is_empty()` None/Many
+  boundary (else the two-tab-no-ws test flips and the picker is skipped); M2
+  `confirm_agent_pick` closes the modal **unconditionally** (export's tail only closes on
+  success); M3 `AgentChoice` must derive `Debug`; S1 do **not** preserve `SelectAgent`
+  across config recovery; S2 use a **unit** variant (drop the data-in-variant fallback);
+  S3 the row discriminator is `terminal_title_stripped`, not `name` (absent for claude);
+  S4 the zero-case status loses its `agent failed:` prefix (noted); S5 fix the
+  `export.rs` test. Only **two** modal sites gain the picker (diff-freeze, mouse-capture);
+  all other `Mode::List` sites are left alone.
+- **Spec-first (SPEC-GAPS):** retire `HH-SOLE-OR-REFUSE` **and** `HH-REFUSE-SAYS-CLIPBOARD`
+  (don't reuse codes); the picker "acts through the `down`/`up` bindings" — `j`/`k` are
+  **not** fixed, only `↑`/`↓`/`enter`/`esc` are; enumerate the input.md set-sentences
+  (~172/173/62); drop `overview.md` and the `tui.md` popup edit; sharpen the new HH-*
+  wording so they don't duplicate review-model.md's consume-on-success; update the lead
+  prose of "Sending to the agent". `config.md`/`review-model.md` correctly untouched.
+- **Simplicity (TRIM-RECOMMENDED):** drop `begin_agent_pick` (inline its 3 assignments)
+  and `cancel_agent_pick` (route `Esc` straight to `close_modal`), taking the new method
+  count from five to three; `SendTarget` is transient, not held across frames (`Pick` stays
+  borrowed for the poll path); `popup_modal` and the `Pick`/`SendTarget` split are justified,
+  not overbuilt; all folded fixes are internally consistent. It also caught that
+  `active_field`/`pending_location`/`carry_authored_state_from` are exhaustive matches
+  needing an explicit (no-op) `SelectAgent` arm — folded above.
+
+## Replan Triggers
+
+- If a future herdr drops `terminal_title_stripped` for some kind, the row falls back to
+  `name`-or-kind + pane id, noted in the spec.

--- a/docs/plans/2026-07-24-agent-select-dialog/plan.md
+++ b/docs/plans/2026-07-24-agent-select-dialog/plan.md
@@ -46,11 +46,12 @@ Zero candidates still refuses with the clipboard hint; exactly one still sends d
   agents, pane `label` is `∅` on every agent pane (only plugin panes set it), and `cwd` is
   identical within a worktree. The row is composed and **omits every empty part**:
   `{name or kind} · {tab-label, shown only when it differs from the kind} · {status} — {title}`
-  (title = `terminal_title_stripped`, the live "what it's working on"). No pane id is shown;
-  `pane_id` is retained **internally** as the send target. The tab label needs a second
+  (title = `terminal_title_stripped`, the live "what it's working on"). The pane id is hidden;
+  `pane_id` is retained **internally** as the send target. **Exception:** rows that would
+  render byte-identical each show their short pane id (`ambiguous_rows`), so several
+  look-alike agents in one tab are never a blind choice. The tab label needs a second
   `herdr tab list --workspace <ws>` call joined on `tab_id` (cheap, synchronous between
-  frames like the agent list). Two agents identical in kind, tab-label, and title render as
-  look-alike rows but remain distinct selections addressing their own panes.
+  frames like the agent list).
 - A send whose chosen agent has since vanished fails gracefully: comments stay, the error
   shows, **the picker closes** (the reviewer re-presses `Send` for a fresh list).
 - **Turn tracking is unchanged.** `last-turn` still resolves only the *sole* agent; an
@@ -343,3 +344,9 @@ misfired and were re-spawned); their must-fixes are incorporated above:
 
 - If a future herdr drops `terminal_title_stripped` for some kind, the row falls back to
   `name`-or-kind + pane id, noted in the spec.
+
+## Replan Log
+
+- Row format settled with Ivan during implementation: drop the always-on pane id; key rows on
+  name-or-kind + tab label + status + title; show the short pane id only as a collision
+  fallback (`ambiguous_rows`) so several look-alike agents in one tab are never a blind choice.

--- a/specs/find-in-file.md
+++ b/specs/find-in-file.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-07-20
-Last edited: 2026-07-21
+Last edited: 2026-07-24
 ---
 
 # Find in file
@@ -29,7 +29,7 @@ Literal search within the open file in the read pane, opened with `ctrl+f`: ever
 - The query is the search input's field: the comment editor's controls, newlines excluded, a paste's newlines flattened to spaces (`input.md`, `search.md`).
 - An empty query shows a dim placeholder, lights nothing, and leaves the count blank.
 - While the band is open it owns the keymap. Every printable key is query text, so the review keys (`n`, `u`, `1`, …) lose their review action. Only the steps and `esc` act. Every other key is inert.
-- The find key is inert while composing a comment and in the comments list (`input.md`).
+- The find key is inert while composing a comment, in the comments list, and in the agent picker (`input.md`).
 
 ## Matching
 

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-23
-Last edited: 2026-07-18
+Last edited: 2026-07-24
 ---
 
 # herdr host
@@ -119,24 +119,26 @@ The binary reviews the pane's working directory, normalized to its git top level
 
 ## Sending to the agent
 
-`Send` hands over every written comment at once. The target is resolved in order:
+`Send` hands over every written comment at once. A single agent in scope receives them directly. Several agents open a picker to choose one. With no agent in scope the send refuses and the status names the clipboard copy.
 
-1. the sole agent in the sidebar's tab,
-2. else the sole agent in its workspace.
+The target resolves in order: the sole agent in the sidebar's tab, else the sole agent in its workspace. reviewr writes the comment blocks into the chosen agent pane without submitting, then focuses it. You add context and press enter.
 
-reviewr writes the comment blocks into the agent pane without submitting, then focuses it. You add context and press enter.
+Over several candidates the picker lists exactly that set. Each row shows the agent's name or kind, then its tab label when that label adds over the kind, then its status, then its terminal title. `input.md` holds the picker's keys.
 
 The candidate rules, coded for citation:
 
-| code                       | Always true                                                            |
-| -------------------------- | ---------------------------------------------------------------------- |
-| `HH-AGENT-PANES`           | Only panes carrying an `agent` field are candidates.                    |
-| `HH-NOT-SELF`              | The sidebar's own pane is never a candidate.                            |
-| `HH-TAB-WINS`              | A sole tab agent wins over the workspace fallback.                      |
-| `HH-SOLE-OR-REFUSE`        | Zero or several candidates refuse the send. Nothing is sent partially.  |
-| `HH-REFUSE-SAYS-CLIPBOARD` | A refusal says why and points at the clipboard copy.                    |
+| code                   | Always true                                                          |
+| ---------------------- | ------------------------------------------------------------------- |
+| `HH-AGENT-PANES`       | Only panes carrying an `agent` field are candidates.                |
+| `HH-NOT-SELF`          | The sidebar's own pane is never a candidate.                        |
+| `HH-TAB-WINS`          | A sole tab agent wins over the workspace fallback.                  |
+| `HH-ONE-SENDS`         | A single candidate receives the comments with no picker.            |
+| `HH-MANY-PICK`         | Several candidates open the picker over exactly that set.           |
+| `HH-ZERO-REFUSE`       | No candidate refuses the send and names the clipboard copy.         |
+| `HH-PICK-SENDS-CHOSEN` | The picker sends to the highlighted pane, not a re-resolved target. |
+| `HH-PICK-CANCEL-KEEPS` | Cancelling the picker sends nothing.                                |
 
-With `tab` placement the sidebar has its own tab, so resolution goes straight to the workspace fallback.
+With `tab` placement the sidebar has its own tab, so resolution skips to the workspace fallback, where several agents open the picker.
 
 ## Clipboard
 
@@ -144,7 +146,7 @@ The export copies through the OS clipboard utility on the machine where the bina
 
 ## Turn tracking
 
-The `last-turn` scope (`review-model.md`) needs to know when a turn starts. reviewr polls the agent's status on every worktree refresh. A turn starts when the status moves from resting (`idle` or `done`) to `working`. Moves from `blocked` or `unknown` to `working` do not start a turn.
+The `last-turn` scope (`review-model.md`) needs to know when a turn starts. reviewr polls the agent's status on every worktree refresh. A turn starts when the status moves from resting (`idle` or `done`) to `working`. Moves from `blocked` or `unknown` to `working` do not start a turn. Tracking follows a single agent only. Several agents in scope leave the resolution ambiguous, so tracking pauses like a missing agent, and the picker never auto-selects one for it.
 
 On a turn start, reviewr snapshots the worktree as a candidate baseline. The candidate becomes the live baseline on the first poll where that turn changed a file. A turn that changes nothing never moves the baseline. The live baseline is the old side of every `last-turn` diff until the next change-producing turn replaces it.
 
@@ -167,6 +169,7 @@ Send and tracking:
 - Browsing and the clipboard export work without the herdr CLI. Sending and turn tracking need it. Without it, `last-turn` stays empty and `uncommitted` and `branch` are unaffected.
 - Turn tracking resolves the agent under the same candidate rules (`HH-AGENT-PANES`, `HH-NOT-SELF`, `HH-TAB-WINS`), so a plugin sidebar or shell in the tab never pauses tracking.
 - A failed clipboard utility or `herdr pane send-text` reports the error. The comments stay in the list.
+- A picker send whose chosen agent has vanished reports the error and closes the picker. The comments stay, so a fresh `Send` re-lists the agents.
 - A turn shorter than one poll interval, or one whose start is masked by a transient `unknown` status, is missed. `last-turn` then shows the changes since the last observed turn start. It never shows lines the agent did not write.
 - A crash mid-snapshot costs at most one failed refresh. Ref updates are atomic. Leftover locks are cleared before the next snapshot and on every exit path.
 - Two sidebars on one worktree write the same baseline ref. Each samples on its own clock, so their snapshots of one turn start can differ by the edits between them. Last-writer-wins keeps the baseline within one poll interval of the turn start.

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -123,7 +123,7 @@ The binary reviews the pane's working directory, normalized to its git top level
 
 The target resolves in order: the sole agent in the sidebar's tab, else the sole agent in its workspace. reviewr writes the comment blocks into the chosen agent pane without submitting, then focuses it. You add context and press enter.
 
-Over several candidates the picker lists exactly that set. Each row shows the agent's name or kind, then its tab label when that label adds over the kind, then its status, then its terminal title. `input.md` holds the picker's keys.
+Over several candidates the picker lists exactly that set. Each row shows the agent's name or kind, then its tab label when that label adds over the kind, then its status, then its terminal title. Rows that would otherwise be identical each show their short pane id, so the choice is never blind. `input.md` holds the picker's keys.
 
 The candidate rules, coded for citation:
 

--- a/specs/input.md
+++ b/specs/input.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-07-17
-Last edited: 2026-07-21
+Last edited: 2026-07-24
 ---
 
 # Input
@@ -19,6 +19,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 - The arrows, `tab`, `esc`, `enter`, and the page keys are structural. They are fixed and never rebind.
 - A key hint in the header or the footer shows its action's first bound key.
 - The comments list acts through the same bindings and closes on `esc` and the `comments` binding.
+- The agent picker acts through the `down`/`up` bindings, sends to the highlighted agent on `enter`, and cancels on `esc`. `send` opens it when several agents are in scope (`herdr-host.md`).
 - Prose and mockups elsewhere show the default keys.
 
 | action                                                   | does                                        | keys                                        | mouse                         |
@@ -59,7 +60,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 
 `navigator-grow` and `navigator-shrink` change the active share by four percentage points. The allowed range clamps every change.
 
-These three navigator actions work from either main pane on every tab. While the comment editor is open, their printable characters are text. In the comments list they are inert. Those local modes omit the navigator actions from the footer.
+These three navigator actions work from either main pane on every tab. While the comment editor is open, their printable characters are text. In the comments list and the agent picker they are inert. Those local modes omit the navigator actions from the footer.
 
 A divider drag belongs to the navigator position and split axis at mouse-down. A keypress, terminal resize, or config-driven layout change cancels it. After cancellation, drag events are consumed until mouse-up rather than becoming a selection in the read pane.
 
@@ -169,8 +170,8 @@ Row 1's primary and actions follow the cursor:
 - An armed crossing outranks the cursor's own action and leads row 1, since only the footer says the next press leaves the file. It is the one movement key on row 1 (see Changeset traversal). While it is armed, the `move` band drops the hunk step, whose key row 1 now shows.
 - `scope`, `search`, and `find` are global, not cursor actions, so the `go` band carries them, never row 1 — `search` in every context, `find` wherever the read pane has content (`search.md`, `find-in-file.md`). `scope` leads row 1 only where nothing else does, an empty or notice diff.
 - Movement keys never sit on row 1. The `move` band shows them.
-- The comment editor, the comments list, the search screen, and the find band show their own one-row footer, without `?`. The expansion's open state is kept and restored when they close.
-- `?` (the `keys` action) toggles the expansion in `Normal` mode only. It is text in the comment editor and the search and find inputs, and inert in the comments list.
+- The comment editor, the comments list, the agent picker, the search screen, and the find band show their own one-row footer, without `?`. The expansion's open state is kept and restored when they close.
+- `?` (the `keys` action) toggles the expansion in `Normal` mode only. It is text in the comment editor and the search and find inputs, and inert in the comments list and the agent picker.
 - The changed-file count and line totals live in the header. The footer carries only the comment count, inside `s send N`.
 - On `PR` row 1 carries the PR state line and `o open ↗` per `pr-tab.md`, and `?` expands to the rest.
 

--- a/specs/search.md
+++ b/specs/search.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-07-18
-Last edited: 2026-07-20
+Last edited: 2026-07-24
 ---
 
 # Search
@@ -52,7 +52,7 @@ results.
 
 - `/` opens the search screen from any tab, from either pane. `esc` returns to the tab
   and place it left.
-- In the comment editor `/` is text. In the comments list it is inert.
+- In the comment editor `/` is text. In the comments list and the agent picker it is inert.
 - The header stays. The input band sits under it: the query with its caret, then the mode
   chips `files │ code`, the active one lit like the active header tab, the inactive one
   quiet. An empty query shows a dim placeholder. The footer carries the `tab` flip key, so

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,10 +11,11 @@ use std::path::PathBuf;
 use anyhow::Result;
 
 use crate::diff::{DiffCache, FileDiff, Row, View};
-use crate::export::{ExportTarget, format_all};
+use crate::export::{Agent, ExportTarget, format_all};
 use crate::file_list::{self, Annotation, Entry, RowKind};
 use crate::forge;
 use crate::git;
+use crate::herdr::{AgentChoice, SendTarget, resolve_send_target};
 use crate::highlight::Highlighter;
 use crate::logln;
 use crate::model::{Comment, CommentStore, Scope, Side};
@@ -128,6 +129,10 @@ pub enum Mode {
     },
     /// Browsing the comments-list overlay.
     List,
+    /// Choosing which agent to send to when several are in scope, a centered-popup modal like
+    /// `List` (specs/herdr-host.md HH-MANY-PICK, specs/input.md). Candidates live in
+    /// [`App::agent_choices`], the highlight in [`App::agent_cursor`].
+    SelectAgent,
     /// The search screen, replacing the body from any tab (specs/search.md). Its state
     /// lives in [`App::search`].
     Search,
@@ -331,6 +336,10 @@ pub enum FooterAction {
     Newline,
     Cancel,
     CloseList,
+    /// Send the comments to the highlighted agent in the picker (`enter`).
+    ConfirmAgent,
+    /// Move the highlight in the agent picker (`↑`/`↓`).
+    ChooseAgent,
     OpenPr,
     Refresh,
     Tabs,
@@ -456,6 +465,11 @@ pub struct App {
     pub select_anchor: Option<usize>,
     pub store: CommentStore,
     pub list_cursor: usize,
+    /// The agent picker's candidates while `mode == SelectAgent`, empty otherwise. Snapshotted
+    /// when the picker opens (`send_to_agent`), consumed by cancel/confirm (`specs/herdr-host.md`).
+    pub agent_choices: Vec<AgentChoice>,
+    /// The highlighted row in the agent picker.
+    pub agent_cursor: usize,
     pub mode: Mode,
     pub input: String,
     /// The comment editor's caret: a char index into `input` (`0..=chars().count()`).
@@ -606,6 +620,8 @@ impl App {
             select_anchor: None,
             store: CommentStore::new(),
             list_cursor: 0,
+            agent_choices: Vec::new(),
+            agent_cursor: 0,
             mode: Mode::Normal,
             input: String::new(),
             caret: 0,
@@ -739,8 +755,10 @@ impl App {
         match old_mode {
             // `set_config_error` closes the search overlay and the find band before the mode is
             // stored, so neither reaches recovery; their query is not restored (specs/search.md,
-            // specs/find-in-file.md).
-            Mode::Normal | Mode::Search | Mode::Find => {}
+            // specs/find-in-file.md). The agent picker is likewise not preserved: recovery drops
+            // to `Normal` with comments intact (the store is carried above), and the reviewer
+            // re-presses `Send` — the candidate snapshot would otherwise be stale.
+            Mode::Normal | Mode::Search | Mode::Find | Mode::SelectAgent => {}
             Mode::List | Mode::Composing { .. } => {
                 self.scope = old.scope;
                 self.tab = old.tab;
@@ -810,6 +828,13 @@ impl App {
 
     pub fn composing(&self) -> bool {
         matches!(self.mode, Mode::Composing { .. })
+    }
+
+    /// Whether a centered-popup modal owns the screen — the comments list or the agent picker.
+    /// These freeze the diff under them and capture the mouse, unlike the body-replacing
+    /// `Search`/`Find` screens (`specs/herdr-host.md`, `specs/input.md`).
+    pub fn popup_modal(&self) -> bool {
+        matches!(self.mode, Mode::List | Mode::SelectAgent)
     }
 
     /// The entry under the cursor when the cursor is on a file row; `None` on a directory
@@ -944,10 +969,11 @@ impl App {
             .min(self.file_rows.len().saturating_sub(1));
         // A poll preserves the file-list wheel scroll — it does not reveal the cursor.
         // Explicit actions (navigation, a scope switch) request their own reveal.
-        // While a modal is open — composing a comment, or the comments-list overlay — the
-        // open diff is frozen, so a poll can't shift the anchor beneath the writer or reset
-        // the scroll/selection under the overlay. The file list still updates above.
-        if !self.composing() && self.mode != Mode::List {
+        // While a modal is open — composing a comment, or a centered-popup overlay (the
+        // comments list or the agent picker) — the open diff is frozen, so a poll can't shift
+        // the anchor beneath the writer or reset the scroll/selection under the overlay. The
+        // file list still updates above.
+        if !self.composing() && !self.popup_modal() {
             // A poll keeps the reader on the same file; only a different shown file resets
             // the diff view to the top. It also drops an armed crossing, which was armed at the
             // edge of a file that is no longer the one on screen (specs/input.md).
@@ -2404,7 +2430,8 @@ impl App {
             Mode::Composing { .. } => Some((&mut self.input, &mut self.caret)),
             Mode::Search => self.search.as_mut().map(|s| (&mut s.query, &mut s.caret)),
             Mode::Find => self.find.as_mut().map(|f| (&mut f.query, &mut f.caret)),
-            Mode::Normal | Mode::List => None,
+            // The agent picker has no editable field — it moves a highlight, not a caret.
+            Mode::Normal | Mode::List | Mode::SelectAgent => None,
         }
     }
 
@@ -2619,7 +2646,7 @@ impl App {
                 };
                 Some(c.location())
             }
-            Mode::Normal | Mode::List | Mode::Search | Mode::Find => None,
+            Mode::Normal | Mode::List | Mode::SelectAgent | Mode::Search | Mode::Find => None,
         }
     }
 
@@ -2693,7 +2720,7 @@ impl App {
             self.status = "comment deleted".to_string();
             // Don't strand the user in an empty "Comments (0)" overlay, matching `export`.
             if self.store.is_empty() {
-                self.close_list();
+                self.close_modal();
             }
         }
     }
@@ -3075,10 +3102,56 @@ impl App {
         }
     }
 
-    pub fn close_list(&mut self) {
-        if self.mode == Mode::List {
+    /// Close whichever centered-popup modal is open (the comments list or the agent picker),
+    /// returning to `Normal`. Touches only `mode`, so consume-on-success and comment retention
+    /// are unaffected. A no-op in any other mode.
+    pub fn close_modal(&mut self) {
+        if self.popup_modal() {
             self.mode = Mode::Normal;
         }
+    }
+
+    /// Send the written comments to an agent (`s` / the header `Send` click): straight to the
+    /// sole agent, to the picker over several, or refuse over none (`specs/herdr-host.md`
+    /// HH-ONE-SENDS / HH-MANY-PICK / HH-ZERO-REFUSE). The empty-store check precedes resolution,
+    /// so the picker never opens with nothing to send.
+    pub fn send_to_agent(&mut self) {
+        if self.store.is_empty() {
+            self.status = "no comments to send".to_string();
+            return;
+        }
+        match resolve_send_target() {
+            Ok(SendTarget::One(pane)) => self.export(&Agent { pane }),
+            Ok(SendTarget::Many(choices)) => {
+                self.agent_choices = choices;
+                self.agent_cursor = 0;
+                self.mode = Mode::SelectAgent;
+            }
+            Ok(SendTarget::None) => {
+                self.status = "no agent here — copy to the clipboard instead".to_string();
+            }
+            Err(e) => self.status = format!("agent failed: {e}"),
+        }
+    }
+
+    /// Move the highlight in the agent picker, clamping at both ends.
+    pub fn agent_move(&mut self, delta: isize) {
+        if self.mode == Mode::SelectAgent && !self.agent_choices.is_empty() {
+            self.agent_cursor = step(self.agent_cursor, delta, self.agent_choices.len());
+        }
+    }
+
+    /// Send every comment to the highlighted agent (`enter` in the picker), then close the
+    /// picker regardless of outcome. `export` consumes the comments only on success and reports
+    /// the result; on a failed send (the chosen agent has since vanished) the comments stay and
+    /// the error shows, but the picker still closes so the reviewer can re-press `Send` for a
+    /// fresh list (`specs/herdr-host.md` HH-PICK-SENDS-CHOSEN).
+    pub fn confirm_agent_pick(&mut self) {
+        if let Some(choice) = self.agent_choices.get(self.agent_cursor) {
+            let pane = choice.pane_id.clone();
+            self.export(&Agent { pane });
+        }
+        self.close_modal();
     }
 
     /// The footer's actions for the current context, tagged with their [`Band`] — row 1 (primary,
@@ -3105,6 +3178,9 @@ impl App {
                     (A::EditComment, Do),
                     (A::DeleteComment, Do),
                 ];
+            }
+            Mode::SelectAgent => {
+                return vec![(A::ConfirmAgent, Primary), (A::Cancel, Do), (A::ChooseAgent, Do)];
             }
             Mode::Search => {
                 // With nothing pickable — warming, errored, or no matches — only the
@@ -3289,7 +3365,7 @@ impl App {
         }
         self.clamp_list_cursor();
         if self.store.is_empty() {
-            self.close_list();
+            self.close_modal();
         }
     }
 
@@ -3623,5 +3699,109 @@ mod tests {
         assert!(app.set_tab(super::Tab::AllFiles).is_err());
         assert!(app.move_cursor(1).is_err());
         assert!(app.select_file(0).is_err());
+    }
+
+    // --- Agent picker (specs/herdr-host.md HH-MANY-PICK, specs/input.md) -----------------
+
+    fn with_comment(app: &mut App) {
+        app.store.add(Comment {
+            file: "a.rs".to_string(),
+            side: Side::New,
+            start: 1,
+            end: 1,
+            lines: "+x".to_string(),
+            text: "note".to_string(),
+            diff_anchored: true,
+        });
+    }
+
+    fn choice(pane: &str) -> crate::herdr::AgentChoice {
+        crate::herdr::AgentChoice {
+            pane_id: pane.to_string(),
+            kind: "claude".to_string(),
+            name: None,
+            tab_label: None,
+            status: crate::turn::Status::Idle,
+            title: String::new(),
+        }
+    }
+
+    #[test]
+    fn send_with_no_comments_reports_it_and_opens_no_picker() {
+        // The empty-store check precedes agent resolution, so nothing shells out and no picker
+        // opens over an empty review.
+        let mut app = App::blocked(PathBuf::from("."), Scope::Uncommitted, None);
+        app.send_to_agent();
+        assert_eq!(app.status, "no comments to send");
+        assert_eq!(app.mode, Mode::Normal);
+    }
+
+    #[test]
+    fn popup_modal_covers_the_list_and_the_picker_only() {
+        let mut app = App::blocked(PathBuf::from("."), Scope::Uncommitted, None);
+        assert!(!app.popup_modal());
+        app.mode = Mode::List;
+        assert!(app.popup_modal());
+        app.mode = Mode::SelectAgent;
+        assert!(app.popup_modal());
+        // The body-replacing search screen is not a centered-popup modal.
+        app.mode = Mode::Search;
+        assert!(!app.popup_modal());
+    }
+
+    #[test]
+    fn agent_move_clamps_within_the_choices_and_only_in_the_picker() {
+        let mut app = App::blocked(PathBuf::from("."), Scope::Uncommitted, None);
+        app.agent_choices = vec![choice("w:p1"), choice("w:p2")];
+        // Inert outside the picker.
+        app.agent_move(1);
+        assert_eq!(app.agent_cursor, 0);
+        app.mode = Mode::SelectAgent;
+        app.agent_move(1);
+        assert_eq!(app.agent_cursor, 1);
+        app.agent_move(1); // clamps at the last row
+        assert_eq!(app.agent_cursor, 1);
+        app.agent_move(-5); // clamps at the first row
+        assert_eq!(app.agent_cursor, 0);
+    }
+
+    #[test]
+    fn cancelling_the_picker_returns_to_normal_and_keeps_comments() {
+        let mut app = App::blocked(PathBuf::from("."), Scope::Uncommitted, None);
+        with_comment(&mut app);
+        app.agent_choices = vec![choice("w:p1")];
+        app.mode = Mode::SelectAgent;
+        app.close_modal();
+        assert_eq!(app.mode, Mode::Normal);
+        assert_eq!(app.store.len(), 1, "Esc sends nothing — the comment stays");
+    }
+
+    #[test]
+    fn confirm_with_no_choice_closes_without_sending_or_panicking() {
+        // A confirm on an empty picker (a race that emptied the list) must not index out of
+        // bounds; it closes to Normal with the comment untouched and never shells out.
+        let mut app = App::blocked(PathBuf::from("."), Scope::Uncommitted, None);
+        with_comment(&mut app);
+        app.mode = Mode::SelectAgent; // agent_choices left empty
+        app.confirm_agent_pick();
+        assert_eq!(app.mode, Mode::Normal);
+        assert_eq!(app.store.len(), 1);
+    }
+
+    #[test]
+    fn config_recovery_does_not_preserve_the_picker() {
+        // The candidate snapshot would be stale after recovery, so the picker falls to Normal
+        // with comments intact; the reviewer re-presses Send (specs/herdr-host.md).
+        let mut old = App::blocked(PathBuf::from("."), Scope::Uncommitted, None);
+        with_comment(&mut old);
+        old.mode = Mode::SelectAgent;
+        old.agent_choices = vec![choice("w:p1")];
+
+        let mut recovered = App::new(PathBuf::from("."), Scope::Uncommitted, None);
+        recovered.carry_authored_state_from(&mut old);
+
+        assert_eq!(recovered.mode, Mode::Normal);
+        assert_eq!(recovered.store.len(), 1, "comments survive recovery");
+        assert!(recovered.agent_choices.is_empty());
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -465,8 +465,9 @@ pub struct App {
     pub select_anchor: Option<usize>,
     pub store: CommentStore,
     pub list_cursor: usize,
-    /// The agent picker's candidates while `mode == SelectAgent`, empty otherwise. Snapshotted
-    /// when the picker opens (`send_to_agent`), consumed by cancel/confirm (`specs/herdr-host.md`).
+    /// The agent picker's candidates, valid while `mode == SelectAgent`. Snapshotted when the
+    /// picker opens (`send_to_agent`); left in place on close (inert outside the picker) and
+    /// replaced on the next open (`specs/herdr-host.md`).
     pub agent_choices: Vec<AgentChoice>,
     /// The highlighted row in the agent picker.
     pub agent_cursor: usize,
@@ -3141,14 +3142,20 @@ impl App {
         }
     }
 
+    /// The highlighted choice, the one `confirm_agent_pick` sends to. `None` when the list is
+    /// empty (a race that emptied it under the picker).
+    pub fn picked_agent(&self) -> Option<&AgentChoice> {
+        self.agent_choices.get(self.agent_cursor)
+    }
+
     /// Send every comment to the highlighted agent (`enter` in the picker), then close the
-    /// picker regardless of outcome. `export` consumes the comments only on success and reports
-    /// the result; on a failed send (the chosen agent has since vanished) the comments stay and
-    /// the error shows, but the picker still closes so the reviewer can re-press `Send` for a
-    /// fresh list (`specs/herdr-host.md` HH-PICK-SENDS-CHOSEN).
+    /// picker regardless of outcome. The send targets that row's pane, never a re-resolved one
+    /// (`specs/herdr-host.md` HH-PICK-SENDS-CHOSEN). `export` consumes the comments only on
+    /// success; on a failed send (the chosen agent has since vanished) the comments stay and the
+    /// error shows, and the picker still closes so the reviewer can re-press `Send` for a fresh
+    /// list (`specs/herdr-host.md`, Failure semantics).
     pub fn confirm_agent_pick(&mut self) {
-        if let Some(choice) = self.agent_choices.get(self.agent_cursor) {
-            let pane = choice.pane_id.clone();
+        if let Some(pane) = self.picked_agent().map(|c| c.pane_id.clone()) {
             self.export(&Agent { pane });
         }
         self.close_modal();
@@ -3786,6 +3793,17 @@ mod tests {
         app.confirm_agent_pick();
         assert_eq!(app.mode, Mode::Normal);
         assert_eq!(app.store.len(), 1);
+    }
+
+    #[test]
+    fn the_picker_targets_the_highlighted_row_not_the_first() {
+        // HH-PICK-SENDS-CHOSEN: confirm sends to agent_choices[agent_cursor], so moving the
+        // highlight changes which pane it would target.
+        let mut app = App::blocked(PathBuf::from("."), Scope::Uncommitted, None);
+        app.agent_choices = vec![choice("w:p1"), choice("w:p2"), choice("w:p3")];
+        app.mode = Mode::SelectAgent;
+        app.agent_move(2);
+        assert_eq!(app.picked_agent().map(|c| c.pane_id.as_str()), Some("w:p3"));
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -102,9 +102,13 @@ fn select_tool(
     tools.iter().copied().find(|(cmd, _)| present(cmd))
 }
 
-/// The agent pane: fill its input via `herdr pane send-text`, then focus it.
+/// A resolved agent pane: fill its input via `herdr pane send-text`, then focus it. The
+/// caller resolves which pane (`herdr::resolve_send_target`, then either the sole agent or
+/// the reviewer's picker choice) and hands it here — this target never resolves.
 #[derive(Debug)]
-pub struct Agent;
+pub struct Agent {
+    pub pane: String,
+}
 
 impl ExportTarget for Agent {
     fn label(&self) -> &'static str {
@@ -116,11 +120,10 @@ impl ExportTarget for Agent {
     }
 
     fn export(&self, text: &str) -> Result<()> {
-        let pane = herdr::resolve_agent_pane()?;
-        herdr::send_text(&pane, text)?;
+        herdr::send_text(&self.pane, text)?;
         // Focus is a convenience once the text is delivered; a focus failure must NOT fail the
         // export, or the comments stay unconsumed and the next Send duplicates the whole review.
-        let _ = herdr::focus(&pane);
+        let _ = herdr::focus(&self.pane);
         Ok(())
     }
 }
@@ -150,8 +153,9 @@ mod tests {
 
     #[test]
     fn export_confirmations_name_the_actual_result_and_pluralize_comments() {
-        assert_eq!(Agent.success_message(1), "added 1 comment to agent input");
-        assert_eq!(Agent.success_message(2), "added 2 comments to agent input");
+        let agent = Agent { pane: "w8:p1".to_string() };
+        assert_eq!(agent.success_message(1), "added 1 comment to agent input");
+        assert_eq!(agent.success_message(2), "added 2 comments to agent input");
         assert_eq!(Clipboard.success_message(1), "copied 1 comment");
         assert_eq!(Clipboard.success_message(2), "copied 2 comments");
     }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -28,14 +28,12 @@ struct AgentPane {
     pane_id: String,
     tab_id: String,
     workspace_id: String,
-    /// The agent session name (`herdr agent start <name>` / `agent rename`). Usually absent —
-    /// unset for every `claude` session and most `codex` ones — so it is a lead label only
-    /// when present (`AgentChoice::lead`).
-    #[serde(default)]
+    /// The agent session name (`herdr agent start <name>` / `agent rename`). Usually absent,
+    /// unset for every `claude` session and most `codex` ones, so it is a lead label only when
+    /// present (`AgentChoice::lead`). A missing field deserializes to `None`, like `agent`.
     name: Option<String>,
     /// The pane's live terminal title — what the agent is working on. The one field that
     /// reliably differs between same-kind agents in a worktree (`herdr-host.md` HH-MANY-PICK).
-    #[serde(default)]
     terminal_title_stripped: Option<String>,
 }
 
@@ -53,7 +51,6 @@ struct TabList {
 struct TabInfo {
     tab_id: String,
     /// The tab's user-assigned label, when it has one.
-    #[serde(default)]
     label: Option<String>,
 }
 
@@ -130,9 +127,13 @@ fn agent_list() -> Result<Vec<AgentPane>> {
 
 /// `tab_id → label` for one workspace, best-effort: any tab without a label is skipped.
 fn tab_labels(ws: &str) -> Result<HashMap<String, String>> {
-    let json = herdr(&["tab", "list", "--workspace", ws])?;
-    let resp: TabListResponse = serde_json::from_str(&json).context("parsing tab list")?;
-    Ok(resp.result.tabs.into_iter().filter_map(|t| Some((t.tab_id, t.label?))).collect())
+    parse_tab_labels(&herdr(&["tab", "list", "--workspace", ws])?)
+}
+
+/// The `tab_id → label` map from a `herdr tab list` envelope, tabs without a label skipped.
+fn parse_tab_labels(json: &str) -> Result<HashMap<String, String>> {
+    let resp: TabListResponse = serde_json::from_str(json).context("parsing tab list")?;
+    Ok(resp.result.tabs.into_iter().filter_map(|t| t.label.map(|l| (t.tab_id, l))).collect())
 }
 
 /// The send target for the written comments: the sole agent in this tab, else the sole
@@ -261,7 +262,7 @@ pub fn focus(pane: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentChoice, AgentPane, Pick, Status, parse_agents, pick};
+    use super::{AgentChoice, AgentPane, Pick, Status, parse_agents, parse_tab_labels, pick};
 
     /// One agent entry shaped like the real `herdr agent list` output (api notes).
     fn agent(pane: &str, tab: &str, ws: &str) -> AgentPane {
@@ -400,6 +401,27 @@ mod tests {
     }
 
     #[test]
+    fn parse_agents_reads_the_name_and_title_fields_when_present() {
+        // Pins the exact `herdr agent list` key spelling the picker's labels depend on: a
+        // rename on herdr's side would otherwise deserialize silently to None and blank the
+        // row, with every other test still green.
+        let json = r#"{"result":{"agents":[{"agent":"codex","agent_status":"idle","pane_id":"w:p1","tab_id":"w:t1","workspace_id":"w","name":"fbig-import","terminal_title_stripped":"port to kotlin"}]}}"#;
+        let parsed = parse_agents(json).unwrap();
+        assert_eq!(parsed[0].name.as_deref(), Some("fbig-import"));
+        assert_eq!(parsed[0].terminal_title_stripped.as_deref(), Some("port to kotlin"));
+    }
+
+    #[test]
+    fn parse_tab_labels_reads_labels_and_skips_unlabeled_tabs() {
+        // Pins the `herdr tab list` key spelling (`tabs[].label`) the tab-note column depends on.
+        let json =
+            r#"{"result":{"tabs":[{"tab_id":"w:t1","label":"upgrade test"},{"tab_id":"w:t2"}]}}"#;
+        let labels = parse_tab_labels(json).unwrap();
+        assert_eq!(labels.get("w:t1").map(String::as_str), Some("upgrade test"));
+        assert!(!labels.contains_key("w:t2"), "a tab with no label is skipped");
+    }
+
+    #[test]
     fn row_lead_prefers_name_then_kind() {
         assert_eq!(choice("codex", Some("fbig-import"), None, "t").lead(), "fbig-import");
         assert_eq!(choice("claude", None, None, "t").lead(), "claude");
@@ -418,5 +440,7 @@ mod tests {
         assert_eq!(choice("codex", None, Some("codex"), "t").tab_note(), None);
         // No tab label (join missing / no workspace id) omits it.
         assert_eq!(choice("claude", None, None, "t").tab_note(), None);
+        // An empty-string label is treated as absent.
+        assert_eq!(choice("claude", None, Some(""), "t").tab_note(), None);
     }
 }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -83,6 +83,29 @@ impl AgentChoice {
     pub fn tab_note(&self) -> Option<&str> {
         self.tab_label.as_deref().filter(|l| !l.is_empty() && *l != self.kind)
     }
+
+    /// The short pane id (`p7` from `w…:p7`), the last colon segment. Shown only as the
+    /// collision fallback (`ambiguous_rows`), never otherwise.
+    pub fn short_pane(&self) -> &str {
+        self.pane_id.rsplit(':').next().unwrap_or(&self.pane_id)
+    }
+
+    /// The visible identity of a row: everything it shows except the hidden pane id. Two
+    /// choices with the same key render as look-alike rows.
+    fn row_key(&self) -> (&str, Option<&str>, Status, &str) {
+        (self.lead(), self.tab_note(), self.status, self.title.as_str())
+    }
+}
+
+/// For each choice, whether its composed row would be identical to another's. The picker
+/// appends the short pane id to exactly these, so several look-alike agents (same kind, no
+/// name, same tab note, same status, same title) are never a blind choice (`specs/herdr-host.md`
+/// HH-MANY-PICK).
+pub fn ambiguous_rows(choices: &[AgentChoice]) -> Vec<bool> {
+    choices
+        .iter()
+        .map(|c| choices.iter().filter(|other| other.row_key() == c.row_key()).count() > 1)
+        .collect()
 }
 
 /// Where a `Send` should go once the candidates are resolved (`specs/herdr-host.md`,
@@ -442,5 +465,29 @@ mod tests {
         assert_eq!(choice("claude", None, None, "t").tab_note(), None);
         // An empty-string label is treated as absent.
         assert_eq!(choice("claude", None, Some(""), "t").tab_note(), None);
+    }
+
+    fn choice_pane(pane: &str, kind: &str, title: &str) -> AgentChoice {
+        AgentChoice { pane_id: pane.to_string(), ..choice(kind, None, None, title) }
+    }
+
+    #[test]
+    fn ambiguous_rows_flags_look_alikes_and_spares_distinct_rows() {
+        // Two nameless same-kind agents with no tab note and no title render identically; a
+        // third with a title stands on its own.
+        let rows = [
+            choice_pane("w:p1", "claude", ""),
+            choice_pane("w:p2", "claude", ""),
+            choice_pane("w:p3", "claude", "porting invitations"),
+        ];
+        assert_eq!(super::ambiguous_rows(&rows), vec![true, true, false]);
+        // A lone agent is never ambiguous.
+        assert_eq!(super::ambiguous_rows(&rows[2..]), vec![false]);
+    }
+
+    #[test]
+    fn short_pane_is_the_last_colon_segment() {
+        assert_eq!(choice_pane("w656b5dd9e0ab31:p7", "codex", "").short_pane(), "p7");
+        assert_eq!(choice_pane("bare", "codex", "").short_pane(), "bare");
     }
 }

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -1,13 +1,14 @@
-//! herdr host integration: resolve the agent pane and send to it.
+//! herdr host integration: resolve the send target and write to an agent pane.
 //!
 //! See `specs/herdr-host.md`. Uses the herdr CLI via `$HERDR_BIN_PATH`. Only the
 //! agent-send export depends on this module; browsing and clipboard do not.
 
+use std::collections::HashMap;
 use std::env;
 use std::process::Command;
 
 use crate::turn::Status;
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -27,6 +28,74 @@ struct AgentPane {
     pane_id: String,
     tab_id: String,
     workspace_id: String,
+    /// The agent session name (`herdr agent start <name>` / `agent rename`). Usually absent —
+    /// unset for every `claude` session and most `codex` ones — so it is a lead label only
+    /// when present (`AgentChoice::lead`).
+    #[serde(default)]
+    name: Option<String>,
+    /// The pane's live terminal title — what the agent is working on. The one field that
+    /// reliably differs between same-kind agents in a worktree (`herdr-host.md` HH-MANY-PICK).
+    #[serde(default)]
+    terminal_title_stripped: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TabListResponse {
+    result: TabList,
+}
+
+#[derive(Debug, Deserialize)]
+struct TabList {
+    tabs: Vec<TabInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TabInfo {
+    tab_id: String,
+    /// The tab's user-assigned label, when it has one.
+    #[serde(default)]
+    label: Option<String>,
+}
+
+/// One agent the reviewer can send to, resolved for the picker. `pane_id` is the send
+/// target and is never displayed; the rest compose the row (`specs/herdr-host.md`
+/// HH-MANY-PICK, `specs/input.md`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentChoice {
+    /// The pane to write to. Internal — never shown.
+    pub pane_id: String,
+    /// The agent kind, `claude`/`codex` (the `agent` field).
+    pub kind: String,
+    /// The session name, when set — usually `None`.
+    pub name: Option<String>,
+    /// The tab's label, when the join found one — shown only when it differs from the kind.
+    pub tab_label: Option<String>,
+    pub status: Status,
+    /// The terminal title (`""` when the pane reports none).
+    pub title: String,
+}
+
+impl AgentChoice {
+    /// The row's lead label: the session name if set, else the agent kind.
+    pub fn lead(&self) -> &str {
+        self.name.as_deref().filter(|s| !s.is_empty()).unwrap_or(&self.kind)
+    }
+
+    /// The tab label to show as context — only when it adds information beyond the kind
+    /// (a tab literally named `codex` beside a `codex` agent says nothing).
+    pub fn tab_note(&self) -> Option<&str> {
+        self.tab_label.as_deref().filter(|l| !l.is_empty() && *l != self.kind)
+    }
+}
+
+/// Where a `Send` should go once the candidates are resolved (`specs/herdr-host.md`,
+/// HH-ONE-SENDS / HH-MANY-PICK / HH-ZERO-REFUSE): straight to the sole pane, to the picker
+/// over several, or nowhere.
+#[derive(Debug)]
+pub enum SendTarget {
+    One(String),
+    Many(Vec<AgentChoice>),
+    None,
 }
 
 fn herdr_bin() -> String {
@@ -39,7 +108,7 @@ fn herdr(args: &[&str]) -> Result<String> {
         .output()
         .with_context(|| format!("running herdr {args:?}"))?;
     if !out.status.success() {
-        bail!("herdr {args:?} failed: {}", String::from_utf8_lossy(&out.stderr).trim());
+        anyhow::bail!("herdr {args:?} failed: {}", String::from_utf8_lossy(&out.stderr).trim());
     }
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
@@ -54,22 +123,35 @@ fn agent_env() -> (Option<String>, Option<String>, Option<String>) {
 }
 
 /// The agents herdr currently lists. The one place the `agent list` call and its envelope
-/// parsing live, shared by pane and status resolution.
+/// parsing live, shared by send-target and status resolution.
 fn agent_list() -> Result<Vec<AgentPane>> {
     parse_agents(&herdr(&["agent", "list"])?)
 }
 
-/// The agent pane to send to: the sole agent in this tab, else the sole workspace agent.
-///
-/// A refusal says why and names the clipboard fallback (`specs/herdr-host.md`, HH-SOLE-OR-REFUSE/HH-REFUSE-SAYS-CLIPBOARD) —
-/// the status line renders it as `agent failed: <this message>`.
-pub fn resolve_agent_pane() -> Result<String> {
+/// `tab_id → label` for one workspace, best-effort: any tab without a label is skipped.
+fn tab_labels(ws: &str) -> Result<HashMap<String, String>> {
+    let json = herdr(&["tab", "list", "--workspace", ws])?;
+    let resp: TabListResponse = serde_json::from_str(&json).context("parsing tab list")?;
+    Ok(resp.result.tabs.into_iter().filter_map(|t| Some((t.tab_id, t.label?))).collect())
+}
+
+/// The send target for the written comments: the sole agent in this tab, else the sole
+/// workspace agent (`HH-ONE-SENDS`); several candidates go to the picker (`HH-MANY-PICK`);
+/// none refuses (`HH-ZERO-REFUSE`). Only the `Many` branch joins `tab list` for the row
+/// labels; `One`/`None` skip it.
+pub fn resolve_send_target() -> Result<SendTarget> {
     let (tab, ws, me) = agent_env();
-    match pick_agent(&agent_list()?, tab.as_deref(), ws.as_deref(), me.as_deref()) {
-        Ok(agent) => Ok(agent.pane_id.clone()),
-        Err(Refusal::NoAgent) => bail!("no agent here — copy to the clipboard instead"),
-        Err(Refusal::Several) => bail!("several agents here — copy to the clipboard instead"),
-    }
+    let agents = agent_list()?;
+    Ok(match pick(&agents, tab.as_deref(), ws.as_deref(), me.as_deref()) {
+        Pick::One(agent) => SendTarget::One(agent.pane_id.clone()),
+        Pick::None => SendTarget::None,
+        Pick::Many(panes) => {
+            // Best-effort labels: without a workspace id (or on a failed call) rows fall back
+            // to the kind. All candidates share the reviewer's workspace, so one call covers them.
+            let labels = ws.as_deref().and_then(|w| tab_labels(w).ok()).unwrap_or_default();
+            SendTarget::Many(panes.iter().map(|a| a.to_choice(&labels)).collect())
+        }
+    })
 }
 
 /// The documented `result.agents` array from `herdr agent list`.
@@ -79,41 +161,66 @@ fn parse_agents(json: &str) -> Result<Vec<AgentPane>> {
 }
 
 /// The resolved agent's `agent_status` (`idle`/`working`/`blocked`/`done`/`unknown`), for
-/// turn tracking (`specs/herdr-host.md`). `Ok(None)` when no agent resolves, so the caller
-/// treats an absent or ambiguous agent the same as a missing herdr — turn tracking pauses.
+/// turn tracking (`specs/herdr-host.md`). `Ok(None)` when no *single* agent resolves, so an
+/// absent or ambiguous agent is treated like a missing herdr — turn tracking pauses. The
+/// picker never changes this: an ambiguous send is still `None` here.
 pub fn resolved_agent_status() -> Result<Option<Status>> {
     let (tab, ws, me) = agent_env();
-    Ok(pick_agent(&agent_list()?, tab.as_deref(), ws.as_deref(), me.as_deref())
-        .ok()
-        .map(|agent| agent.agent_status))
+    let agents = agent_list()?;
+    Ok(match pick(&agents, tab.as_deref(), ws.as_deref(), me.as_deref()) {
+        Pick::One(agent) => Some(agent.agent_status),
+        Pick::Many(_) | Pick::None => None,
+    })
 }
 
-/// Why no agent resolved: none to send to, or too many to pick from.
-#[derive(Debug, PartialEq, Eq)]
-enum Refusal {
-    NoAgent,
-    Several,
+impl AgentPane {
+    /// Build the picker choice for this pane, looking its tab label up in the join map.
+    /// `agent` is always `Some` here — non-agent panes never become candidates.
+    fn to_choice(&self, labels: &HashMap<String, String>) -> AgentChoice {
+        AgentChoice {
+            pane_id: self.pane_id.clone(),
+            kind: self.agent.clone().unwrap_or_default(),
+            name: self.name.clone().filter(|s| !s.is_empty()),
+            tab_label: labels.get(&self.tab_id).cloned(),
+            status: self.agent_status,
+            title: self.terminal_title_stripped.clone().unwrap_or_default(),
+        }
+    }
 }
 
-/// The sole agent in this tab, else the sole workspace agent (`specs/herdr-host.md`, HH-AGENT-PANES through HH-SOLE-OR-REFUSE).
+/// The resolved send target: one agent, several to pick from, or none.
+enum Pick<'a> {
+    One(&'a AgentPane),
+    Many(Vec<&'a AgentPane>),
+    None,
+}
+
+/// Classify the candidates (`specs/herdr-host.md`, HH-AGENT-PANES / HH-NOT-SELF / HH-TAB-WINS
+/// / HH-ONE-SENDS / HH-MANY-PICK / HH-ZERO-REFUSE):
 ///
-/// The workspace candidates are a superset of the tab candidates whenever both env ids are
-/// present, so the refusal reason reads off the widest scope: no candidates anywhere is
-/// `NoAgent`, anything else is `Several`.
-fn pick_agent<'a>(
+/// - a sole tab agent wins outright (`HH-TAB-WINS`);
+/// - otherwise the **widest non-empty** candidate set decides — the workspace candidates when
+///   present, else the tab candidates: one → `One`, several → `Many(those)`;
+/// - `None` only when both sets are empty. So two agents sharing our tab with no workspace id
+///   are `Many`, never `None` — the picker still opens.
+fn pick<'a>(
     agents: &'a [AgentPane],
     tab: Option<&str>,
     ws: Option<&str>,
     me: Option<&str>,
-) -> Result<&'a AgentPane, Refusal> {
+) -> Pick<'a> {
     let in_tab = candidates(agents, tab, me, |agent| &agent.tab_id);
     if let &[agent] = in_tab.as_slice() {
-        return Ok(agent);
+        return Pick::One(agent);
     }
-    match candidates(agents, ws, me, |agent| &agent.workspace_id).as_slice() {
-        &[agent] => Ok(agent),
-        [] if in_tab.is_empty() => Err(Refusal::NoAgent),
-        _ => Err(Refusal::Several),
+    let in_ws = candidates(agents, ws, me, |agent| &agent.workspace_id);
+    match in_ws.as_slice() {
+        &[agent] => Pick::One(agent),
+        [] if in_tab.is_empty() => Pick::None,
+        // Workspace scope is empty (no workspace id) but the tab holds several — pick among them.
+        [] => Pick::Many(in_tab),
+        // Workspace scope is the widest ambiguous set (it is a superset of the tab candidates).
+        _ => Pick::Many(in_ws),
     }
 }
 
@@ -154,7 +261,7 @@ pub fn focus(pane: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentPane, Refusal, Status, parse_agents, pick_agent};
+    use super::{AgentChoice, AgentPane, Pick, Status, parse_agents, pick};
 
     /// One agent entry shaped like the real `herdr agent list` output (api notes).
     fn agent(pane: &str, tab: &str, ws: &str) -> AgentPane {
@@ -164,43 +271,62 @@ mod tests {
             pane_id: pane.to_string(),
             tab_id: tab.to_string(),
             workspace_id: ws.to_string(),
+            name: None,
+            terminal_title_stripped: None,
         }
     }
 
-    /// One non-agent pane as herdr 0.7.1 lists it live: `agent_status: unknown`, no `agent`
+    /// One non-agent pane as herdr lists it live: `agent_status: unknown`, no `agent`
     /// field — a plugin sidebar or a plain shell.
     fn non_agent_pane(pane: &str, tab: &str, ws: &str) -> AgentPane {
-        AgentPane {
-            agent: None,
-            agent_status: Status::Unknown,
-            pane_id: pane.to_string(),
-            tab_id: tab.to_string(),
-            workspace_id: ws.to_string(),
+        AgentPane { agent: None, agent_status: Status::Unknown, ..agent(pane, tab, ws) }
+    }
+
+    /// A choice for the row-compose tests.
+    fn choice(kind: &str, name: Option<&str>, tab_label: Option<&str>, title: &str) -> AgentChoice {
+        AgentChoice {
+            pane_id: "w:p1".to_string(),
+            kind: kind.to_string(),
+            name: name.map(str::to_string),
+            tab_label: tab_label.map(str::to_string),
+            status: Status::Idle,
+            title: title.to_string(),
         }
     }
 
-    /// [`pick_agent`] reduced to the picked `pane_id`, for terse assertions.
-    fn pick(
+    /// [`pick`] reduced to pane ids, for terse assertions.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Picked {
+        One(String),
+        Many(Vec<String>),
+        None,
+    }
+
+    fn picked(
         agents: &[AgentPane],
         tab: Option<&str>,
         ws: Option<&str>,
         me: Option<&str>,
-    ) -> Result<String, Refusal> {
-        pick_agent(agents, tab, ws, me).map(|agent| agent.pane_id.clone())
+    ) -> Picked {
+        match pick(agents, tab, ws, me) {
+            Pick::One(a) => Picked::One(a.pane_id.clone()),
+            Pick::Many(v) => Picked::Many(v.iter().map(|a| a.pane_id.clone()).collect()),
+            Pick::None => Picked::None,
+        }
     }
 
     #[test]
     fn pick_prefers_the_tab_agent_over_the_workspace() {
         let agents = vec![agent("w8:p1", "w8:t1", "w8"), agent("w8:p2", "w8:t2", "w8")];
         // Both share workspace w8; our tab is w8:t2, so its pane wins (HH-TAB-WINS).
-        assert_eq!(pick(&agents, Some("w8:t2"), Some("w8"), None), Ok("w8:p2".to_string()));
+        assert_eq!(picked(&agents, Some("w8:t2"), Some("w8"), None), Picked::One("w8:p2".into()));
     }
 
     #[test]
     fn pick_falls_back_to_the_sole_workspace_agent() {
         let agents = vec![agent("w8:p1", "w8:t1", "w8")];
-        // No agent shares our tab, but exactly one is in the workspace.
-        assert_eq!(pick(&agents, Some("w8:tX"), Some("w8"), None), Ok("w8:p1".to_string()));
+        // No agent shares our tab, but exactly one is in the workspace (HH-ONE-SENDS).
+        assert_eq!(picked(&agents, Some("w8:tX"), Some("w8"), None), Picked::One("w8:p1".into()));
     }
 
     #[test]
@@ -209,57 +335,88 @@ mod tests {
         // one (w8:p1), excluding our pane leaves the real agent unambiguous (HH-NOT-SELF).
         let agents = vec![agent("w8:p1", "w8:t1", "w8"), agent("w8:p5", "w8:t1", "w8")];
         assert_eq!(
-            pick(&agents, Some("w8:t1"), Some("w8"), Some("w8:p5")),
-            Ok("w8:p1".to_string())
+            picked(&agents, Some("w8:t1"), Some("w8"), Some("w8:p5")),
+            Picked::One("w8:p1".into())
         );
     }
 
     #[test]
     fn non_agent_panes_do_not_make_the_tab_ambiguous() {
         // A tab holding one real agent plus a non-agent pane (another plugin's sidebar, a
-        // plain shell) resolves to the agent, not an ambiguity refusal (HH-AGENT-PANES, #6).
+        // plain shell) resolves to the agent, not the picker (HH-AGENT-PANES).
         let agents = vec![agent("w3:p1", "w3:t1", "w3"), non_agent_pane("w3:p4", "w3:t1", "w3")];
         assert_eq!(
-            pick(&agents, Some("w3:t1"), Some("w3"), Some("w3:p5")),
-            Ok("w3:p1".to_string())
+            picked(&agents, Some("w3:t1"), Some("w3"), Some("w3:p5")),
+            Picked::One("w3:p1".into())
         );
     }
 
     #[test]
-    fn only_non_agent_panes_refuse_as_no_agent() {
-        // A tab and workspace holding nothing but non-agent panes has no one to send to (HH-AGENT-PANES, HH-SOLE-OR-REFUSE).
+    fn only_non_agent_panes_resolve_to_none() {
+        // A tab and workspace holding nothing but non-agent panes has no one to send to
+        // (HH-AGENT-PANES, HH-ZERO-REFUSE).
         let agents =
             vec![non_agent_pane("w3:p2", "w3:t1", "w3"), non_agent_pane("w3:p4", "w3:t1", "w3")];
-        assert_eq!(pick(&agents, Some("w3:t1"), Some("w3"), None), Err(Refusal::NoAgent));
+        assert_eq!(picked(&agents, Some("w3:t1"), Some("w3"), None), Picked::None);
     }
 
     #[test]
-    fn no_matching_agent_refuses_as_no_agent() {
+    fn no_matching_agent_resolves_to_none() {
         let agents = vec![agent("w9:p1", "w9:t1", "w9")];
-        // An agent exists, but in another workspace entirely (HH-SOLE-OR-REFUSE, HH-REFUSE-SAYS-CLIPBOARD).
-        assert_eq!(pick(&agents, Some("w8:t1"), Some("w8"), None), Err(Refusal::NoAgent));
+        // An agent exists, but in another workspace entirely (HH-ZERO-REFUSE).
+        assert_eq!(picked(&agents, Some("w8:t1"), Some("w8"), None), Picked::None);
     }
 
     #[test]
-    fn two_workspace_agents_refuse_as_several() {
+    fn two_workspace_agents_go_to_the_picker_with_the_exact_set() {
         let agents = vec![agent("w8:p1", "w8:t1", "w8"), agent("w8:p2", "w8:t2", "w8")];
-        // Neither shares our tab and the workspace has two — refuse to guess (HH-SOLE-OR-REFUSE, HH-REFUSE-SAYS-CLIPBOARD).
-        assert_eq!(pick(&agents, Some("w8:tZ"), Some("w8"), None), Err(Refusal::Several));
+        // Neither shares our tab and the workspace has two — the picker lists exactly them
+        // (HH-MANY-PICK), in list order.
+        assert_eq!(
+            picked(&agents, Some("w8:tZ"), Some("w8"), None),
+            Picked::Many(vec!["w8:p1".into(), "w8:p2".into()])
+        );
     }
 
     #[test]
-    fn two_tab_agents_refuse_as_several_even_without_a_workspace_id() {
+    fn two_tab_agents_go_to_the_picker_even_without_a_workspace_id() {
         let agents = vec![agent("w8:p1", "w8:t1", "w8"), agent("w8:p2", "w8:t1", "w8")];
-        // Two agents share our tab and no workspace id is available to widen the scope —
-        // still a several-agents refusal, not a missing-agent one (HH-SOLE-OR-REFUSE, HH-REFUSE-SAYS-CLIPBOARD).
-        assert_eq!(pick(&agents, Some("w8:t1"), None, None), Err(Refusal::Several));
+        // Two agents share our tab and no workspace id is available to widen the scope — still
+        // the picker over both, not a no-agent refusal (HH-MANY-PICK; preserves the pre-picker
+        // ambiguity boundary).
+        assert_eq!(
+            picked(&agents, Some("w8:t1"), None, None),
+            Picked::Many(vec!["w8:p1".into(), "w8:p2".into()])
+        );
     }
 
     #[test]
-    fn parse_agents_accepts_only_the_documented_envelope() {
+    fn parse_agents_accepts_the_envelope_and_defaults_absent_fields() {
         let wrapped = r#"{"result":{"agents":[{"agent":"claude","agent_status":"working","pane_id":"w8:p1","tab_id":"w8:t1","workspace_id":"w8"}]}}"#;
+        // name/terminal_title_stripped are absent → None (agent() sets both None).
         assert_eq!(parse_agents(wrapped).unwrap(), [agent("w8:p1", "w8:t1", "w8")]);
         assert!(parse_agents("[]").is_err());
         assert_eq!(serde_json::from_str::<Status>(r#""starting""#).unwrap(), Status::Unknown);
+    }
+
+    #[test]
+    fn row_lead_prefers_name_then_kind() {
+        assert_eq!(choice("codex", Some("fbig-import"), None, "t").lead(), "fbig-import");
+        assert_eq!(choice("claude", None, None, "t").lead(), "claude");
+        // An empty-string name is treated as unset.
+        assert_eq!(choice("codex", Some(""), None, "t").lead(), "codex");
+    }
+
+    #[test]
+    fn row_tab_note_is_shown_only_when_it_adds_over_the_kind() {
+        // A meaningful tab label shows.
+        assert_eq!(
+            choice("codex", None, Some("upgrade test"), "t").tab_note(),
+            Some("upgrade test")
+        );
+        // A tab label that just repeats the kind is omitted as redundant.
+        assert_eq!(choice("codex", None, Some("codex"), "t").tab_note(), None);
+        // No tab label (join missing / no workspace id) omits it.
+        assert_eq!(choice("claude", None, None, "t").tab_note(), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use ratatui::layout::Rect;
 
 use crate::app::{App, Focus, Mode};
 use crate::config::{Config, PluginConfig};
-use crate::export::{Agent, Clipboard};
+use crate::export::Clipboard;
 use crate::keymap::Keymap;
 use crate::model::Scope;
 
@@ -1443,13 +1443,26 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
     // `comments` binding (`specs/input.md`).
     if app.mode == Mode::List {
         match (action, key.code) {
-            (Some(K::Comments), _) | (_, Esc) => app.close_list(),
+            (Some(K::Comments), _) | (_, Esc) => app.close_modal(),
             (Some(K::Down), _) => app.list_move(1),
             (Some(K::Up), _) => app.list_move(-1),
-            (Some(K::Send), _) => app.export(&Agent),
+            (Some(K::Send), _) => app.send_to_agent(),
             (Some(K::Copy), _) => app.export(&Clipboard),
             (Some(K::Edit), _) => app.start_edit(),
             (Some(K::Delete), _) => app.delete_comment(),
+            _ => {}
+        }
+        return Ok(());
+    }
+
+    // The agent picker acts through the same `down`/`up` bindings, sends the comments to the
+    // highlighted agent on `enter`, and cancels on `esc` (`specs/input.md`, `specs/herdr-host.md`).
+    if app.mode == Mode::SelectAgent {
+        match (action, key.code) {
+            (_, Esc) => app.close_modal(),
+            (_, Enter) => app.confirm_agent_pick(),
+            (Some(K::Down), _) => app.agent_move(1),
+            (Some(K::Up), _) => app.agent_move(-1),
             _ => {}
         }
         return Ok(());
@@ -1486,7 +1499,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             // off-screen cursor. (The comments-list overlay targets the highlighted row instead.)
             K::Edit if app.focus == Focus::Diff => app.start_edit(),
             K::Delete if app.focus == Focus::Diff => app.delete_comment(),
-            K::Send => app.export(&Agent),
+            K::Send => app.send_to_agent(),
             K::Copy => app.export(&Clipboard),
             K::NextComment => app.jump_comment(1),
             K::PrevComment => app.jump_comment(-1),
@@ -1590,7 +1603,7 @@ pub fn handle_mouse(
 
     // A modal captures new mouse gestures, but a divider gesture cancelled by the key that
     // opened it still owns its remaining drag and mouse-up events.
-    if app.composing() || app.mode == Mode::List {
+    if app.composing() || app.popup_modal() {
         match m.kind {
             MouseEventKind::Drag(MouseButton::Left) if app.divider_drag_captured() => {
                 return Ok(());
@@ -1677,7 +1690,7 @@ pub fn handle_mouse(
                 match hit {
                     ui::HeaderHit::Tab(tab) => app.set_tab(tab)?,
                     ui::HeaderHit::Scope => app.set_scope(app.scope.cycle())?,
-                    ui::HeaderHit::Send => app.export(&Agent),
+                    ui::HeaderHit::Send => app.send_to_agent(),
                 }
             } else if let Some(i) =
                 ui::hit_file(area, app, m.column, m.row, app.file_rows.len(), app.file_scroll)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -71,6 +71,10 @@ pub fn render(frame: &mut Frame, app: &App) {
     if app.mode == Mode::List {
         render_comments_list(frame, app, area);
     }
+
+    if app.mode == Mode::SelectAgent {
+        render_agent_picker(frame, app, area);
+    }
 }
 
 /// The vertical bands: tab bar, body, footer. The comment input is inline in the diff, not a band
@@ -1421,6 +1425,8 @@ fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
         A::Newline => ("shift+enter".into(), "newline"),
         A::Cancel => ("esc".into(), "cancel"),
         A::CloseList | A::CloseSearch | A::CloseFind => ("esc".into(), "close"),
+        A::ConfirmAgent => ("enter".into(), "send"),
+        A::ChooseAgent => ("↑↓".into(), "choose"),
         A::Search => (hint(K::Search), "search"),
         A::Find => (hint(K::Find), "find"),
         A::Wrap => (hint(K::Wrap), "wrap"),
@@ -1721,6 +1727,65 @@ fn render_comments_list(frame: &mut Frame, app: &App, area: Rect) {
         })
         .collect();
     frame.render_widget(List::new(items), inner);
+}
+
+/// The agent picker popup (`specs/herdr-host.md` HH-MANY-PICK, `specs/input.md`): a centered
+/// list of the ambiguous candidates. Each row is composed and drops every empty part —
+/// `{name or kind} · {tab-label when it adds over the kind} · {status} — {title}` — with no
+/// pane id shown. Mirrors `render_comments_list`.
+fn render_agent_picker(frame: &mut Frame, app: &App, area: Rect) {
+    let p = app.palette();
+    let popup = centered(area, 80, 60);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(p.mauve))
+        .title(format!("Send to agent ({})", app.agent_choices.len()));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let width = inner.width as usize;
+    let dim = Style::default().fg(p.overlay0);
+    let items: Vec<ListItem> = app
+        .agent_choices
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let mut spans = vec![Span::styled(
+                c.lead().to_string(),
+                Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+            )];
+            if let Some(tab) = c.tab_note() {
+                spans.push(Span::styled(" · ", dim));
+                spans.push(Span::styled(tab.to_string(), dim));
+            }
+            let (word, color) = agent_status_style(p, c.status);
+            spans.push(Span::styled(" · ", dim));
+            spans.push(Span::styled(word, Style::default().fg(color)));
+            if !c.title.is_empty() {
+                // Keep the row on one line: truncate the title to what's left after the rest.
+                let used: usize = spans.iter().map(Span::width).sum();
+                let budget = width.saturating_sub(used + 3);
+                spans.push(Span::styled(" — ", dim));
+                spans.push(Span::styled(truncate_width(&c.title, budget), dim));
+            }
+            selectable_row(spans, width, (i == app.agent_cursor).then_some(p.surface2))
+        })
+        .collect();
+    frame.render_widget(List::new(items), inner);
+}
+
+/// The status word and its colour for a picker row: a resting agent (idle/done) is dim, a
+/// working one takes the accent, a blocked one the alert colour.
+fn agent_status_style(p: &Palette, status: crate::turn::Status) -> (&'static str, Color) {
+    use crate::turn::Status;
+    match status {
+        Status::Idle => ("idle", p.overlay0),
+        Status::Done => ("done", p.overlay0),
+        Status::Working => ("working", p.green),
+        Status::Blocked => ("blocked", p.red),
+        Status::Unknown => ("…", p.overlay0),
+    }
 }
 
 // --- Search screen (specs/search.md) -------------------------------------------------------

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1731,8 +1731,9 @@ fn render_comments_list(frame: &mut Frame, app: &App, area: Rect) {
 
 /// The agent picker popup (`specs/herdr-host.md` HH-MANY-PICK, `specs/input.md`): a centered
 /// list of the ambiguous candidates. Each row is composed and drops every empty part —
-/// `{name or kind} · {tab-label when it adds over the kind} · {status} — {title}` — with no
-/// pane id shown. Mirrors `render_comments_list`.
+/// `{name or kind} · {tab-label when it adds over the kind} · {status} — {title}`. The pane id
+/// is hidden, except that any rows that would render identically each show their short pane id
+/// so the choice is never blind. Mirrors `render_comments_list`.
 fn render_agent_picker(frame: &mut Frame, app: &App, area: Rect) {
     let p = app.palette();
     let popup = centered(area, 80, 60);
@@ -1746,6 +1747,7 @@ fn render_agent_picker(frame: &mut Frame, app: &App, area: Rect) {
 
     let width = inner.width as usize;
     let dim = Style::default().fg(p.overlay0);
+    let ambiguous = crate::herdr::ambiguous_rows(&app.agent_choices);
     let items: Vec<ListItem> = app
         .agent_choices
         .iter()
@@ -1762,6 +1764,12 @@ fn render_agent_picker(frame: &mut Frame, app: &App, area: Rect) {
             let (word, color) = agent_status_style(p, c.status);
             spans.push(Span::styled(" · ", dim));
             spans.push(Span::styled(word, Style::default().fg(color)));
+            // A collision fallback, before the title so its width is reserved: only rows that
+            // would otherwise be identical show their short pane id to tell them apart.
+            if ambiguous[i] {
+                spans.push(Span::styled(" · ", dim));
+                spans.push(Span::styled(c.short_pane().to_string(), dim));
+            }
             if !c.title.is_empty() {
                 // Keep the row on one line: truncate the title to what's left after the rest.
                 let used: usize = spans.iter().map(Span::width).sum();

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -900,6 +900,89 @@ fn esc_peels_one_layer_per_press() {
     assert!(!app.keys_expanded, "the next esc closes the expansion");
 }
 
+/// A written comment, for the picker tests.
+fn note() -> herdr_reviewr::model::Comment {
+    herdr_reviewr::model::Comment {
+        file: "a.rs".into(),
+        side: Side::New,
+        start: 1,
+        end: 1,
+        lines: "+x".into(),
+        text: "note".into(),
+        diff_anchored: true,
+    }
+}
+
+/// A picker candidate on `pane`, otherwise a nameless idle claude.
+fn choice(pane: &str) -> herdr_reviewr::herdr::AgentChoice {
+    herdr_reviewr::herdr::AgentChoice {
+        pane_id: pane.into(),
+        kind: "claude".into(),
+        name: None,
+        tab_label: None,
+        status: Status::Idle,
+        title: String::new(),
+    }
+}
+
+#[test]
+fn send_with_no_comment_is_inert_and_opens_no_picker() {
+    // `s` routes through the keymap to `send_to_agent`, whose empty-store guard precedes agent
+    // resolution — so nothing shells out to herdr and no picker opens.
+    let r = traversal_repo();
+    let mut app = app_on(&r);
+    let keymap = Keymap::default();
+
+    press(&mut app, &keymap, KeyCode::Char('s'));
+
+    assert_eq!(app.status, "no comments to send");
+    assert_eq!(app.mode, Mode::Normal);
+}
+
+#[test]
+fn the_agent_picker_moves_and_cancels_through_the_keymap() {
+    // The herdr-driven open (`send_to_agent` → `resolve_send_target`) is unit-tested; seeding the
+    // open picker keeps this test hermetic (no herdr subprocess) while still driving the move and
+    // cancel through the real key handler and its `Mode::SelectAgent` dispatch.
+    let r = traversal_repo();
+    let mut app = app_on(&r);
+    let keymap = Keymap::default();
+    app.store.add(note());
+    app.agent_choices = vec![choice("w:p1"), choice("w:p2"), choice("w:p3")];
+    app.mode = Mode::SelectAgent;
+
+    // `j`/`k` route through the rebindable down/up bindings and move the highlight, clamped.
+    press(&mut app, &keymap, KeyCode::Char('j'));
+    assert_eq!(app.agent_cursor, 1);
+    press(&mut app, &keymap, KeyCode::Char('k'));
+    assert_eq!(app.agent_cursor, 0);
+    for _ in 0..5 {
+        press(&mut app, &keymap, KeyCode::Char('j'));
+    }
+    assert_eq!(app.agent_cursor, 2, "the highlight clamps at the last row");
+
+    // `esc` cancels: back to Normal, the comment untouched — a cancel sends nothing.
+    press(&mut app, &keymap, KeyCode::Esc);
+    assert_eq!(app.mode, Mode::Normal);
+    assert_eq!(app.store.len(), 1);
+}
+
+#[test]
+fn enter_on_an_empty_picker_closes_without_sending() {
+    // A confirm on a picker a race has emptied must not index out of bounds; it closes to Normal
+    // with the comment untouched and never reaches the send.
+    let r = traversal_repo();
+    let mut app = app_on(&r);
+    let keymap = Keymap::default();
+    app.store.add(note());
+    app.mode = Mode::SelectAgent; // agent_choices intentionally empty
+
+    press(&mut app, &keymap, KeyCode::Enter);
+
+    assert_eq!(app.mode, Mode::Normal);
+    assert_eq!(app.store.len(), 1);
+}
+
 #[test]
 fn esc_on_pr_closes_the_expansion_and_spares_the_frozen_file_tab() {
     use herdr_reviewr::app::Tab;

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -1690,7 +1690,7 @@ fn finishing_an_edit_returns_to_its_origin() {
     assert_eq!(app.mode, Mode::List, "a list-initiated edit returns to the list");
 
     // Edit from the diff → returns to Normal.
-    app.close_list();
+    app.close_modal();
     app.focus = Focus::Diff;
     app.diff_cursor = row_with(&app, '+');
     app.start_edit();
@@ -3060,7 +3060,7 @@ fn find_is_inert_in_wrong_contexts() {
     assert_eq!(app.mode, Mode::List);
     open_find(&mut app, &keymap);
     assert_eq!(app.mode, Mode::List, "inert in the comments list");
-    app.close_list();
+    app.close_modal();
 
     // On the `PR` tab, which has no read-pane file.
     app.set_tab(Tab::Pr).unwrap();


### PR DESCRIPTION
> ⚠️ **Not yet reviewed by a human.** This change was implemented and reviewed by an AI agent (Claude Code) — the spec review, code review, and tests described below are all automated. No human has reviewed it yet, so it is left as a draft. Please let @shumkov know if you are interested in this feature.

## Summary

When a worktree holds several agents, `Send` currently refuses with *"several agents here — copy to the clipboard instead."* This PR makes `Send` open a modal **agent picker** to choose which agent receives the comments. A single agent still sends directly; no agent still refuses.

## Motivation

The refusal forces the reviewer onto `Copy`, which writes the OS clipboard on the machine the binary runs on. When reviewing over SSH/mosh (e.g. Warp → mosh → herdr on a remote host), that is the *remote* machine's clipboard, and a local paste inserts the *local* one — so the notes never reach the agent. "No clipboard over SSH" is already an explicit non-goal, so the fix is to keep the reviewer on the socket-based send even with several agents in scope. It also just makes multi-agent worktrees reviewable without leaving the sidebar.

## Behavior

- **One** agent in scope → sends directly, no picker (unchanged).
- **Several** → the picker lists exactly the ambiguous candidates. `↑`/`↓` (the `down`/`up` bindings) move the highlight, `enter` sends every comment to the highlighted agent and focuses it, `esc` cancels and keeps the comments.
- **Zero** → refuses and names the clipboard copy (unchanged).

The picker is a centered-popup modal, handled like the comments-list overlay (diff frozen underneath, mouse captured), not like the body-replacing `Search`/`Find` screens. It is not preserved across config recovery (the candidate snapshot would be stale) — recovery drops to `Normal` with the comments intact.

```
Send to agent (4)
  claude · idle — Locate Brian Floss follow-up PRs for Kotlin
  codex · upgrade test · working — platform
  release · claude · idle — Check platform repo release workflow signing
  claude · idle · p2 — (no title yet)
```

Each row is `{name or kind} · {tab label when it adds over the kind} · {status} — {title}`, every empty part dropped. `terminal_title_stripped` is the discriminator (agent `name` is usually absent). The pane id is hidden, **except** that any rows which would render byte-identical each show their short pane id (`p2` above), so several look-alike agents in one tab are never a blind choice.

## Implementation

- **`herdr.rs`** — the two-way resolve becomes a three-way `Pick` (`One` / `Many` / `None`) that preserves the exact prior ambiguity boundary (verified by a truth table across tab/workspace scope, including the no-`HERDR_WORKSPACE_ID` case). `resolve_send_target` owns a `Many`-only `herdr tab list --workspace <ws>` join for the row's tab label (best-effort: a missing workspace id, a failed call, or an unlabeled tab all degrade to the kind). `resolved_agent_status` maps `One → Some`, `Many`/`None → None`, so **turn tracking is unchanged** (an ambiguous send still pauses it; the picker never auto-selects for it). `Pick` borrows, so the per-poll status path allocates nothing.
- **`export.rs`** — `Agent` now addresses a resolved pane; the caller resolves.
- **`app.rs` / `lib.rs`** — a unit `Mode::SelectAgent`, `send_to_agent` / `agent_move` / `confirm_agent_pick`, `close_list` → `close_modal` (widened to both popups), and a `popup_modal()` helper used at the diff-freeze and mouse-capture sites. The three exhaustive `match self.mode` sites gain a no-op `SelectAgent` arm.
- **`ui.rs`** — `render_agent_picker` mirrors `render_comments_list`; `ambiguous_rows` drives the collision fallback.

## Specs

Landed with the code. In `herdr-host.md`, `HH-SOLE-OR-REFUSE` and `HH-REFUSE-SAYS-CLIPBOARD` are retired (not reused) and replaced by `HH-ONE-SENDS`, `HH-MANY-PICK` (lists exactly the ambiguous set), `HH-ZERO-REFUSE`, `HH-PICK-SENDS-CHOSEN` (the send addresses the highlighted pane, not a re-resolved one), and `HH-PICK-CANCEL-KEEPS`. `input.md` adds the picker as a local mode that acts through the `down`/`up` bindings. `search.md`, `find-in-file.md`, and `docs/herdr-api-notes.md` are updated for the new mode and the `tab list` call.

## Testing

`just ci` is green (fmt-check, `clippy -D warnings`, tests, release build). New unit tests cover the `Pick` classifier (including `Many` carrying exactly the ambiguous set and the two-tab-no-workspace-id case), the row composition (`lead`/`tab_note` including empty strings), the collision detection (`ambiguous_rows`/`short_pane`), the JSON key spelling (a round-trip parse pinning `terminal_title_stripped`/`name`/`label` so a herdr-side rename can't silently blank the labels while CI stays green), and the picker state machine (empty-store precedence, cancel keeps comments, confirm targets the highlighted row, no-preserve across config recovery).

## Notes

- Adds a dependency on `herdr tab list --workspace <ws>` (only on an ambiguous send) and reads `terminal_title_stripped` / `name` from `agent list` and `label` from `tab list` — all optional, all degrading gracefully to the kind if absent.
- The send path already uses `pane send-text`, so no new herdr write surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
