### PR TITLE
Name the tab a tab-placement open creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **A `tab`-placement sidebar is now labeled in the tab bar.** herdr gives a fresh tab a bare
+  number, so the sidebar showed up as a stray like `4` and got closed as clutter. It now names
+  the tab `reviewr`. The rename is best-effort, so an open that already succeeded never fails
+  because the rename did.
+
 ## [0.26.0] — 2026-07-28
 
 ### Changed

--- a/docs/herdr-api-notes.md
+++ b/docs/herdr-api-notes.md
@@ -38,6 +38,7 @@ herdr plugin pane close <pane_id>
 ```
 - A `split` (or `zoomed`) pane **must** pass `--target-pane` (it implies the workspace); `--workspace` alone errors.
 - New pane id: `.result.plugin_pane.pane.pane_id`. The pane is auto-labeled with the entrypoint `title`.
+- The same pane object carries `tab_id` (verified across 10 live plugin panes, 0.7.5). A `tab`-placement open reads `.result.plugin_pane.pane.tab_id` to rename the fresh tab.
 - **`plugin pane close` only closes panes in the in-memory plugin-pane registry** — after a herdr
   restart it refuses a still-live sidebar with `plugin_pane_not_found` (observed, 0.7.1). Plain
   `herdr pane close <pane_id>` closes any pane by id; prefer it for teardown.
@@ -97,6 +98,9 @@ workspace. No sample held two agents in one tab, so the order inside a tab is un
 `herdr tab list --workspace <ws>` → `{"result":{"tabs":[ {tab_id, label, number, pane_count} ]}}`.
 `label` and `number` differ: a tab with `number: 4` defaults to `label: "1"`, a per-workspace
 ordinal. The picker joins `label` on `tab_id`, best effort.
+
+`herdr tab rename <tab_id> <label>` sets a tab's `label` (0.7.5). A `tab`-placement open uses it to
+name the fresh tab `reviewr`.
 
 ```
 herdr pane send-text <agent_pane> "<literal text>"   # writes input, no Enter

--- a/herdr/sidebar.sh
+++ b/herdr/sidebar.sh
@@ -155,8 +155,16 @@ overlay)
   ;;
 esac
 
-new=$("$H" plugin pane open --plugin "${HERDR_PLUGIN_ID:-persiyanov.reviewr}" --entrypoint sidebar \
-  "$@" --cwd "$cwd" "$focus" 2>/dev/null |
-  jq -r '.result.plugin_pane.pane.pane_id // empty' 2>/dev/null)
+open_json=$("$H" plugin pane open --plugin "${HERDR_PLUGIN_ID:-persiyanov.reviewr}" --entrypoint sidebar \
+  "$@" --cwd "$cwd" "$focus" 2>/dev/null)
+new=$(printf '%s' "$open_json" | jq -r '.result.plugin_pane.pane.pane_id // empty' 2>/dev/null)
 [ -n "$new" ] || refuse "herdr plugin pane open failed"
+
+# A tab open lands in a fresh tab that herdr labels with a bare index; name it
+# after the plugin so the tab bar reads "reviewr" (HH-TAB-NAMED). Cosmetic: a
+# failed rename never fails an open that already succeeded.
+if [ "$placement" = tab ]; then
+  tab=$(printf '%s' "$open_json" | jq -r '.result.plugin_pane.pane.tab_id // empty' 2>/dev/null)
+  [ -z "$tab" ] || "$H" tab rename "$tab" reviewr >/dev/null 2>&1
+fi
 [ "$mode" = auto-open ] || printf 'opened %s (%s) in %s\n' "$new" "$placement" "$ws"

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -66,6 +66,8 @@ A manual open keeps focus on the agent for `split`, and gives focus to reviewr o
 
 A `split` or `zoomed` open attaches to the focused pane, or to the workspace's first pane when the context has none.
 
+A `tab` open names the fresh tab `reviewr`, using the `tab_id` the pane-open result reports. herdr otherwise labels a new tab with a bare number. The rename is cosmetic. When it fails, or an older herdr omits `tab_id`, the open still succeeds and the tab keeps its numeric label.
+
 **HH-EVENT-BESIDE-LAYOUT: a layout plugin handles the same event**
 
 1. `auto_open = false`. A layout plugin also handles `worktree.created`.

--- a/tests/sidebar.rs
+++ b/tests/sidebar.rs
@@ -15,7 +15,7 @@ fn fake_herdr(dir: &Path) -> (PathBuf, PathBuf) {
     fs::write(
         &path,
         format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\ncase \"$*\" in\n  'pane list'*) printf '%s\\n' '{{\"result\":{{\"panes\":[{{\"pane_id\":\"agent-1\",\"label\":\"agent\"}}]}}}}' ;;\n  *) printf '%s\\n' '{{\"result\":{{\"plugin_pane\":{{\"pane\":{{\"pane_id\":\"reviewr-1\"}}}}}}}}' ;;\nesac\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\ncase \"$*\" in\n  'pane list'*) printf '%s\\n' '{{\"result\":{{\"panes\":[{{\"pane_id\":\"agent-1\",\"label\":\"agent\"}}]}}}}' ;;\n  *) printf '%s\\n' '{{\"result\":{{\"plugin_pane\":{{\"pane\":{{\"pane_id\":\"reviewr-1\",\"tab_id\":\"tab-9\"}}}}}}}}' ;;\nesac\n",
             log.display()
         ),
     )
@@ -159,4 +159,52 @@ fn valid_non_default_placement_and_direction_reach_herdr_arguments() {
             assert!(calls.contains(direction), "{calls}");
         }
     }
+}
+
+#[test]
+fn tab_placement_open_names_its_fresh_tab() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("config.toml"), "toggle_placement = \"tab\"\n").unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+    let context = serde_json::json!({"focused_pane_cwd": env!("CARGO_MANIFEST_DIR")}).to_string();
+
+    let output = Command::new("bash")
+        .arg("herdr/sidebar.sh")
+        .arg("open")
+        .env("HERDR_REVIEWR_BIN", reviewr_bin())
+        .env("HERDR_PLUGIN_CONFIG_DIR", dir.path())
+        .env("HERDR_BIN_PATH", &herdr)
+        .env("HERDR_WORKSPACE_ID", "workspace-1")
+        .env("HERDR_PANE_ID", "agent-1")
+        .env("HERDR_PLUGIN_CONTEXT_JSON", &context)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(calls.contains("tab rename tab-9 reviewr"), "{calls}");
+}
+
+#[test]
+fn split_placement_open_renames_no_tab() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("config.toml"), "toggle_placement = \"split\"\n").unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+    let context = serde_json::json!({"focused_pane_cwd": env!("CARGO_MANIFEST_DIR")}).to_string();
+
+    let output = Command::new("bash")
+        .arg("herdr/sidebar.sh")
+        .arg("open")
+        .env("HERDR_REVIEWR_BIN", reviewr_bin())
+        .env("HERDR_PLUGIN_CONFIG_DIR", dir.path())
+        .env("HERDR_BIN_PATH", &herdr)
+        .env("HERDR_WORKSPACE_ID", "workspace-1")
+        .env("HERDR_PANE_ID", "agent-1")
+        .env("HERDR_PLUGIN_CONTEXT_JSON", &context)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(!calls.contains("tab rename"), "{calls}");
 }


### PR DESCRIPTION
## Problem

With `toggle_placement = "tab"`, the sidebar opens in a fresh tab that herdr labels with a bare index — the tab bar shows `4` instead of anything identifying reviewr. In practice that tab is indistinguishable from a stray: we hit exactly that on a fresh worktree workspace, where the auto-opened reviewr tab got closed as leftover clutter before anyone realized what it was.

## Fix

`sidebar.sh` already receives the new tab's id in the pane-open result (`.result.plugin_pane.pane.tab_id`), so after a successful `tab`-placement open it now runs `herdr tab rename <tab_id> reviewr`. No second pane listing, no race — one extra call on the path that already created the tab.

Best-effort by design: a failed rename, or an older herdr that omits `tab_id`, never fails an open that already succeeded — the tab just keeps its numeric label, same as today.

## Coverage

- Spec: the placement section of `specs/herdr-host.md` documents the rename as best-effort, cosmetic prose. It is **not** an invariant. The behavior is conditional and cosmetic, which the repo's invariant admission rule (unconditional, load-bearing, non-local) excludes. The earlier `HH-TAB-NAMED` invariant was dropped.
- API notes: `docs/herdr-api-notes.md` records the two herdr facts this depends on — `herdr tab rename <tab_id> <label>` (0.7.5), and `tab_id` on the pane object `plugin pane open` returns (verified across 10 live plugin panes, 0.7.5).
- Tests: `tab_placement_open_names_its_fresh_tab` (asserts the `tab rename tab-9 reviewr` call reaches the fake herdr) and `split_placement_open_renames_no_tab` (asserts no rename on non-tab placements); the shared fake's pane-open response gains a `tab_id`. Full `--test sidebar` suite: 8 passed. `just ci` green.
- Changelog entry under Unreleased.
- Rebased onto `main` (0.26.0); the conflict with the turn-tracking spec rewrite is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
