### PR TITLE
feat: GitHub Issue tab and per-tab reviewr pane scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   open → closed → all; `a` cycles all assignees → mine (`@me`); `L` cycles priority labels
   any → p0 → p1 → p2; `o` opens the selected issue in the browser. Lists are cached by query
   for one minute so tab re-entry and filter flips do not re-hit `gh` while fresh. Parent and
-  sub-issues nest under their parent when both are in the list (indent + `done/total`).
+  sub-issues nest under their parent when both are in the list (indent + `done/total`). When an
+  issue has comments, a detail section lists description then the thread (`→` / `←` to enter
+  and leave); on top/bottom navigator layout the comments pane sits beside the issue list.
   GitHub-only via `gh`; no comment write or edit.
 - **Per-tab reviewr panes.** `toggle` / `open` / `close` scope to the current herdr tab when
   `HERDR_TAB_ID` is set, so each herdr tab can keep its own reviewr instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Issue tab.** `4` opens a read-only GitHub Issues list (default: all open). `i` cycles
+  open → closed → all; `o` opens the selected issue in the browser. GitHub-only via `gh`;
+  no comment write or edit.
+- **Per-tab reviewr panes.** `toggle` / `open` / `close` scope to the current herdr tab when
+  `HERDR_TAB_ID` is set, so each herdr tab can keep its own reviewr instance.
+
 ## [0.29.0] — 2026-08-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Issue tab.** `4` opens a read-only GitHub Issues list (default: all open). `i` cycles
   open → closed → all; `a` cycles all assignees → mine (`@me`); `L` cycles priority labels
   any → p0 → p1 → p2; `o` opens the selected issue in the browser. Lists are cached by query
-  for one minute so tab re-entry and filter flips do not re-hit `gh` while fresh. GitHub-only
-  via `gh`; no comment write or edit.
+  for one minute so tab re-entry and filter flips do not re-hit `gh` while fresh. Parent and
+  sub-issues nest under their parent when both are in the list (indent + `done/total`).
+  GitHub-only via `gh`; no comment write or edit.
 - **Per-tab reviewr panes.** `toggle` / `open` / `close` scope to the current herdr tab when
   `HERDR_TAB_ID` is set, so each herdr tab can keep its own reviewr instance.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - **Issue tab.** `4` opens a read-only GitHub Issues list (default: all open). `i` cycles
-  open → closed → all; `o` opens the selected issue in the browser. GitHub-only via `gh`;
-  no comment write or edit.
+  open → closed → all; `a` cycles all assignees → mine (`@me`); `L` cycles priority labels
+  any → p0 → p1 → p2; `o` opens the selected issue in the browser. Lists are cached by query
+  for one minute so tab re-entry and filter flips do not re-hit `gh` while fresh. GitHub-only
+  via `gh`; no comment write or edit.
 - **Per-tab reviewr panes.** `toggle` / `open` / `close` scope to the current herdr tab when
   `HERDR_TAB_ID` is set, so each herdr tab can keep its own reviewr instance.
 

--- a/LOCAL-PATCH.md
+++ b/LOCAL-PATCH.md
@@ -1,0 +1,35 @@
+# Local patch: per-tab toggle
+
+This checkout is linked into herdr (`herdr plugin link`).
+
+## What changed
+
+`herdr/pane.sh` scopes `toggle` / `open` / `close` to the **current herdr tab**
+when `HERDR_TAB_ID` is set and `toggle_placement` is not `tab`.
+
+- Each tab can keep its own reviewr instance.
+- Toggle in one tab does not close reviewr in another tab.
+- `toggle_placement = "tab"` still uses workspace scope (reviewr is a sibling tab).
+- `auto_open` / `worktree.created` stays workspace-scoped.
+
+## Update from upstream
+
+```bash
+cd /Users/zhuo/Developer/work/herdr-reviewr
+git fetch origin
+git rebase origin/main
+# if pane.sh conflicts: keep per-tab logic, take upstream for the rest
+# if release binary needed after a version bump:
+#   copy new binary from a fresh `herdr plugin install` temp, or build with `just install`
+```
+
+Config is separate and survives:
+
+`~/.config/herdr/plugins/config/persiyanov.reviewr/`
+
+## Switch back to official
+
+```bash
+herdr plugin uninstall persiyanov.reviewr
+herdr plugin install persiyanov/herdr-reviewr
+```

--- a/LOCAL-PATCH.md
+++ b/LOCAL-PATCH.md
@@ -15,12 +15,12 @@ when `HERDR_TAB_ID` is set and `toggle_placement` is not `tab`.
 ## Update from upstream
 
 ```bash
-cd /Users/zhuo/Developer/work/herdr-reviewr
+cd /Users/zhuo/Developer/forks/herdr-reviewer
 git fetch origin
 git rebase origin/main
 # if pane.sh conflicts: keep per-tab logic, take upstream for the rest
-# if release binary needed after a version bump:
-#   copy new binary from a fresh `herdr plugin install` temp, or build with `just install`
+# release binary after build:
+#   just install   # or cargo build --release && herdr plugin link .
 ```
 
 Config is separate and survives:

--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ The action names and their defaults:
 | `scope-uncommitted` / `scope-branch` / `scope-last-turn` | `u` / `b` / `t` |
 | `tab-changes` / `tab-all-files` / `tab-pr` / `tab-issue` | `1` / `2` / `3` / `4` |
 | `issue-filter` | `i` (Issue tab: open → closed → all) |
+| `issue-assignee` | `a` (Issue tab: all → mine) |
+| `issue-priority` | `L` (Issue tab: any → p0 → p1 → p2) |
 | `wrap` | `w` |
 | `preview` | `m` |
 | `navigator-position` | `p` |

--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ The action names and their defaults:
 | `next-hunk` / `prev-hunk` | `]` / `[` |
 | `next-file` / `prev-file` | `f` / `F` |
 | `scope-uncommitted` / `scope-branch` / `scope-last-turn` | `u` / `b` / `t` |
-| `tab-changes` / `tab-all-files` / `tab-pr` | `1` / `2` / `3` |
+| `tab-changes` / `tab-all-files` / `tab-pr` / `tab-issue` | `1` / `2` / `3` / `4` |
+| `issue-filter` | `i` (Issue tab: open → closed → all) |
 | `wrap` | `w` |
 | `preview` | `m` |
 | `navigator-position` | `p` |

--- a/herdr/pane.sh
+++ b/herdr/pane.sh
@@ -11,6 +11,11 @@
 # and never read. There is no state file. Actions refuse loudly (exit 1, one stderr line)
 # and report successes on stdout; a refused event reports its config error through stderr
 # for herdr's plugin log.
+#
+# Local patch (per-tab scope): when HERDR_TAB_ID is set and toggle_placement is not "tab",
+# open/close/toggle only count reviewr panes in the current herdr tab. Other tabs keep
+# their own instances. placement=tab still uses workspace scope (reviewr lives in a
+# sibling tab). auto-open has no tab context and stays workspace-scoped.
 set -uo pipefail
 
 # herdr runs plugin commands with a minimal PATH; ensure jq/git resolve on common installs.
@@ -81,6 +86,7 @@ refuse() {
 
 ws="${HERDR_WORKSPACE_ID:-}"
 pane="${HERDR_PANE_ID:-}"
+tab="${HERDR_TAB_ID:-}"
 cwd=""
 [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ] &&
   cwd=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | jq -r '.focused_pane_cwd // .workspace_cwd // empty' 2>/dev/null)
@@ -92,6 +98,7 @@ if [ "$mode" = auto-open ] && [ -n "${HERDR_PLUGIN_EVENT_JSON:-}" ]; then
   ws=$(printf '%s' "$ev" | jq -r '.data.workspace.workspace_id // .data.worktree.open_workspace_id // empty' 2>/dev/null)
   cwd=$(printf '%s' "$ev" | jq -r '.data.workspace.worktree.checkout_path // .data.worktree.path // empty' 2>/dev/null)
   pane=""
+  tab=""
 fi
 
 [ -n "$ws" ] || refuse "no workspace context (invoke from inside herdr)"
@@ -101,6 +108,16 @@ fi
 panes_json=$("$H" pane list --workspace "$ws" 2>/dev/null) && [ -n "$panes_json" ] &&
   printf '%s' "$panes_json" | jq -e '.result.panes' >/dev/null 2>&1 ||
   refuse "herdr pane list failed for $ws"
+
+# Default upstream behavior is one reviewr per workspace. Local patch: when we know the
+# caller's tab and reviewr is not itself a sibling herdr tab (placement=tab), only manage
+# panes in that tab so each herdr tab can keep its own sidebar.
+scope_tab=""
+if [ -n "$tab" ] && [ "$placement" != "tab" ]; then
+  scope_tab="$tab"
+fi
+scope_label="$ws"
+[ -n "$scope_tab" ] && scope_label="$ws tab $scope_tab"
 
 # A reviewr pane runs the review UI in its foreground process group (specs/herdr-host.md,
 # Pane identity). A wrapped launch (`cargo run`) counts through its child; a flag run
@@ -135,12 +152,17 @@ is_reviewr_pane() {
   [ "$count" -gt 0 ] 2>/dev/null
 }
 
-# The workspace's reviewr panes: any tab, any placement, however they were launched
-# (HH-LAUNCHER-BLIND) — the actions and a layout's own pane converge on one set. The
-# per-pane reads run concurrently, so the sweep costs one process-info round-trip of
-# wall clock, not one per pane in the workspace. Each probe reports through a marker
-# file keyed by its position in the list, so nothing rests on a pane id's spelling.
-pane_list=$(printf '%s' "$panes_json" | jq -r '.result.panes[].pane_id // empty' 2>/dev/null)
+# Reviewr panes in scope: current tab when scope_tab is set, else the whole workspace
+# (HH-LAUNCHER-BLIND within that scope). The per-pane reads run concurrently, so the
+# sweep costs one process-info round-trip of wall clock, not one per pane. Each probe
+# reports through a marker file keyed by its position in the list, so nothing rests on
+# a pane id's spelling.
+if [ -n "$scope_tab" ]; then
+  pane_list=$(printf '%s' "$panes_json" | jq -r --arg t "$scope_tab" \
+    '.result.panes[] | select(.tab_id == $t) | .pane_id // empty' 2>/dev/null)
+else
+  pane_list=$(printf '%s' "$panes_json" | jq -r '.result.panes[].pane_id // empty' 2>/dev/null)
+fi
 probe_dir=$(mktemp -d) || refuse "cannot create a temp dir"
 trap 'rm -rf "$probe_dir"' EXIT
 i=0
@@ -199,13 +221,13 @@ close_all() {
   done <<EOF
 $existing
 EOF
-  [ -z "$failed" ] || refuse "herdr pane close failed for$failed in $ws"
-  printf 'closed%s in %s\n' "$closed" "$ws"
+  [ -z "$failed" ] || refuse "herdr pane close failed for$failed in $scope_label"
+  printf 'closed%s in %s\n' "$closed" "$scope_label"
 }
 
 case "$mode" in
 close)
-  [ -n "$existing" ] || { printf 'close: nothing open in %s\n' "$ws"; exit 0; }
+  [ -n "$existing" ] || { printf 'close: nothing open in %s\n' "$scope_label"; exit 0; }
   close_all
   exit 0
   ;;
@@ -217,7 +239,7 @@ toggle)
   ;;
 open | auto-open)
   if [ -n "$existing" ]; then
-    [ "$mode" = open ] && printf 'open: already open (%s) in %s\n' "$(printf '%s' "$existing" | tr '\n' ' ' | sed 's/ $//')" "$ws"
+    [ "$mode" = open ] && printf 'open: already open (%s) in %s\n' "$(printf '%s' "$existing" | tr '\n' ' ' | sed 's/ $//')" "$scope_label"
     exit 0
   fi
   ;;
@@ -236,13 +258,18 @@ focus=--no-focus
 [ "$mode" != auto-open ] && [ "$placement" != "split" ] && focus=--focus
 
 # Placement decides the pane-open shape (spec: Pane placement). A split or zoomed
-# open attaches to the focused pane, else the workspace's first pane.
+# open attaches to the focused pane, else the first pane in scope (current tab when set).
 case "$placement" in
 split | zoomed)
   if [ -z "$pane" ]; then
-    pane=$(printf '%s' "$panes_json" | jq -r '.result.panes[0].pane_id // empty' 2>/dev/null)
+    if [ -n "$scope_tab" ]; then
+      pane=$(printf '%s' "$panes_json" | jq -r --arg t "$scope_tab" \
+        '.result.panes[] | select(.tab_id == $t) | .pane_id // empty' 2>/dev/null | head -n1)
+    else
+      pane=$(printf '%s' "$panes_json" | jq -r '.result.panes[0].pane_id // empty' 2>/dev/null)
+    fi
   fi
-  [ -n "$pane" ] || refuse "no pane to attach to in $ws"
+  [ -n "$pane" ] || refuse "no pane to attach to in $scope_label"
   set -- --placement "$placement" --target-pane "$pane"
   [ "$placement" = "split" ] && set -- "$@" --direction "$direction"
   ;;
@@ -266,7 +293,7 @@ new=$(printf '%s' "$open_json" | jq -r '.result.plugin_pane.pane.pane_id // empt
 # after the plugin so the tab bar reads "reviewr" (specs/herdr-host.md). Cosmetic: a
 # failed rename never fails an open that already succeeded.
 if [ "$placement" = tab ]; then
-  tab=$(printf '%s' "$open_json" | jq -r '.result.plugin_pane.pane.tab_id // empty' 2>/dev/null)
-  [ -z "$tab" ] || "$H" tab rename "$tab" reviewr >/dev/null 2>&1
+  opened_tab=$(printf '%s' "$open_json" | jq -r '.result.plugin_pane.pane.tab_id // empty' 2>/dev/null)
+  [ -z "$opened_tab" ] || "$H" tab rename "$opened_tab" reviewr >/dev/null 2>&1
 fi
-[ "$mode" = auto-open ] || printf 'opened %s (%s) in %s\n' "$new" "$placement" "$ws"
+[ "$mode" = auto-open ] || printf 'opened %s (%s) in %s\n' "$new" "$placement" "$scope_label"

--- a/specs/input.md
+++ b/specs/input.md
@@ -33,7 +33,8 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 | —                                                        | scroll the viewport, selection put          | —                                           | wheel over the pane           |
 | —                                                        | scroll the diff horizontally (wrap off)     | `←` / `→`                                   | —                             |
 | `scope-uncommitted` / `scope-branch` / `scope-last-turn` | switch scope                                | `u` / `b` / `t`                             | click the scope chip to cycle |
-| `tab-changes` / `tab-all-files` / `tab-pr`               | switch tab                                  | `1` / `2` / `3`                             | click a tab name              |
+| `tab-changes` / `tab-all-files` / `tab-pr` / `tab-issue` | switch tab                                  | `1` / `2` / `3` / `4`                       | click a tab name              |
+| `issue-filter`                                           | cycle Issue list filter (open/closed/all)   | `i`                                         | click `[filter]` chip         |
 | —                                                        | expand the fold under the cursor            | `→`                                         | click the `⋯` row             |
 | —                                                        | open a link in rendered markdown            | —                                           | click the link                |
 | `wrap`                                                   | toggle line wrap                            | `w`                                         | —                             |

--- a/specs/input.md
+++ b/specs/input.md
@@ -34,7 +34,9 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 | —                                                        | scroll the diff horizontally (wrap off)     | `←` / `→`                                   | —                             |
 | `scope-uncommitted` / `scope-branch` / `scope-last-turn` | switch scope                                | `u` / `b` / `t`                             | click the scope chip to cycle |
 | `tab-changes` / `tab-all-files` / `tab-pr` / `tab-issue` | switch tab                                  | `1` / `2` / `3` / `4`                       | click a tab name              |
-| `issue-filter`                                           | cycle Issue list filter (open/closed/all)   | `i`                                         | click `[filter]` chip         |
+| `issue-filter`                                           | cycle Issue state filter (open/closed/all)  | `i`                                         | click `[open]` / state chip   |
+| `issue-assignee`                                         | cycle Issue assignee (all/mine)             | `a`                                         | click `[all]` / assignee chip |
+| `issue-priority`                                         | cycle Issue priority label (any/p0/p1/p2)   | `L`                                         | click `[any]` / priority chip |
 | —                                                        | expand the fold under the cursor            | `→`                                         | click the `⋯` row             |
 | —                                                        | open a link in rendered markdown            | —                                           | click the link                |
 | `wrap`                                                   | toggle line wrap                            | `w`                                         | —                             |

--- a/specs/issue-tab.md
+++ b/specs/issue-tab.md
@@ -6,18 +6,18 @@ Last edited: 2026-08-07
 
 # Issue tab
 
-A read-only GitHub Issues list in reviewr's frame: filter chip in the header, issues in the navigator, the selected body in the read pane.
+A read-only GitHub Issues list in reviewr's frame: filter chips in the header, issues in the navigator, the selected body in the read pane.
 
 ## Overview
 
 ```
- 1 Changes  2 All files  3 PR  4 Issue    #42 Fix the pane                [open]
+ 1 Changes  2 All files  3 PR  4 Issue    #42 Fix the pane     [open] [all] [any]
 ╭─ #42 · @alice ─────────────────────────╮╭─ Issues · open ──────────────╮
 │ labels: bug, ui                        ││ ● #42 Fix the pane        2d │
 │                                        ││ ● #41 Docs polish         5d │
 │ Details here…                          ││                              │
 ╰────────────────────────────────────────╯╰──────────────────────────────╯
- 12 open issues   i open · o open ↗ · …                                    ?
+ 12 open issues   i open · a all · L any · o open ↗ · …                    ?
 ```
 
 v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close — those need write permissions and stay out of scope.
@@ -27,25 +27,33 @@ v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close �
 ### Header and footer
 
 - Tab label is `4 Issue` (rebindable as `tab-issue`).
-- Right-anchored filter chip: `[open]` (default), `[closed]`, or `[all]`. Click or `i` (`issue-filter`) cycles open → closed → all → open.
-- Selected issue title sits left of the chip when room allows.
-- Footer leads with the filter action; `o open ↗` when a row is selected; go/move bands match the PR tab (line/page only).
+- Right-anchored filter chips (state, assignee, priority), each clickable:
+  - State `[open]` (default) / `[closed]` / `[all]` — `i` (`issue-filter`)
+  - Assignee `[all]` (default) / `[mine]` — `a` (`issue-assignee`); `mine` is `gh --assignee @me`
+  - Priority `[any]` (default) / `[p0]` / `[p1]` / `[p2]` — `L` (`issue-priority`); matches that label name case-insensitively via `gh --label`
+- Selected issue title sits left of the chips when room allows.
+- Footer row 1: primary `i {state}`, then `a {assignee}` and `L {priority}` as actions; `o open ↗`
+  when a row is selected. go/move bands match the PR tab (line/page only).
 
 ### Navigator and read pane
 
-- Navigator title `Issues · {filter}`; rows `#n title  age` with open/closed glyph
+- Navigator title `Issues · {state}` plus ` · mine` / ` · pN` when those filters are active; rows `#n title  age` with open/closed glyph
   (`●` green = open, `○` dim = closed). A title too wide for the row keeps its **head**
   and trails with `…` (not a path-style head elision).
 - `j`/`k` or a click selects an issue; the read pane shows labels (if any) then the body as markdown.
-- Empty body shows a dim italic placeholder. Empty list shows `No {filter} issues.`
-- `o` opens the selected issue URL in the browser; `r` refetches.
-- Authoring keys (`s`, `c`, `v`, `d`, `e`) are inert.
+- Empty body shows a dim italic placeholder. Empty list shows `No {query} issues.`
+- `o` opens the selected issue URL in the browser; `r` refetches (bypasses the cache).
+- Authoring keys (`s`, `c`, `v`, `d`, `e`) are inert. The comments-list key is free for other tabs; priority uses `L` so it does not steal `l`.
 
 ### Filter and refresh
 
-- Default filter is **open** (all open issues in the repository).
-- Fetch on tab entry, on filter change, on `r`, and on a slow fallback timer while the tab is active.
-- A failed refetch keeps the last good list and shows a retry notice (same freeze rule as the PR tab).
+- Default query: **open**, all assignees, any priority.
+- Filters compose into one `gh issue list` call (`--state`, optional `--assignee @me`, optional `--label pN`).
+- **Cache.** Successful list results are keyed by the full query (and repository identity). Within a **1 minute** TTL:
+  - Re-entering the Issue tab with the same query paints the cache and does **not** call `gh`.
+  - Cycling a filter paints a cached result for the new query immediately when present and fresh; only a miss or expiry starts a fetch.
+- Fetch triggers: first need (no fresh cache), filter change without a fresh cache entry, `r` (always), and a slow fallback timer (**1 minute**) while the tab is active and the current query's entry is stale or missing.
+- A failed refetch keeps the last good list for the active query and shows a retry notice (same freeze rule as the PR tab).
 
 ### Degradation
 
@@ -57,6 +65,8 @@ v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close �
 - Writing comments, editing, closing, or assigning issues.
 - Multi-forge issue providers.
 - Linking issues to the current branch PR.
+- Arbitrary label pickers or multi-label OR queries beyond the p0/p1/p2 cycle.
+- Resolving the signed-in login for display (assignee filter uses `@me`).
 
 ## Related specs
 

--- a/specs/issue-tab.md
+++ b/specs/issue-tab.md
@@ -1,0 +1,64 @@
+---
+Status: Current
+Created: 2026-08-07
+Last edited: 2026-08-07
+---
+
+# Issue tab
+
+A read-only GitHub Issues list in reviewr's frame: filter chip in the header, issues in the navigator, the selected body in the read pane.
+
+## Overview
+
+```
+ 1 Changes  2 All files  3 PR  4 Issue    #42 Fix the pane                [open]
+╭─ #42 · @alice ─────────────────────────╮╭─ Issues · open ──────────────╮
+│ labels: bug, ui                        ││ ● #42 Fix the pane        2d │
+│                                        ││ ● #41 Docs polish         5d │
+│ Details here…                          ││                              │
+╰────────────────────────────────────────╯╰──────────────────────────────╯
+ 12 open issues   i open · o open ↗ · …                                    ?
+```
+
+v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close — those need write permissions and stay out of scope.
+
+## Behavior
+
+### Header and footer
+
+- Tab label is `4 Issue` (rebindable as `tab-issue`).
+- Right-anchored filter chip: `[open]` (default), `[closed]`, or `[all]`. Click or `i` (`issue-filter`) cycles open → closed → all → open.
+- Selected issue title sits left of the chip when room allows.
+- Footer leads with the filter action; `o open ↗` when a row is selected; go/move bands match the PR tab (line/page only).
+
+### Navigator and read pane
+
+- Navigator title `Issues · {filter}`; rows `#n title  age` with open/closed glyph.
+- `j`/`k` or a click selects an issue; the read pane shows labels (if any) then the body as markdown.
+- Empty body shows a dim italic placeholder. Empty list shows `No {filter} issues.`
+- `o` opens the selected issue URL in the browser; `r` refetches.
+- Authoring keys (`s`, `c`, `v`, `d`, `e`) are inert.
+
+### Filter and refresh
+
+- Default filter is **open** (all open issues in the repository).
+- Fetch on tab entry, on filter change, on `r`, and on a slow fallback timer while the tab is active.
+- A failed refetch keeps the last good list and shows a retry notice (same freeze rule as the PR tab).
+
+### Degradation
+
+- Missing `gh`, unauthenticated host, missing forge remote, unsupported host, and non-GitHub forges each render their own empty-state remedy.
+- GitLab / Azure DevOps remotes say Issues are GitHub-only for now.
+
+## Non-goals
+
+- Writing comments, editing, closing, or assigning issues.
+- Multi-forge issue providers.
+- Linking issues to the current branch PR.
+
+## Related specs
+
+- [pr-tab](./pr-tab.md) — layout and interaction template
+- [forge-host](./forge-host.md) — repository identity
+- [input](./input.md) — keybindings
+- [tui](./tui.md) — frame chrome

--- a/specs/issue-tab.md
+++ b/specs/issue-tab.md
@@ -33,7 +33,9 @@ v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close �
 
 ### Navigator and read pane
 
-- Navigator title `Issues · {filter}`; rows `#n title  age` with open/closed glyph.
+- Navigator title `Issues · {filter}`; rows `#n title  age` with open/closed glyph
+  (`●` green = open, `○` dim = closed). A title too wide for the row keeps its **head**
+  and trails with `…` (not a path-style head elision).
 - `j`/`k` or a click selects an issue; the read pane shows labels (if any) then the body as markdown.
 - Empty body shows a dim italic placeholder. Empty list shows `No {filter} issues.`
 - `o` opens the selected issue URL in the browser; `r` refetches.

--- a/specs/issue-tab.md
+++ b/specs/issue-tab.md
@@ -13,9 +13,9 @@ A read-only GitHub Issues list in reviewr's frame: filter chips in the header, i
 ```
  1 Changes  2 All files  3 PR  4 Issue    #42 Fix the pane     [open] [all] [any]
 ╭─ #42 · @alice ─────────────────────────╮╭─ Issues · open ──────────────╮
-│ labels: bug, ui                        ││ ● #42 Fix the pane        2d │
-│                                        ││ ● #41 Docs polish         5d │
-│ Details here…                          ││                              │
+│ labels: bug, ui                        ││ ● #10 Epic              1/2 2d│
+│                                        ││   ● #12 child a            1d│
+│ Details here…                          ││   ● #13 child b            5h│
 ╰────────────────────────────────────────╯╰──────────────────────────────╯
  12 open issues   i open · a all · L any · o open ↗ · …                    ?
 ```
@@ -40,9 +40,13 @@ v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close �
 - Navigator title `Issues · {state}` plus ` · mine` / ` · pN` when those filters are active; rows `#n title  age` with open/closed glyph
   (`●` green = open, `○` dim = closed). A title too wide for the row keeps its **head**
   and trails with `…` (not a path-style head elision).
+- **Parent / sub-issues.** Fetched via `parent` and `subIssuesSummary` on `gh issue list`. The list
+  is reordered so each child sits under its parent when both are in the current result (one
+  nesting level, two-space indent). A child whose parent is missing from the list (e.g. open
+  filter, closed parent) stays top-level. Parents with sub-issues show `done/total` before the age.
 - `j`/`k` or a click selects an issue; the read pane leads with the **full title** in markdown H1
-  style (bold mauve, wrapped — the navigator may have truncated it), then labels (if any), then
-  the body as markdown.
+  style (bold mauve, wrapped — the navigator may have truncated it), then a dim parent/sub
+  summary when relevant, then labels (if any), then the body as markdown.
 - Empty body shows a dim italic placeholder. Empty list shows `No {query} issues.`
 - `o` opens the selected issue URL in the browser; `r` refetches (bypasses the cache).
 - Authoring keys (`s`, `c`, `v`, `d`, `e`) are inert. The comments-list key is free for other tabs; priority uses `L` so it does not steal `l`.
@@ -69,6 +73,7 @@ v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close �
 - Linking issues to the current branch PR.
 - Arbitrary label pickers or multi-label OR queries beyond the p0/p1/p2 cycle.
 - Resolving the signed-in login for display (assignee filter uses `@me`).
+- Expand/collapse of sub-issue trees, multi-level nesting, or extra fetches for missing parents.
 
 ## Related specs
 

--- a/specs/issue-tab.md
+++ b/specs/issue-tab.md
@@ -13,14 +13,19 @@ A read-only GitHub Issues list in reviewr's frame: filter chips in the header, i
 ```
  1 Changes  2 All files  3 PR  4 Issue    #42 Fix the pane     [open] [all] [any]
 ╭─ #42 · @alice ─────────────────────────╮╭─ Issues · open ──────────────╮
-│ labels: bug, ui                        ││ ● #10 Epic              1/2 2d│
-│                                        ││   ● #12 child a            1d│
-│ Details here…                          ││   ● #13 child b            5h│
+│ labels: bug, ui                        ││ #10 Epic                1/2 2d│
+│                                        ││   #12 child a              1d│
+│ Details here…                          ││   #13 child b              5h│
+│                                        ││                              │
+│                                        ││ comments · 2                 │
+│                                        ││ description                  │
+│                                        ││ @bob                   5h    │
+│                                        ││ @alice                  2d    │
 ╰────────────────────────────────────────╯╰──────────────────────────────╯
  12 open issues   i open · a all · L any · o open ↗ · …                    ?
 ```
 
-v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close — those need write permissions and stay out of scope.
+v1 is **GitHub only** via `gh issue list` (list rows include each issue's comments). No comment write, no edit, no close — those need write permissions and stay out of scope.
 
 ## Behavior
 
@@ -37,18 +42,41 @@ v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close �
 
 ### Navigator and read pane
 
-- Navigator title `Issues · {state}` plus ` · mine` / ` · pN` when those filters are active; rows `#n title  age` with open/closed glyph
-  (`●` green = open, `○` dim = closed). A title too wide for the row keeps its **head**
+- Navigator title `Issues · {state}` plus ` · mine` / ` · pN` when those filters are active; rows `#n title  age`.
+  Open/closed is carried by the `#n` color only: accent (yellow) when open, secondary dim
+  (`overlay0`) when closed. A title too wide for the row keeps its **head**
   and trails with `…` (not a path-style head elision).
 - **Parent / sub-issues.** Fetched via `parent` and `subIssuesSummary` on `gh issue list`. The list
   is reordered so each child sits under its parent when both are in the current result (one
   nesting level, two-space indent). A child whose parent is missing from the list (e.g. open
   filter, closed parent) stays top-level. Parents with sub-issues show `done/total` before the age.
-- `j`/`k` or a click selects an issue; the read pane leads with the **full title** in markdown H1
-  style (bold mauve, wrapped — the navigator may have truncated it), then a dim parent/sub
-  summary when relevant, then labels (if any), then the body as markdown.
-- Empty body shows a dim italic placeholder. Empty list shows `No {query} issues.`
-- `o` opens the selected issue URL in the browser; `r` refetches (bypasses the cache).
+- **Detail section.** When the selected issue has at least one comment, a detail surface
+  lists a pinned `description` row (the issue body) then the comments newest-first
+  (`@author` and age). Omitted entirely when the selected issue has no comments. Comments
+  arrive with the list fetch (`gh issue list --json …,comments`).
+  - **Side body layout** (`left`/`right`): detail stacks under the issue rows in one
+    navigator column, under a dim `comments · N` header.
+  - **Stacked body layout** (`top`/`bottom`): the navigator splits **half-and-half** —
+    issues on the left, a `comments · N` panel on the right — so the short navigator
+    height still leaves room for the thread.
+  - The detail surface always ends with a one-row hint `← issues · → comments` (the inert
+    direction is dimmed).
+- **Two-level focus.** The issue list and the detail section are separate focus zones:
+  - `→` on an issue with comments enters detail focus on `description` (issue row stays
+    highlighted as the selected parent). `→` is inert when the issue has no comments.
+  - `←` (or `esc`) from detail returns focus to the issue list; the same issue stays selected.
+  - `j`/`k` move within the active zone only (issues, or description → comments).
+  - A click on an issue selects it and leaves detail. A click on `description` or a comment
+    enters detail on that row.
+- The read pane shows the focused detail (or the issue body while list-focused):
+  - **Description / list focus:** the **full title** in markdown H1 style (bold mauve,
+    wrapped — the navigator may have truncated it), then a dim parent/sub summary when
+    relevant, then labels (if any), then the body as markdown. Empty body shows a dim
+    italic placeholder.
+  - **Comment focused:** `@author · comment` title and the comment body as markdown.
+- Empty list shows `No {query} issues.`
+- `o` opens the selected issue URL in the browser (issue row or its comment); `r` refetches
+  (bypasses the cache).
 - Authoring keys (`s`, `c`, `v`, `d`, `e`) are inert. The comments-list key is free for other tabs; priority uses `L` so it does not steal `l`.
 
 ### Filter and refresh

--- a/specs/issue-tab.md
+++ b/specs/issue-tab.md
@@ -40,7 +40,9 @@ v1 is **GitHub only** via `gh issue list`. No comment write, no edit, no close �
 - Navigator title `Issues · {state}` plus ` · mine` / ` · pN` when those filters are active; rows `#n title  age` with open/closed glyph
   (`●` green = open, `○` dim = closed). A title too wide for the row keeps its **head**
   and trails with `…` (not a path-style head elision).
-- `j`/`k` or a click selects an issue; the read pane shows labels (if any) then the body as markdown.
+- `j`/`k` or a click selects an issue; the read pane leads with the **full title** in markdown H1
+  style (bold mauve, wrapped — the navigator may have truncated it), then labels (if any), then
+  the body as markdown.
 - Empty body shows a dim italic placeholder. Empty list shows `No {query} issues.`
 - `o` opens the selected issue URL in the browser; `r` refetches (bypasses the cache).
 - Authoring keys (`s`, `c`, `v`, `d`, `e`) are inert. The comments-list key is free for other tabs; priority uses `L` so it does not steal `l`.

--- a/specs/overview.md
+++ b/specs/overview.md
@@ -19,13 +19,14 @@ open the pane → pick a changed file → read its diff → comment on a range
 → send the comments to the agent → add a line and hit enter
 ```
 
-Three tabs:
+Four tabs:
 
 | tab         | shows                                                                  |
 | ----------- | ---------------------------------------------------------------------- |
 | `Changes`   | the active scope's changed files, with a syntax-highlighted diff viewer |
 | `All files` | the whole repo tree, with a read-and-comment content viewer             |
 | `PR`        | a read-only mirror of the pull request: state, checks, comments         |
+| `Issue`     | a read-only GitHub Issues list (open by default; filterable)            |
 
 ## Voice
 
@@ -43,6 +44,7 @@ to move the work forward.
 - The `Changes` view: a changed-files list per scope plus the diff viewer (`diff-view.md`).
 - The `All files` tab: a repo tree and content viewer, annotated with the active scope's changes (`file-list.md`, `diff-view.md`).
 - The `PR` tab: pull-request identity, state, checks, and comments, read from the repository's forge, with external links only (`forge-host.md`, `pr-tab.md`).
+- The `Issue` tab: GitHub issues list (open / closed / all), body read-only, external links only (`issue-tab.md`).
 - Three scopes: `uncommitted`, `branch`, `last-turn` (`review-model.md`).
 - Comments anchored to `path:start-end`, held in memory for the review pass.
 - Export of all comments to the agent input or the clipboard.

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -11,7 +11,7 @@ The terminal frame: the pane layout, the tabs, and how the view stays current.
 ## Overview
 
 ```
-┌ 1 Changes  2 All files  3 PR  [uncommitted]  9 changed  +42 −18 [ Send (3) ] ┐
+┌ 1 Changes  2 All files  3 PR  4 Issue  [uncommitted]  9 changed  +42 −18 [ Send (3) ] ┐
 │ ⋯  11 unmodified lines                       │ M llm_registry.py  +18 -8  │
 │ 40    def resolve(self, name):               │ M deep_research.py +155-62 │
 │ 41 ▌  from .z import w                         │ D old_runner.py    -47     │

--- a/src/app.rs
+++ b/src/app.rs
@@ -4052,6 +4052,9 @@ mod tests {
                 updated_at: "2026-08-01T12:00:00Z".into(),
                 url: "https://github.com/o/r/issues/1".into(),
                 labels: vec![],
+                parent_number: None,
+                sub_completed: 0,
+                sub_total: 0,
             }],
             truncated: false,
         }));

--- a/src/app.rs
+++ b/src/app.rs
@@ -560,13 +560,22 @@ pub struct App {
     issue_notice: Option<String>,
     /// A same-input issue refresh that crossed the loading-indicator delay.
     issue_refreshing: bool,
-    /// Navigator cursor over the issue list.
+    /// Navigator cursor over the issue list (always the selected issue; stays highlighted while
+    /// the detail section below is focused — specs/issue-tab.md).
     pub(crate) issue_cursor: usize,
+    /// When `Some`, focus is in the detail section under the selected issue: `0` is the
+    /// pinned `description` row (issue body), `1 + i` is `comments[i]`. `None` means focus is
+    /// on the issue list. `→` enters (when the issue has comments); `←` leaves.
+    pub(crate) issue_detail_cursor: Option<usize>,
     /// Top visible line of the issue read pane.
     pub(crate) issue_read_scroll: usize,
-    /// Top visible row of the issue navigator.
+    /// Top visible row of the issue list (or the combined list in side layout).
     issue_nav_scroll: std::cell::Cell<usize>,
     issue_nav_max_scroll: std::cell::Cell<usize>,
+    /// Top visible row of the detail pane when the navigator is split issues | comments
+    /// (stacked body layout with comments present — specs/issue-tab.md).
+    issue_detail_nav_scroll: std::cell::Cell<usize>,
+    issue_detail_nav_max_scroll: std::cell::Cell<usize>,
     reveal_issue_nav: std::cell::Cell<bool>,
     /// Issue refresh awaiting dispatch (same draw-then-fetch cadence as PR).
     pub issue_pending: Option<RefreshKind>,
@@ -721,9 +730,12 @@ impl App {
             issue_notice: None,
             issue_refreshing: false,
             issue_cursor: 0,
+            issue_detail_cursor: None,
             issue_read_scroll: 0,
             issue_nav_scroll: std::cell::Cell::new(0),
             issue_nav_max_scroll: std::cell::Cell::new(usize::MAX),
+            issue_detail_nav_scroll: std::cell::Cell::new(0),
+            issue_detail_nav_max_scroll: std::cell::Cell::new(usize::MAX),
             reveal_issue_nav: std::cell::Cell::new(true),
             issue_pending: None,
             world_request: None,
@@ -2096,8 +2108,10 @@ impl App {
         self.issue_notice = None;
         self.issue_refreshing = false;
         self.issue_cursor = 0;
+        self.issue_detail_cursor = None;
         self.issue_read_scroll = 0;
         self.issue_nav_scroll.set(0);
+        self.issue_detail_nav_scroll.set(0);
         self.reveal_issue_nav.set(true);
     }
 
@@ -2153,25 +2167,47 @@ impl App {
         self.paint_issue_view(view);
     }
 
-    /// Install a view and reconcile the cursor by issue number (Continuity).
+    /// Install a view and reconcile the cursor by issue number (Continuity). A detail focus on
+    /// description survives while the issue still has comments; a comment focus follows
+    /// author+timestamp identity.
     fn paint_issue_view(&mut self, view: crate::issue::IssueView) {
         self.issue_notice = None;
-        let selected = self.issue_selected().map(|i| i.number);
+        let selected_number = self.issue_selected().map(|i| i.number);
+        let detail = self.issue_detail_cursor;
+        let selected_comment = self.issue_selected_comment().map(|c| {
+            (c.author.clone(), c.created_at.clone())
+        });
         self.issue = view;
-        if let Some(number) = selected {
+        if let Some(number) = selected_number {
             if let Some(i) = self.issue_snapshot().and_then(|s| {
                 s.issues.iter().position(|issue| issue.number == number)
             }) {
                 self.issue_cursor = i;
+                self.issue_detail_cursor = match detail {
+                    Some(0) if self.issue_has_detail() => Some(0),
+                    None | Some(0) => None,
+                    Some(_) => selected_comment.and_then(|(author, created)| {
+                        let issue = self.issue_snapshot()?.issues.get(i)?;
+                        let pos = issue
+                            .comments
+                            .iter()
+                            .position(|c| c.author == author && c.created_at == created)?;
+                        Some(pos + 1)
+                    }),
+                };
+                self.clamp_issue_detail_cursor();
                 return;
             }
             self.issue_read_scroll = 0;
+            self.issue_detail_cursor = None;
         }
         let clamped = self.issue_row_count().saturating_sub(1);
         if self.issue_cursor > clamped {
             self.issue_read_scroll = 0;
+            self.issue_detail_cursor = None;
         }
         self.issue_cursor = self.issue_cursor.min(clamped);
+        self.clamp_issue_detail_cursor();
     }
 
     pub fn issue_notice(&self) -> Option<&str> {
@@ -2209,18 +2245,126 @@ impl App {
         self.issue_snapshot()?.issues.get(self.issue_cursor)
     }
 
+    /// Whether the selected issue has a detail section (at least one comment).
+    #[must_use]
+    pub fn issue_has_detail(&self) -> bool {
+        self.issue_selected_comment_count() > 0
+    }
+
+    /// Comment count for the selected issue (0 when there is no selection).
+    #[must_use]
+    pub fn issue_selected_comment_count(&self) -> usize {
+        self.issue_selected().map_or(0, |i| i.comments.len())
+    }
+
+    /// Selectable rows in the detail section: `description` plus each comment.
+    /// Zero when the selected issue has no comments (section hidden).
+    #[must_use]
+    pub fn issue_detail_row_count(&self) -> usize {
+        if self.issue_has_detail() {
+            1 + self.issue_selected_comment_count()
+        } else {
+            0
+        }
+    }
+
+    /// Whether focus is in the detail section under the selected issue.
+    #[must_use]
+    pub fn issue_detail_focused(&self) -> bool {
+        self.issue_detail_cursor.is_some()
+    }
+
+    /// Whether the read pane should show the issue description (list focus, or detail on
+    /// the pinned `description` row).
+    #[must_use]
+    pub fn issue_showing_description(&self) -> bool {
+        match self.issue_detail_cursor {
+            None | Some(0) => true,
+            Some(_) => false,
+        }
+    }
+
+    /// The comment under the detail cursor, when focus is on a comment row (`index >= 1`).
+    #[must_use]
+    pub fn issue_selected_comment(&self) -> Option<&crate::issue::IssueComment> {
+        let index = self.issue_detail_cursor?;
+        if index == 0 {
+            return None;
+        }
+        self.issue_selected()?.comments.get(index - 1)
+    }
+
     pub fn issue_move(&mut self, delta: isize) {
-        let n = self.issue_row_count();
-        if n == 0 {
+        if self.issue_row_count() == 0 {
             return;
         }
+        // Detail focus: j/k walk description → comments without leaving the selected issue.
+        if let Some(c) = self.issue_detail_cursor {
+            let m = self.issue_detail_row_count();
+            if m == 0 {
+                self.issue_detail_cursor = None;
+                return;
+            }
+            let next = (c as isize + delta).clamp(0, m as isize - 1) as usize;
+            if next != c {
+                self.issue_select_detail(next);
+            }
+            return;
+        }
+        let n = self.issue_row_count();
         self.issue_select(step(self.issue_cursor, delta, n));
     }
 
-    pub(crate) fn issue_select(&mut self, i: usize) {
+    /// Select an issue row and return focus to the issue list.
+    pub fn issue_select(&mut self, i: usize) {
         self.issue_cursor = i;
+        self.issue_detail_cursor = None;
         self.issue_read_scroll = 0;
         self.reveal_issue_nav.set(true);
+    }
+
+    /// Focus detail row `d` (`0` = description, `1+i` = comment i) of the selected issue.
+    pub fn issue_select_detail(&mut self, d: usize) {
+        let m = self.issue_detail_row_count();
+        if m == 0 {
+            self.issue_detail_cursor = None;
+            return;
+        }
+        self.issue_detail_cursor = Some(d.min(m - 1));
+        self.issue_read_scroll = 0;
+        self.reveal_issue_nav.set(true);
+    }
+
+    /// `→` from the issue list: enter the detail section on `description` when the selected
+    /// issue has comments. No-op when already in detail or the issue has none.
+    pub fn issue_enter_detail(&mut self) {
+        if self.issue_detail_cursor.is_some() || !self.issue_has_detail() {
+            return;
+        }
+        // Land on description so the left pane still shows the issue body until the user moves.
+        self.issue_select_detail(0);
+    }
+
+    /// `←` from the detail section: return focus to the issue list. The issue row stays selected.
+    pub fn issue_exit_detail(&mut self) {
+        if self.issue_detail_cursor.is_none() {
+            return;
+        }
+        self.issue_detail_cursor = None;
+        self.issue_read_scroll = 0;
+        self.reveal_issue_nav.set(true);
+    }
+
+    fn clamp_issue_detail_cursor(&mut self) {
+        let m = self.issue_detail_row_count();
+        match self.issue_detail_cursor {
+            Some(_) if m == 0 => self.issue_detail_cursor = None,
+            Some(c) if c >= m => {
+                self.issue_detail_cursor = Some(m - 1);
+                self.issue_read_scroll = 0;
+            }
+            _ => {}
+        }
     }
 
     pub(crate) fn issue_scroll_nav(&mut self, delta: isize) {
@@ -2232,6 +2376,25 @@ impl App {
         ));
     }
 
+    /// Scroll the detail list (description + comments) when it has its own pane.
+    pub(crate) fn issue_scroll_detail_nav(&mut self, delta: isize) {
+        self.reveal_issue_nav.set(false);
+        self.issue_detail_nav_scroll.set(clamp_scroll(
+            self.issue_detail_nav_scroll.get(),
+            delta,
+            self.issue_detail_nav_max_scroll.get(),
+        ));
+    }
+
+    /// Page/wheel scroll for the navigator: when detail is focused, prefer the detail pane.
+    pub(crate) fn issue_scroll_focused_nav(&mut self, delta: isize) {
+        if self.issue_detail_focused() {
+            self.issue_scroll_detail_nav(delta);
+        } else {
+            self.issue_scroll_nav(delta);
+        }
+    }
+
     pub(crate) fn issue_scroll_read(&mut self, delta: isize) {
         self.issue_read_scroll =
             clamp_scroll(self.issue_read_scroll, delta, self.pr_read_max_scroll.get());
@@ -2241,12 +2404,24 @@ impl App {
         self.issue_nav_max_scroll.set(max);
     }
 
+    pub(crate) fn note_issue_detail_nav_max_scroll(&self, max: usize) {
+        self.issue_detail_nav_max_scroll.set(max);
+    }
+
     pub(crate) fn issue_nav_scroll(&self) -> usize {
         self.issue_nav_scroll.get()
     }
 
     pub(crate) fn set_issue_nav_scroll(&self, scroll: usize) {
         self.issue_nav_scroll.set(scroll);
+    }
+
+    pub(crate) fn issue_detail_nav_scroll(&self) -> usize {
+        self.issue_detail_nav_scroll.get()
+    }
+
+    pub(crate) fn set_issue_detail_nav_scroll(&self, scroll: usize) {
+        self.issue_detail_nav_scroll.set(scroll);
     }
 
     pub(crate) fn take_issue_nav_reveal(&self) -> bool {
@@ -4055,6 +4230,7 @@ mod tests {
                 parent_number: None,
                 sub_completed: 0,
                 sub_total: 0,
+                comments: vec![],
             }],
             truncated: false,
         }));

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::time::Instant;
 
 use anyhow::Result;
 
@@ -41,6 +42,13 @@ enum DividerDrag {
         position: crate::config::NavigatorPosition,
     },
     Cancelled,
+}
+
+/// One cached Issue list result with its fetch time (specs/issue-tab.md TTL).
+#[derive(Clone, Debug)]
+struct IssueCacheEntry {
+    fetched_at: Instant,
+    view: crate::issue::IssueView,
 }
 
 /// Which pane has the keyboard.
@@ -365,8 +373,12 @@ pub enum FooterAction {
     MovePickerRow,
     ClosePicker,
     OpenPr,
-    /// Cycle the Issue tab's list filter (open → closed → all).
+    /// Cycle the Issue tab's state filter (open → closed → all).
     IssueFilter,
+    /// Cycle the Issue tab's assignee filter (all → mine).
+    IssueAssignee,
+    /// Cycle the Issue tab's priority-label filter (any → p0 → p1 → p2).
+    IssuePriority,
     Refresh,
     Tabs,
     Quit,
@@ -539,8 +551,11 @@ pub struct App {
     pub pr_pending: Option<RefreshKind>,
     /// The read-only `Issue` tab's view of GitHub issues (`src/issue.rs`).
     pub issue: crate::issue::IssueView,
-    /// Active list filter for the Issue tab (default: all open issues).
-    pub issue_filter: crate::issue::IssueFilter,
+    /// Active list query for the Issue tab (state × assignee × priority).
+    pub issue_query: crate::issue::IssueQuery,
+    /// Successful Issue lists keyed by query, with fetch time for the TTL cache
+    /// (specs/issue-tab.md). Cleared with the rest of the issue view on identity loss.
+    issue_cache: HashMap<crate::issue::IssueQuery, IssueCacheEntry>,
     /// Persistent same-input fetch remedy for the Issue tab.
     issue_notice: Option<String>,
     /// A same-input issue refresh that crossed the loading-indicator delay.
@@ -701,7 +716,8 @@ impl App {
             reveal_pr_nav: std::cell::Cell::new(true),
             pr_pending: None,
             issue: crate::issue::IssueView::Pending,
-            issue_filter: crate::issue::IssueFilter::Open,
+            issue_query: crate::issue::IssueQuery::default(),
+            issue_cache: HashMap::new(),
             issue_notice: None,
             issue_refreshing: false,
             issue_cursor: 0,
@@ -1843,7 +1859,9 @@ impl App {
             return Ok(());
         }
         if tab == Tab::Issue {
-            self.request_issue_refresh(RefreshKind::Ambient);
+            // TTL cache: re-entry within the window paints memory and skips `gh`
+            // (specs/issue-tab.md).
+            self.resolve_issue_query(RefreshKind::Ambient);
             return Ok(());
         }
         // Entering a file tab: bring its state into the diff fields if the other file tab holds
@@ -2074,6 +2092,7 @@ impl App {
     /// Clear a snapshot whose repository identity no longer matches.
     pub fn clear_issue(&mut self) {
         self.issue = crate::issue::IssueView::Pending;
+        self.issue_cache.clear();
         self.issue_notice = None;
         self.issue_refreshing = false;
         self.issue_cursor = 0;
@@ -2082,15 +2101,60 @@ impl App {
         self.reveal_issue_nav.set(true);
     }
 
+    /// State chip / legacy accessor for the open/closed/all dimension.
+    #[must_use]
+    pub fn issue_filter(&self) -> crate::issue::IssueFilter {
+        self.issue_query.state
+    }
+
+    /// Paint a cached list for the active query when one exists, and only queue a network
+    /// fetch when the cache is missing, stale, or the refresh is forced (`r`).
+    pub fn resolve_issue_query(&mut self, kind: RefreshKind) {
+        let query = self.issue_query;
+        let cached = self.issue_cache.get(&query).cloned();
+        let fresh = cached
+            .as_ref()
+            .is_some_and(|entry| entry.fetched_at.elapsed() < crate::issue::ISSUE_CACHE_TTL);
+        if let Some(entry) = cached {
+            if matches!(entry.view, crate::issue::IssueView::List(_)) {
+                self.paint_issue_view(entry.view);
+            }
+        } else if !matches!(self.issue, crate::issue::IssueView::List(_)) {
+            self.issue = crate::issue::IssueView::Pending;
+        }
+        let need_fetch = match kind {
+            RefreshKind::Forced => true,
+            RefreshKind::Ambient => !fresh,
+        };
+        if need_fetch {
+            self.request_issue_refresh(kind);
+            if kind == RefreshKind::Forced {
+                self.refresh_commanded = true;
+            }
+        }
+    }
+
     /// Apply a fetched issue view. Transient errors keep the last good list when one exists.
+    /// Successful lists are written into the per-query cache.
     pub fn apply_issue(&mut self, view: crate::issue::IssueView) {
         self.issue_refreshing = false;
+        if let crate::issue::IssueView::List(snapshot) = &view {
+            self.issue_cache.insert(
+                snapshot.query,
+                IssueCacheEntry { fetched_at: Instant::now(), view: view.clone() },
+            );
+        }
         let retry = view.retry_remedy(self.keymap().hint(crate::keymap::Action::Refresh));
         let has_list = matches!(self.issue, crate::issue::IssueView::List(_));
         if has_list && let Some(message) = retry {
             self.issue_notice = Some(message);
             return;
         }
+        self.paint_issue_view(view);
+    }
+
+    /// Install a view and reconcile the cursor by issue number (Continuity).
+    fn paint_issue_view(&mut self, view: crate::issue::IssueView) {
         self.issue_notice = None;
         let selected = self.issue_selected().map(|i| i.number);
         self.issue = view;
@@ -2189,16 +2253,23 @@ impl App {
         self.reveal_issue_nav.replace(false)
     }
 
-    /// Cycle the Issue list filter and refetch.
+    /// Cycle the Issue state filter (open → closed → all) and resolve via cache / fetch.
     pub fn cycle_issue_filter(&mut self) {
-        self.issue_filter = self.issue_filter.cycle();
-        // Keep place only if the new list still contains the selection — apply_issue does that
-        // after the fetch. Clear notice and show pending only when there is no list yet.
-        if !matches!(self.issue, crate::issue::IssueView::List(_)) {
-            self.issue = crate::issue::IssueView::Pending;
-        }
-        self.request_issue_refresh(RefreshKind::Forced);
-        self.refresh_commanded = true;
+        self.issue_query.state = self.issue_query.state.cycle();
+        // Prefer a fresh cache entry; only hit the network on miss/expiry (specs/issue-tab.md).
+        self.resolve_issue_query(RefreshKind::Ambient);
+    }
+
+    /// Cycle the Issue assignee filter (all → mine).
+    pub fn cycle_issue_assignee(&mut self) {
+        self.issue_query.assignee = self.issue_query.assignee.cycle();
+        self.resolve_issue_query(RefreshKind::Ambient);
+    }
+
+    /// Cycle the Issue priority-label filter (any → p0 → p1 → p2).
+    pub fn cycle_issue_priority(&mut self) {
+        self.issue_query.priority = self.issue_query.priority.cycle();
+        self.resolve_issue_query(RefreshKind::Ambient);
     }
 
     /// Open the selected issue in the browser.
@@ -3500,10 +3571,15 @@ impl App {
             return out;
         }
 
-        // The read-only Issue tab: filter cycle is primary; open the selected issue when one is
+        // The read-only Issue tab: state filter is primary; assignee and priority sit as row-1
+        // `Do` actions (the footer paints only one Primary). Open the selected issue when one is
         // selected. Same go/move bands as PR (no hunk/file steps).
         if self.tab == Tab::Issue {
-            let mut out = vec![(A::IssueFilter, Primary)];
+            let mut out = vec![
+                (A::IssueFilter, Primary),
+                (A::IssueAssignee, Do),
+                (A::IssuePriority, Do),
+            ];
             if self.issue_selected().is_some() {
                 out.push((A::OpenPr, Do));
             }
@@ -3958,6 +4034,44 @@ mod tests {
     use crate::config::NavigatorPosition;
     use crate::model::{Comment, Scope, Side};
     use std::path::PathBuf;
+
+    #[test]
+    fn issue_cache_skips_network_when_fresh() {
+        use crate::issue::{Issue, IssueAssignee, IssueQuery, IssueSnapshot, IssueState, IssueView};
+        let mut app = App::blocked(PathBuf::from("."), Scope::Uncommitted, None);
+        let query = IssueQuery::default();
+        app.issue_query = query;
+        app.apply_issue(IssueView::List(IssueSnapshot {
+            query,
+            issues: vec![Issue {
+                number: 1,
+                title: "cached".into(),
+                body: String::new(),
+                state: IssueState::Open,
+                author: "a".into(),
+                updated_at: "2026-08-01T12:00:00Z".into(),
+                url: "https://github.com/o/r/issues/1".into(),
+                labels: vec![],
+            }],
+            truncated: false,
+        }));
+        app.issue_pending = None;
+        // Ambient resolve of the same query must not re-queue a fetch.
+        app.resolve_issue_query(super::RefreshKind::Ambient);
+        assert!(app.issue_pending.is_none(), "fresh cache skips ambient fetch");
+        assert_eq!(app.issue_selected().map(|i| i.number), Some(1));
+
+        // Cycling to mine with no cache entry should request a fetch.
+        app.cycle_issue_assignee();
+        assert_eq!(app.issue_query.assignee, IssueAssignee::Mine);
+        assert_eq!(app.issue_pending, Some(super::RefreshKind::Ambient));
+
+        // Forced refresh always queues even when the cache is fresh.
+        app.issue_query = query;
+        app.issue_pending = None;
+        app.resolve_issue_query(super::RefreshKind::Forced);
+        assert_eq!(app.issue_pending, Some(super::RefreshKind::Forced));
+    }
 
     #[test]
     fn the_read_pane_scroll_stops_at_the_bottom_edge() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,13 +57,14 @@ enum Anchor {
     Dir(String),
 }
 
-/// Which top-level tab is active: the changes reviewer, the whole-repo browser, or the
-/// read-only PR mirror.
+/// Which top-level tab is active: the changes reviewer, the whole-repo browser, the
+/// read-only PR mirror, or the read-only GitHub Issues list.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Tab {
     Changes,
     AllFiles,
     Pr,
+    Issue,
 }
 
 /// What a pending PR refresh may do to a fetch already in flight: an ambient trigger —
@@ -78,9 +79,15 @@ pub enum RefreshKind {
 
 impl Tab {
     /// Whether this tab uses the file-tree / diff machinery (and so the per-tab stash). The
-    /// `PR` tab does not — it holds its own state and never swaps into the diff fields.
+    /// `PR` and `Issue` tabs do not — each holds its own state and never swaps into the
+    /// diff fields.
     pub(crate) fn is_file_tab(self) -> bool {
         matches!(self, Tab::Changes | Tab::AllFiles)
+    }
+
+    /// Whether this tab is a forge mirror (PR or Issues) rather than a file browser.
+    pub(crate) fn is_mirror_tab(self) -> bool {
+        matches!(self, Tab::Pr | Tab::Issue)
     }
 }
 
@@ -358,6 +365,8 @@ pub enum FooterAction {
     MovePickerRow,
     ClosePicker,
     OpenPr,
+    /// Cycle the Issue tab's list filter (open → closed → all).
+    IssueFilter,
     Refresh,
     Tabs,
     Quit,
@@ -528,6 +537,24 @@ pub struct App {
     /// The PR refresh awaiting dispatch, if any; the event loop services it after drawing, so
     /// a `loading` frame shows before the blocking CLI calls run.
     pub pr_pending: Option<RefreshKind>,
+    /// The read-only `Issue` tab's view of GitHub issues (`src/issue.rs`).
+    pub issue: crate::issue::IssueView,
+    /// Active list filter for the Issue tab (default: all open issues).
+    pub issue_filter: crate::issue::IssueFilter,
+    /// Persistent same-input fetch remedy for the Issue tab.
+    issue_notice: Option<String>,
+    /// A same-input issue refresh that crossed the loading-indicator delay.
+    issue_refreshing: bool,
+    /// Navigator cursor over the issue list.
+    pub(crate) issue_cursor: usize,
+    /// Top visible line of the issue read pane.
+    pub(crate) issue_read_scroll: usize,
+    /// Top visible row of the issue navigator.
+    issue_nav_scroll: std::cell::Cell<usize>,
+    issue_nav_max_scroll: std::cell::Cell<usize>,
+    reveal_issue_nav: std::cell::Cell<bool>,
+    /// Issue refresh awaiting dispatch (same draw-then-fetch cadence as PR).
+    pub issue_pending: Option<RefreshKind>,
     /// The world refresh request awaiting dispatch, if any; the event loop hands it to
     /// the worker after the frame paints (specs/tui.md).
     pub world_request: Option<crate::world::WorldRequest>,
@@ -673,6 +700,16 @@ impl App {
             pr_nav_max_scroll: std::cell::Cell::new(usize::MAX),
             reveal_pr_nav: std::cell::Cell::new(true),
             pr_pending: None,
+            issue: crate::issue::IssueView::Pending,
+            issue_filter: crate::issue::IssueFilter::Open,
+            issue_notice: None,
+            issue_refreshing: false,
+            issue_cursor: 0,
+            issue_read_scroll: 0,
+            issue_nav_scroll: std::cell::Cell::new(0),
+            issue_nav_max_scroll: std::cell::Cell::new(usize::MAX),
+            reveal_issue_nav: std::cell::Cell::new(true),
+            issue_pending: None,
             world_request: None,
             search: None,
             search_dirty: false,
@@ -1523,6 +1560,8 @@ impl App {
         };
         if self.tab == Tab::Pr {
             self.pr_read_scroll = idx.min(self.pr_read_max_scroll.get());
+        } else if self.tab == Tab::Issue {
+            self.issue_read_scroll = idx.min(self.pr_read_max_scroll.get());
         } else if self.preview_active() {
             self.preview_scrolled = true;
             self.preview_scroll = idx.min(self.preview_max_scroll.get());
@@ -1556,9 +1595,9 @@ impl App {
         self.navigator_position = self.navigator_position.clockwise();
     }
 
-    /// Whether the active tab can hide its navigator — `PR` never does (specs/tui.md).
+    /// Whether the active tab can hide its navigator — forge mirror tabs never do.
     fn navigator_can_hide(&self) -> bool {
-        self.tab != Tab::Pr
+        !self.tab.is_mirror_tab()
     }
 
     /// Whether the hidden state applies on the active tab.
@@ -1796,11 +1835,15 @@ impl App {
             return Ok(());
         }
         self.tab = tab;
-        // Entering the PR tab leaves the file tabs frozen in place and fetches the PR. A
-        // `loading` frame draws before the blocking fetch the event loop services, and a
-        // re-entry keeps the last snapshot on screen while it refetches.
+        // Entering a forge mirror tab leaves the file tabs frozen and fetches. A `loading`
+        // frame draws before the blocking fetch the event loop services; re-entry keeps
+        // the last snapshot on screen while it refetches.
         if tab == Tab::Pr {
             self.request_pr_refresh(RefreshKind::Ambient);
+            return Ok(());
+        }
+        if tab == Tab::Issue {
+            self.request_issue_refresh(RefreshKind::Ambient);
             return Ok(());
         }
         // Entering a file tab: bring its state into the diff fields if the other file tab holds
@@ -2017,6 +2060,157 @@ impl App {
         };
         match crate::browser::open(&url) {
             Ok(()) => self.status = format!("opened {} in browser", self.pr_forge.abbr()),
+            Err(e) => self.status = e.to_string(),
+        }
+    }
+
+    // ---- Issue tab (GitHub issues, read-only) ---------------------------------------------
+
+    /// Queue an Issue-tab refresh, merging into any request already pending.
+    pub fn request_issue_refresh(&mut self, kind: RefreshKind) {
+        self.issue_pending = self.issue_pending.max(Some(kind));
+    }
+
+    /// Clear a snapshot whose repository identity no longer matches.
+    pub fn clear_issue(&mut self) {
+        self.issue = crate::issue::IssueView::Pending;
+        self.issue_notice = None;
+        self.issue_refreshing = false;
+        self.issue_cursor = 0;
+        self.issue_read_scroll = 0;
+        self.issue_nav_scroll.set(0);
+        self.reveal_issue_nav.set(true);
+    }
+
+    /// Apply a fetched issue view. Transient errors keep the last good list when one exists.
+    pub fn apply_issue(&mut self, view: crate::issue::IssueView) {
+        self.issue_refreshing = false;
+        let retry = view.retry_remedy(self.keymap().hint(crate::keymap::Action::Refresh));
+        let has_list = matches!(self.issue, crate::issue::IssueView::List(_));
+        if has_list && let Some(message) = retry {
+            self.issue_notice = Some(message);
+            return;
+        }
+        self.issue_notice = None;
+        let selected = self.issue_selected().map(|i| i.number);
+        self.issue = view;
+        if let Some(number) = selected {
+            if let Some(i) = self.issue_snapshot().and_then(|s| {
+                s.issues.iter().position(|issue| issue.number == number)
+            }) {
+                self.issue_cursor = i;
+                return;
+            }
+            self.issue_read_scroll = 0;
+        }
+        let clamped = self.issue_row_count().saturating_sub(1);
+        if self.issue_cursor > clamped {
+            self.issue_read_scroll = 0;
+        }
+        self.issue_cursor = self.issue_cursor.min(clamped);
+    }
+
+    pub fn issue_notice(&self) -> Option<&str> {
+        self.issue_notice.as_deref()
+    }
+
+    pub fn set_issue_refreshing(&mut self, refreshing: bool) {
+        if refreshing && matches!(self.issue, crate::issue::IssueView::Pending) {
+            self.issue = crate::issue::IssueView::Loading;
+            self.issue_refreshing = false;
+        } else {
+            self.issue_refreshing = refreshing;
+        }
+    }
+
+    pub fn issue_refreshing(&self) -> bool {
+        self.issue_refreshing
+    }
+
+    #[must_use]
+    pub fn issue_snapshot(&self) -> Option<&crate::issue::IssueSnapshot> {
+        match &self.issue {
+            crate::issue::IssueView::List(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    #[must_use]
+    pub fn issue_row_count(&self) -> usize {
+        self.issue_snapshot().map_or(0, |s| s.issues.len())
+    }
+
+    #[must_use]
+    pub fn issue_selected(&self) -> Option<&crate::issue::Issue> {
+        self.issue_snapshot()?.issues.get(self.issue_cursor)
+    }
+
+    pub fn issue_move(&mut self, delta: isize) {
+        let n = self.issue_row_count();
+        if n == 0 {
+            return;
+        }
+        self.issue_select(step(self.issue_cursor, delta, n));
+    }
+
+    pub(crate) fn issue_select(&mut self, i: usize) {
+        self.issue_cursor = i;
+        self.issue_read_scroll = 0;
+        self.reveal_issue_nav.set(true);
+    }
+
+    pub(crate) fn issue_scroll_nav(&mut self, delta: isize) {
+        self.reveal_issue_nav.set(false);
+        self.issue_nav_scroll.set(clamp_scroll(
+            self.issue_nav_scroll.get(),
+            delta,
+            self.issue_nav_max_scroll.get(),
+        ));
+    }
+
+    pub(crate) fn issue_scroll_read(&mut self, delta: isize) {
+        self.issue_read_scroll =
+            clamp_scroll(self.issue_read_scroll, delta, self.pr_read_max_scroll.get());
+    }
+
+    pub(crate) fn note_issue_nav_max_scroll(&self, max: usize) {
+        self.issue_nav_max_scroll.set(max);
+    }
+
+    pub(crate) fn issue_nav_scroll(&self) -> usize {
+        self.issue_nav_scroll.get()
+    }
+
+    pub(crate) fn set_issue_nav_scroll(&self, scroll: usize) {
+        self.issue_nav_scroll.set(scroll);
+    }
+
+    pub(crate) fn take_issue_nav_reveal(&self) -> bool {
+        self.reveal_issue_nav.replace(false)
+    }
+
+    /// Cycle the Issue list filter and refetch.
+    pub fn cycle_issue_filter(&mut self) {
+        self.issue_filter = self.issue_filter.cycle();
+        // Keep place only if the new list still contains the selection — apply_issue does that
+        // after the fetch. Clear notice and show pending only when there is no list yet.
+        if !matches!(self.issue, crate::issue::IssueView::List(_)) {
+            self.issue = crate::issue::IssueView::Pending;
+        }
+        self.request_issue_refresh(RefreshKind::Forced);
+        self.refresh_commanded = true;
+    }
+
+    /// Open the selected issue in the browser.
+    pub fn issue_open(&mut self) {
+        let Some(url) = self.issue_selected().map(|i| i.url.clone()) else {
+            return;
+        };
+        if url.is_empty() {
+            return;
+        }
+        match crate::browser::open(&url) {
+            Ok(()) => self.status = "opened issue in browser".to_string(),
             Err(e) => self.status = e.to_string(),
         }
     }
@@ -2248,7 +2442,7 @@ impl App {
     /// the expansion and never disturbs the file tab the reviewer will return to (`overview.md`
     /// Continuity).
     pub fn escape(&mut self) {
-        if self.tab != Tab::Pr {
+        if !self.tab.is_mirror_tab() {
             if self.select_anchor.is_some() {
                 self.clear_selection();
                 return;
@@ -3294,6 +3488,24 @@ impl App {
             let mut out = Vec::new();
             if self.pr_snapshot().is_some() {
                 out.push((A::OpenPr, Primary));
+            }
+            out.push((A::Search, Go));
+            out.push((A::TogglePane, Go));
+            out.push((A::NavigatorPosition, Go));
+            out.push((A::Tabs, Go));
+            out.push((A::Refresh, Go));
+            out.push((A::Quit, Go));
+            out.push((A::MoveLine, Move));
+            out.push((A::MovePage, Move));
+            return out;
+        }
+
+        // The read-only Issue tab: filter cycle is primary; open the selected issue when one is
+        // selected. Same go/move bands as PR (no hunk/file steps).
+        if self.tab == Tab::Issue {
+            let mut out = vec![(A::IssueFilter, Primary)];
+            if self.issue_selected().is_some() {
+                out.push((A::OpenPr, Do));
             }
             out.push((A::Search, Go));
             out.push((A::TogglePane, Go));

--- a/src/app.rs
+++ b/src/app.rs
@@ -2174,14 +2174,14 @@ impl App {
         self.issue_notice = None;
         let selected_number = self.issue_selected().map(|i| i.number);
         let detail = self.issue_detail_cursor;
-        let selected_comment = self.issue_selected_comment().map(|c| {
-            (c.author.clone(), c.created_at.clone())
-        });
+        let selected_comment =
+            self.issue_selected_comment().map(|c| (c.author.clone(), c.created_at.clone()));
         self.issue = view;
         if let Some(number) = selected_number {
-            if let Some(i) = self.issue_snapshot().and_then(|s| {
-                s.issues.iter().position(|issue| issue.number == number)
-            }) {
+            if let Some(i) = self
+                .issue_snapshot()
+                .and_then(|s| s.issues.iter().position(|issue| issue.number == number))
+            {
                 self.issue_cursor = i;
                 self.issue_detail_cursor = match detail {
                     Some(0) if self.issue_has_detail() => Some(0),
@@ -2261,11 +2261,7 @@ impl App {
     /// Zero when the selected issue has no comments (section hidden).
     #[must_use]
     pub fn issue_detail_row_count(&self) -> usize {
-        if self.issue_has_detail() {
-            1 + self.issue_selected_comment_count()
-        } else {
-            0
-        }
+        if self.issue_has_detail() { 1 + self.issue_selected_comment_count() } else { 0 }
     }
 
     /// Whether focus is in the detail section under the selected issue.
@@ -3750,11 +3746,8 @@ impl App {
         // `Do` actions (the footer paints only one Primary). Open the selected issue when one is
         // selected. Same go/move bands as PR (no hunk/file steps).
         if self.tab == Tab::Issue {
-            let mut out = vec![
-                (A::IssueFilter, Primary),
-                (A::IssueAssignee, Do),
-                (A::IssuePriority, Do),
-            ];
+            let mut out =
+                vec![(A::IssueFilter, Primary), (A::IssueAssignee, Do), (A::IssuePriority, Do)];
             if self.issue_selected().is_some() {
                 out.push((A::OpenPr, Do));
             }
@@ -4212,7 +4205,9 @@ mod tests {
 
     #[test]
     fn issue_cache_skips_network_when_fresh() {
-        use crate::issue::{Issue, IssueAssignee, IssueQuery, IssueSnapshot, IssueState, IssueView};
+        use crate::issue::{
+            Issue, IssueAssignee, IssueQuery, IssueSnapshot, IssueState, IssueView,
+        };
         let mut app = App::blocked(PathBuf::from("."), Scope::Uncommitted, None);
         let query = IssueQuery::default();
         app.issue_query = query;

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -405,14 +405,10 @@ fn parse_issues(json: &str) -> Result<Vec<Issue>, IssueError> {
             }
         });
         let summary = row.get("subIssuesSummary");
-        let sub_completed = summary
-            .and_then(|s| s.get("completed"))
-            .and_then(Value::as_u64)
-            .unwrap_or(0) as u32;
-        let sub_total = summary
-            .and_then(|s| s.get("total"))
-            .and_then(Value::as_u64)
-            .unwrap_or(0) as u32;
+        let sub_completed =
+            summary.and_then(|s| s.get("completed")).and_then(Value::as_u64).unwrap_or(0) as u32;
+        let sub_total =
+            summary.and_then(|s| s.get("total")).and_then(Value::as_u64).unwrap_or(0) as u32;
         let mut comments = parse_comments(row.get("comments"));
         // Newest first — matches the PR tab's comment surface (specs/issue-tab.md).
         comments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
@@ -620,10 +616,7 @@ mod tests {
     fn order_as_tree_nests_children_under_present_parents() {
         // Input: child, parent, other — output: parent, child, other.
         let ordered = order_as_tree(vec![bare(2, Some(1)), bare(1, None), bare(3, None)]);
-        assert_eq!(
-            ordered.iter().map(|i| i.number).collect::<Vec<_>>(),
-            vec![1, 2, 3]
-        );
+        assert_eq!(ordered.iter().map(|i| i.number).collect::<Vec<_>>(), vec![1, 2, 3]);
     }
 
     #[test]

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -183,14 +183,19 @@ fn gh_issue_list(
     state: &str,
     cancelled: &AtomicBool,
 ) -> Result<String, IssueError> {
+    // `gh issue list` has no `--hostname` flag. Pin the host with the `[HOST/]OWNER/REPO`
+    // form of `--repo` (enterprise) or plain `OWNER/REPO` (github.com).
+    let repo_arg = if host.eq_ignore_ascii_case("github.com") {
+        repo_slug.to_string()
+    } else {
+        format!("{host}/{repo_slug}")
+    };
     let mut cmd = Command::new("gh");
     cmd.current_dir(repo).args([
         "issue",
         "list",
-        "--hostname",
-        host,
         "--repo",
-        repo_slug,
+        &repo_arg,
         "--state",
         state,
         "--limit",

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -159,6 +159,17 @@ impl IssueQuery {
     }
 }
 
+/// One plain comment on an issue (from `gh issue list --json comments`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IssueComment {
+    pub author: String,
+    pub author_is_bot: bool,
+    pub body: String,
+    /// ISO-8601 `…Z` post time — newest-first sort key.
+    pub created_at: String,
+    pub url: String,
+}
+
 /// One GitHub issue row.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Issue {
@@ -176,6 +187,8 @@ pub struct Issue {
     pub sub_completed: u32,
     /// Total sub-issues under this issue (`subIssuesSummary.total`).
     pub sub_total: u32,
+    /// Issue-thread comments, newest first (specs/issue-tab.md).
+    pub comments: Vec<IssueComment>,
 }
 
 impl Issue {
@@ -324,7 +337,7 @@ fn gh_issue_list(
         "--limit",
         &ISSUE_CAP.to_string(),
         "--json",
-        "number,title,body,state,author,updatedAt,url,labels,parent,subIssuesSummary",
+        "number,title,body,state,author,updatedAt,url,labels,parent,subIssuesSummary,comments",
     ]);
     if query.assignee == IssueAssignee::Mine {
         cmd.args(["--assignee", "@me"]);
@@ -400,6 +413,9 @@ fn parse_issues(json: &str) -> Result<Vec<Issue>, IssueError> {
             .and_then(|s| s.get("total"))
             .and_then(Value::as_u64)
             .unwrap_or(0) as u32;
+        let mut comments = parse_comments(row.get("comments"));
+        // Newest first — matches the PR tab's comment surface (specs/issue-tab.md).
+        comments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
         issues.push(Issue {
             number,
             title,
@@ -412,9 +428,31 @@ fn parse_issues(json: &str) -> Result<Vec<Issue>, IssueError> {
             parent_number,
             sub_completed,
             sub_total,
+            comments,
         });
     }
     Ok(issues)
+}
+
+fn parse_comments(value: Option<&Value>) -> Vec<IssueComment> {
+    let Some(rows) = value.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let author = row["author"]["login"].as_str().unwrap_or("").to_string();
+        if author.is_empty() && row["body"].as_str().unwrap_or("").is_empty() {
+            continue;
+        }
+        out.push(IssueComment {
+            author_is_bot: forge::is_named_bot(&author),
+            author,
+            body: row["body"].as_str().unwrap_or("").to_string(),
+            created_at: row["createdAt"].as_str().unwrap_or("").to_string(),
+            url: row["url"].as_str().unwrap_or("").to_string(),
+        });
+    }
+    out
 }
 
 /// Put each child immediately under its parent when both are in the list. One nesting level.
@@ -513,7 +551,21 @@ mod tests {
             "url": "https://github.com/o/r/issues/42",
             "labels": [{"name": "bug"}, {"name": "ui"}],
             "parent": null,
-            "subIssuesSummary": {"completed": 1, "percentCompleted": 50, "total": 2}
+            "subIssuesSummary": {"completed": 1, "percentCompleted": 50, "total": 2},
+            "comments": [
+              {
+                "author": {"login": "carol"},
+                "body": "older note",
+                "createdAt": "2026-07-01T12:00:00Z",
+                "url": "https://github.com/o/r/issues/42#issuecomment-1"
+              },
+              {
+                "author": {"login": "dave"},
+                "body": "newer note",
+                "createdAt": "2026-08-01T12:00:00Z",
+                "url": "https://github.com/o/r/issues/42#issuecomment-2"
+              }
+            ]
           },
           {
             "number": 7,
@@ -525,7 +577,8 @@ mod tests {
             "url": "https://github.com/o/r/issues/7",
             "labels": [],
             "parent": {"number": 42, "title": "Fix the pane"},
-            "subIssuesSummary": {"completed": 0, "percentCompleted": 0, "total": 0}
+            "subIssuesSummary": {"completed": 0, "percentCompleted": 0, "total": 0},
+            "comments": []
           }
         ]"#;
         let issues = parse_issues(json).unwrap();
@@ -538,8 +591,12 @@ mod tests {
         assert_eq!(issues[0].parent_number, None);
         assert_eq!(issues[0].sub_completed, 1);
         assert_eq!(issues[0].sub_total, 2);
+        assert_eq!(issues[0].comments.len(), 2);
+        assert_eq!(issues[0].comments[0].author, "dave", "comments are newest-first");
+        assert_eq!(issues[0].comments[1].author, "carol");
         assert_eq!(issues[1].state, IssueState::Closed);
         assert_eq!(issues[1].parent_number, Some(42));
+        assert!(issues[1].comments.is_empty());
     }
 
     fn bare(number: u64, parent: Option<u64>) -> Issue {
@@ -555,6 +612,7 @@ mod tests {
             parent_number: parent,
             sub_completed: 0,
             sub_total: 0,
+            comments: vec![],
         }
     }
 

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -170,6 +170,23 @@ pub struct Issue {
     pub updated_at: String,
     pub url: String,
     pub labels: Vec<String>,
+    /// Parent issue number when this is a GitHub sub-issue (`parent.number`).
+    pub parent_number: Option<u64>,
+    /// Closed sub-issues under this issue (`subIssuesSummary.completed`).
+    pub sub_completed: u32,
+    /// Total sub-issues under this issue (`subIssuesSummary.total`).
+    pub sub_total: u32,
+}
+
+impl Issue {
+    /// Navigator indent depth: one level when the parent is also present in the list.
+    #[must_use]
+    pub fn tree_depth(&self, present: &std::collections::HashSet<u64>) -> usize {
+        match self.parent_number {
+            Some(parent) if present.contains(&parent) => 1,
+            _ => 0,
+        }
+    }
 }
 
 /// Lifecycle shown on a row and in the read pane.
@@ -275,7 +292,9 @@ fn fetch_inner(
     let repo_slug = format!("{}/{}", target.owner(), target.name());
     let host = target.host();
     let json = gh_issue_list(repo, host, &repo_slug, query, cancelled)?;
-    let issues = parse_issues(&json)?;
+    let mut issues = parse_issues(&json)?;
+    // Nest children under parents that landed in the same fetch (specs/issue-tab.md).
+    issues = order_as_tree(issues);
     let truncated = issues.len() >= ISSUE_CAP;
     Ok(IssueView::List(IssueSnapshot { query, issues, truncated }))
 }
@@ -305,7 +324,7 @@ fn gh_issue_list(
         "--limit",
         &ISSUE_CAP.to_string(),
         "--json",
-        "number,title,body,state,author,updatedAt,url,labels",
+        "number,title,body,state,author,updatedAt,url,labels,parent,subIssuesSummary",
     ]);
     if query.assignee == IssueAssignee::Mine {
         cmd.args(["--assignee", "@me"]);
@@ -364,9 +383,70 @@ fn parse_issues(json: &str) -> Result<Vec<Issue>, IssueError> {
             .flatten()
             .filter_map(|label| label["name"].as_str().map(str::to_string))
             .collect();
-        issues.push(Issue { number, title, body, state, author, updated_at, url, labels });
+        // `parent` is null or `{ "number": N, ... }`.
+        let parent_number = row.get("parent").and_then(|p| {
+            if p.is_null() {
+                None
+            } else {
+                p.get("number").and_then(Value::as_u64).filter(|&n| n > 0)
+            }
+        });
+        let summary = row.get("subIssuesSummary");
+        let sub_completed = summary
+            .and_then(|s| s.get("completed"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+        let sub_total = summary
+            .and_then(|s| s.get("total"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as u32;
+        issues.push(Issue {
+            number,
+            title,
+            body,
+            state,
+            author,
+            updated_at,
+            url,
+            labels,
+            parent_number,
+            sub_completed,
+            sub_total,
+        });
     }
     Ok(issues)
+}
+
+/// Put each child immediately under its parent when both are in the list. One nesting level.
+/// Children whose parent is missing (e.g. closed parent while listing open) stay top-level.
+/// Relative order among roots and among siblings follows the input order.
+#[must_use]
+pub fn order_as_tree(issues: Vec<Issue>) -> Vec<Issue> {
+    use std::collections::{HashMap, HashSet};
+    let present: HashSet<u64> = issues.iter().map(|i| i.number).collect();
+    let mut children: HashMap<u64, Vec<Issue>> = HashMap::new();
+    let mut roots = Vec::new();
+    for issue in issues {
+        match issue.parent_number {
+            Some(parent) if present.contains(&parent) => {
+                children.entry(parent).or_default().push(issue);
+            }
+            _ => roots.push(issue),
+        }
+    }
+    let mut out = Vec::with_capacity(roots.len() + children.values().map(Vec::len).sum::<usize>());
+    for root in roots {
+        let number = root.number;
+        out.push(root);
+        if let Some(kids) = children.remove(&number) {
+            out.extend(kids);
+        }
+    }
+    // Orphans of parents that were themselves nested (multi-level) or removed — list flat.
+    for (_, kids) in children {
+        out.extend(kids);
+    }
+    out
 }
 
 #[derive(Debug)]
@@ -431,7 +511,9 @@ mod tests {
             "author": {"login": "alice"},
             "updatedAt": "2026-08-01T12:00:00Z",
             "url": "https://github.com/o/r/issues/42",
-            "labels": [{"name": "bug"}, {"name": "ui"}]
+            "labels": [{"name": "bug"}, {"name": "ui"}],
+            "parent": null,
+            "subIssuesSummary": {"completed": 1, "percentCompleted": 50, "total": 2}
           },
           {
             "number": 7,
@@ -441,7 +523,9 @@ mod tests {
             "author": {"login": "bob"},
             "updatedAt": "2026-07-01T12:00:00Z",
             "url": "https://github.com/o/r/issues/7",
-            "labels": []
+            "labels": [],
+            "parent": {"number": 42, "title": "Fix the pane"},
+            "subIssuesSummary": {"completed": 0, "percentCompleted": 0, "total": 0}
           }
         ]"#;
         let issues = parse_issues(json).unwrap();
@@ -451,6 +535,47 @@ mod tests {
         assert_eq!(issues[0].state, IssueState::Open);
         assert_eq!(issues[0].author, "alice");
         assert_eq!(issues[0].labels, vec!["bug", "ui"]);
+        assert_eq!(issues[0].parent_number, None);
+        assert_eq!(issues[0].sub_completed, 1);
+        assert_eq!(issues[0].sub_total, 2);
         assert_eq!(issues[1].state, IssueState::Closed);
+        assert_eq!(issues[1].parent_number, Some(42));
+    }
+
+    fn bare(number: u64, parent: Option<u64>) -> Issue {
+        Issue {
+            number,
+            title: format!("#{number}"),
+            body: String::new(),
+            state: IssueState::Open,
+            author: "a".into(),
+            updated_at: String::new(),
+            url: String::new(),
+            labels: vec![],
+            parent_number: parent,
+            sub_completed: 0,
+            sub_total: 0,
+        }
+    }
+
+    #[test]
+    fn order_as_tree_nests_children_under_present_parents() {
+        // Input: child, parent, other — output: parent, child, other.
+        let ordered = order_as_tree(vec![bare(2, Some(1)), bare(1, None), bare(3, None)]);
+        assert_eq!(
+            ordered.iter().map(|i| i.number).collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn order_as_tree_leaves_orphan_children_top_level() {
+        // Parent #99 is not in the list (e.g. closed while listing open).
+        let ordered = order_as_tree(vec![bare(2, Some(99)), bare(1, None)]);
+        assert_eq!(
+            ordered.iter().map(|i| i.number).collect::<Vec<_>>(),
+            vec![2, 1],
+            "orphan child keeps its place among roots"
+        );
     }
 }

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -1,0 +1,320 @@
+//! GitHub Issues read path for the read-only `Issue` tab.
+//!
+//! v1 is GitHub-only via `gh issue list`. No comment write, no edit, no close — the tab mirrors
+//! open (default) / closed / all issues and opens the selected one in a browser. List filters
+//! are local presentation over the same repository identity the PR tab already resolves
+//! (`forge::fetch_input`).
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::atomic::AtomicBool;
+
+use serde_json::Value;
+
+use crate::forge::{self, PrFetchInput};
+use crate::git::Forge;
+
+/// How many issues one fetch returns. Matching the PR surface cap keeps list size predictable.
+const ISSUE_CAP: usize = 100;
+
+/// Which issue set the navigator lists. Default is every open issue in the repository.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum IssueFilter {
+    #[default]
+    Open,
+    Closed,
+    All,
+}
+
+impl IssueFilter {
+    /// Cycle open → closed → all → open for the filter key.
+    #[must_use]
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Open => Self::Closed,
+            Self::Closed => Self::All,
+            Self::All => Self::Open,
+        }
+    }
+
+    /// Header / footer chip label.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+            Self::All => "all",
+        }
+    }
+
+    /// `gh issue list --state` value.
+    #[must_use]
+    pub fn gh_state(self) -> &'static str {
+        self.label()
+    }
+}
+
+/// One GitHub issue row.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Issue {
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    pub state: IssueState,
+    pub author: String,
+    pub updated_at: String,
+    pub url: String,
+    pub labels: Vec<String>,
+}
+
+/// Lifecycle shown on a row and in the read pane.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IssueState {
+    Open,
+    Closed,
+}
+
+/// A successful list fetch for one filter.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IssueSnapshot {
+    pub filter: IssueFilter,
+    pub issues: Vec<Issue>,
+    /// `true` when the fetch hit the cap — more issues may exist on GitHub.
+    pub truncated: bool,
+}
+
+/// What the `Issue` tab shows.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IssueView {
+    /// Work pending; under the loading-indicator delay.
+    Pending,
+    /// Work crossed the loading-indicator delay without a snapshot.
+    Loading,
+    /// A list (possibly empty) for the active filter.
+    List(IssueSnapshot),
+    /// `gh` is not on `PATH`.
+    NoCli,
+    /// `gh` is installed but not authenticated for this host.
+    NotAuthed(String),
+    /// No recognized forge remote.
+    NeedsForgeRemote,
+    /// Remote host is not a supported forge host.
+    UnsupportedHost(String),
+    /// Remote host is supported but path is not a repository.
+    MalformedOrigin(String),
+    /// Repository is not GitHub — v1 Issues is GitHub-only.
+    NeedsGitHub,
+    /// Local Git read failed before the fetch.
+    GitError(String),
+    /// Transient CLI failure; the app freezes the last good view when one exists.
+    Error(String),
+}
+
+impl IssueView {
+    /// Retryable failure message for the notice strip / empty pane.
+    pub fn retry_remedy(&self, refresh: crate::keymap::Key) -> Option<String> {
+        match self {
+            Self::NoCli => {
+                Some(format!("GitHub CLI not found. Install `gh`, then press {refresh}."))
+            }
+            Self::NotAuthed(host) => Some(format!(
+                "Not signed in to {host}. Run `gh auth login --hostname {host}`, then press {refresh}."
+            )),
+            Self::GitError(message) => {
+                Some(format!("Git read failed: {message}. Press {refresh} to retry."))
+            }
+            Self::Error(message) => {
+                Some(format!("GitHub unavailable: {message}. Press {refresh} to retry."))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Read issues for one already-derived forge input and filter.
+#[must_use]
+pub fn fetch(
+    repo: &Path,
+    input: &PrFetchInput,
+    filter: IssueFilter,
+    cancelled: &AtomicBool,
+) -> IssueView {
+    match fetch_inner(repo, input, filter, cancelled) {
+        Ok(view) => view,
+        Err(error) => error.into(),
+    }
+}
+
+fn fetch_inner(
+    repo: &Path,
+    input: &PrFetchInput,
+    filter: IssueFilter,
+    cancelled: &AtomicBool,
+) -> Result<IssueView, IssueError> {
+    let target = match &input.repository {
+        crate::git::RepositoryIdentity::Repository(target) => target,
+        crate::git::RepositoryIdentity::Missing | crate::git::RepositoryIdentity::Hostless => {
+            return Ok(IssueView::NeedsForgeRemote);
+        }
+        crate::git::RepositoryIdentity::Unsupported(host) => {
+            return Ok(IssueView::UnsupportedHost(host.clone()));
+        }
+        crate::git::RepositoryIdentity::Malformed(host) => {
+            return Ok(IssueView::MalformedOrigin(host.clone()));
+        }
+    };
+    if target.forge() != Forge::GitHub {
+        return Ok(IssueView::NeedsGitHub);
+    }
+
+    let repo_slug = format!("{}/{}", target.owner(), target.name());
+    let state = filter.gh_state();
+    let host = target.host();
+    let json = gh_issue_list(repo, host, &repo_slug, state, cancelled)?;
+    let issues = parse_issues(&json)?;
+    let truncated = issues.len() >= ISSUE_CAP;
+    Ok(IssueView::List(IssueSnapshot { filter, issues, truncated }))
+}
+
+fn gh_issue_list(
+    repo: &Path,
+    host: &str,
+    repo_slug: &str,
+    state: &str,
+    cancelled: &AtomicBool,
+) -> Result<String, IssueError> {
+    let mut cmd = Command::new("gh");
+    cmd.current_dir(repo).args([
+        "issue",
+        "list",
+        "--hostname",
+        host,
+        "--repo",
+        repo_slug,
+        "--state",
+        state,
+        "--limit",
+        &ISSUE_CAP.to_string(),
+        "--json",
+        "number,title,body,state,author,updatedAt,url,labels",
+    ]);
+    forge::run_provider(
+        &mut cmd,
+        cancelled,
+        IssueError::NoCli,
+        |stderr| classify_failure(stderr, host),
+        IssueError::Other,
+    )
+}
+
+fn classify_failure(stderr: &str, host: &str) -> IssueError {
+    let s = stderr.to_lowercase();
+    if s.contains("not logged")
+        || s.contains("authentication")
+        || s.contains("gh auth login")
+        || s.contains("bad credentials")
+        || s.contains("http 401")
+        || s.contains("status 401")
+    {
+        IssueError::NotAuthed(host.to_owned())
+    } else {
+        IssueError::Other(stderr.trim().to_string())
+    }
+}
+
+fn parse_issues(json: &str) -> Result<Vec<Issue>, IssueError> {
+    let value: Value = serde_json::from_str(json)
+        .map_err(|error| IssueError::Other(format!("invalid issue list JSON: {error}")))?;
+    let rows = value
+        .as_array()
+        .ok_or_else(|| IssueError::Other("issue list JSON is not an array".into()))?;
+    let mut issues = Vec::with_capacity(rows.len());
+    for row in rows {
+        let number = row["number"].as_u64().unwrap_or(0);
+        if number == 0 {
+            continue;
+        }
+        let title = row["title"].as_str().unwrap_or("").to_string();
+        let body = row["body"].as_str().unwrap_or("").to_string();
+        let state = match row["state"].as_str().unwrap_or("OPEN").to_ascii_uppercase().as_str() {
+            "CLOSED" => IssueState::Closed,
+            _ => IssueState::Open,
+        };
+        let author = row["author"]["login"].as_str().unwrap_or("").to_string();
+        let updated_at = row["updatedAt"].as_str().unwrap_or("").to_string();
+        let url = row["url"].as_str().unwrap_or("").to_string();
+        let labels = row["labels"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|label| label["name"].as_str().map(str::to_string))
+            .collect();
+        issues.push(Issue { number, title, body, state, author, updated_at, url, labels });
+    }
+    Ok(issues)
+}
+
+#[derive(Debug)]
+enum IssueError {
+    NoCli,
+    NotAuthed(String),
+    Other(String),
+}
+
+impl From<IssueError> for IssueView {
+    fn from(error: IssueError) -> Self {
+        match error {
+            IssueError::NoCli => Self::NoCli,
+            IssueError::NotAuthed(host) => Self::NotAuthed(host),
+            IssueError::Other(message) => Self::Error(message),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filter_cycles_open_closed_all() {
+        assert_eq!(IssueFilter::Open.cycle(), IssueFilter::Closed);
+        assert_eq!(IssueFilter::Closed.cycle(), IssueFilter::All);
+        assert_eq!(IssueFilter::All.cycle(), IssueFilter::Open);
+        assert_eq!(IssueFilter::Open.gh_state(), "open");
+    }
+
+    #[test]
+    fn parse_issues_reads_gh_json_shape() {
+        let json = r#"[
+          {
+            "number": 42,
+            "title": "Fix the pane",
+            "body": "Details here",
+            "state": "OPEN",
+            "author": {"login": "alice"},
+            "updatedAt": "2026-08-01T12:00:00Z",
+            "url": "https://github.com/o/r/issues/42",
+            "labels": [{"name": "bug"}, {"name": "ui"}]
+          },
+          {
+            "number": 7,
+            "title": "Done",
+            "body": "",
+            "state": "CLOSED",
+            "author": {"login": "bob"},
+            "updatedAt": "2026-07-01T12:00:00Z",
+            "url": "https://github.com/o/r/issues/7",
+            "labels": []
+          }
+        ]"#;
+        let issues = parse_issues(json).unwrap();
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].number, 42);
+        assert_eq!(issues[0].title, "Fix the pane");
+        assert_eq!(issues[0].state, IssueState::Open);
+        assert_eq!(issues[0].author, "alice");
+        assert_eq!(issues[0].labels, vec!["bug", "ui"]);
+        assert_eq!(issues[1].state, IssueState::Closed);
+    }
+
+}

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -1,13 +1,15 @@
 //! GitHub Issues read path for the read-only `Issue` tab.
 //!
 //! v1 is GitHub-only via `gh issue list`. No comment write, no edit, no close — the tab mirrors
-//! open (default) / closed / all issues and opens the selected one in a browser. List filters
-//! are local presentation over the same repository identity the PR tab already resolves
-//! (`forge::fetch_input`).
+//! open (default) / closed / all issues, optional assignee and priority-label filters, and opens
+//! the selected one in a browser. Filters compose into one list call over the same repository
+//! identity the PR tab already resolves (`forge::fetch_input`). Successful lists are cached by
+//! query so tab re-entry and filter cycling do not hammer `gh` (specs/issue-tab.md).
 
 use std::path::Path;
 use std::process::Command;
 use std::sync::atomic::AtomicBool;
+use std::time::Duration;
 
 use serde_json::Value;
 
@@ -17,8 +19,12 @@ use crate::git::Forge;
 /// How many issues one fetch returns. Matching the PR surface cap keeps list size predictable.
 const ISSUE_CAP: usize = 100;
 
+/// Freshness window for a cached list result. Matches the ambient poll so re-entry within the
+/// window paints memory only (specs/issue-tab.md).
+pub const ISSUE_CACHE_TTL: Duration = Duration::from_mins(1);
+
 /// Which issue set the navigator lists. Default is every open issue in the repository.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum IssueFilter {
     #[default]
     Open,
@@ -54,6 +60,105 @@ impl IssueFilter {
     }
 }
 
+/// Assignee dimension. Default lists every assignee; `Mine` is `gh --assignee @me`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum IssueAssignee {
+    #[default]
+    All,
+    Mine,
+}
+
+impl IssueAssignee {
+    #[must_use]
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::All => Self::Mine,
+            Self::Mine => Self::All,
+        }
+    }
+
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Mine => "mine",
+        }
+    }
+}
+
+/// Priority-label dimension. Cycles any → p0 → p1 → p2; each non-`Any` value is a single
+/// `gh --label` name (case as GitHub stores it; we pass lowercase `pN`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum IssuePriority {
+    #[default]
+    Any,
+    P0,
+    P1,
+    P2,
+}
+
+impl IssuePriority {
+    #[must_use]
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Any => Self::P0,
+            Self::P0 => Self::P1,
+            Self::P1 => Self::P2,
+            Self::P2 => Self::Any,
+        }
+    }
+
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Any => "any",
+            Self::P0 => "p0",
+            Self::P1 => "p1",
+            Self::P2 => "p2",
+        }
+    }
+
+    /// `Some` label name for `gh --label`, or `None` when unfiltered.
+    #[must_use]
+    pub fn gh_label(self) -> Option<&'static str> {
+        match self {
+            Self::Any => None,
+            Self::P0 => Some("p0"),
+            Self::P1 => Some("p1"),
+            Self::P2 => Some("p2"),
+        }
+    }
+}
+
+/// Full list query: state × assignee × priority. Cache key and `gh` argument source.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct IssueQuery {
+    pub state: IssueFilter,
+    pub assignee: IssueAssignee,
+    pub priority: IssuePriority,
+}
+
+impl IssueQuery {
+    /// Compact summary for empty states: `open`, `open · mine`, `closed · p1`, …
+    #[must_use]
+    pub fn summary(self) -> String {
+        let mut parts = vec![self.state.label().to_string()];
+        if self.assignee != IssueAssignee::All {
+            parts.push(self.assignee.label().to_string());
+        }
+        if self.priority != IssuePriority::Any {
+            parts.push(self.priority.label().to_string());
+        }
+        parts.join(" · ")
+    }
+
+    /// Navigator title suffix after `Issues · `.
+    #[must_use]
+    pub fn nav_title(self) -> String {
+        self.summary()
+    }
+}
+
 /// One GitHub issue row.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Issue {
@@ -74,10 +179,10 @@ pub enum IssueState {
     Closed,
 }
 
-/// A successful list fetch for one filter.
+/// A successful list fetch for one query.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IssueSnapshot {
-    pub filter: IssueFilter,
+    pub query: IssueQuery,
     pub issues: Vec<Issue>,
     /// `true` when the fetch hit the cap — more issues may exist on GitHub.
     pub truncated: bool,
@@ -90,7 +195,7 @@ pub enum IssueView {
     Pending,
     /// Work crossed the loading-indicator delay without a snapshot.
     Loading,
-    /// A list (possibly empty) for the active filter.
+    /// A list (possibly empty) for the active query.
     List(IssueSnapshot),
     /// `gh` is not on `PATH`.
     NoCli,
@@ -131,15 +236,15 @@ impl IssueView {
     }
 }
 
-/// Read issues for one already-derived forge input and filter.
+/// Read issues for one already-derived forge input and query.
 #[must_use]
 pub fn fetch(
     repo: &Path,
     input: &PrFetchInput,
-    filter: IssueFilter,
+    query: IssueQuery,
     cancelled: &AtomicBool,
 ) -> IssueView {
-    match fetch_inner(repo, input, filter, cancelled) {
+    match fetch_inner(repo, input, query, cancelled) {
         Ok(view) => view,
         Err(error) => error.into(),
     }
@@ -148,7 +253,7 @@ pub fn fetch(
 fn fetch_inner(
     repo: &Path,
     input: &PrFetchInput,
-    filter: IssueFilter,
+    query: IssueQuery,
     cancelled: &AtomicBool,
 ) -> Result<IssueView, IssueError> {
     let target = match &input.repository {
@@ -168,19 +273,18 @@ fn fetch_inner(
     }
 
     let repo_slug = format!("{}/{}", target.owner(), target.name());
-    let state = filter.gh_state();
     let host = target.host();
-    let json = gh_issue_list(repo, host, &repo_slug, state, cancelled)?;
+    let json = gh_issue_list(repo, host, &repo_slug, query, cancelled)?;
     let issues = parse_issues(&json)?;
     let truncated = issues.len() >= ISSUE_CAP;
-    Ok(IssueView::List(IssueSnapshot { filter, issues, truncated }))
+    Ok(IssueView::List(IssueSnapshot { query, issues, truncated }))
 }
 
 fn gh_issue_list(
     repo: &Path,
     host: &str,
     repo_slug: &str,
-    state: &str,
+    query: IssueQuery,
     cancelled: &AtomicBool,
 ) -> Result<String, IssueError> {
     // `gh issue list` has no `--hostname` flag. Pin the host with the `[HOST/]OWNER/REPO`
@@ -197,12 +301,18 @@ fn gh_issue_list(
         "--repo",
         &repo_arg,
         "--state",
-        state,
+        query.state.gh_state(),
         "--limit",
         &ISSUE_CAP.to_string(),
         "--json",
         "number,title,body,state,author,updatedAt,url,labels",
     ]);
+    if query.assignee == IssueAssignee::Mine {
+        cmd.args(["--assignee", "@me"]);
+    }
+    if let Some(label) = query.priority.gh_label() {
+        cmd.args(["--label", label]);
+    }
     forge::run_provider(
         &mut cmd,
         cancelled,
@@ -289,6 +399,28 @@ mod tests {
     }
 
     #[test]
+    fn assignee_and_priority_cycle() {
+        assert_eq!(IssueAssignee::All.cycle(), IssueAssignee::Mine);
+        assert_eq!(IssueAssignee::Mine.cycle(), IssueAssignee::All);
+        assert_eq!(IssuePriority::Any.cycle(), IssuePriority::P0);
+        assert_eq!(IssuePriority::P0.cycle(), IssuePriority::P1);
+        assert_eq!(IssuePriority::P1.cycle(), IssuePriority::P2);
+        assert_eq!(IssuePriority::P2.cycle(), IssuePriority::Any);
+        assert_eq!(IssuePriority::P1.gh_label(), Some("p1"));
+        assert_eq!(IssuePriority::Any.gh_label(), None);
+    }
+
+    #[test]
+    fn query_summary_omits_default_assignee_and_priority() {
+        let q = IssueQuery::default();
+        assert_eq!(q.summary(), "open");
+        let mine = IssueQuery { assignee: IssueAssignee::Mine, ..IssueQuery::default() };
+        assert_eq!(mine.summary(), "open · mine");
+        let p0 = IssueQuery { priority: IssuePriority::P0, ..IssueQuery::default() };
+        assert_eq!(p0.summary(), "open · p0");
+    }
+
+    #[test]
     fn parse_issues_reads_gh_json_shape() {
         let json = r#"[
           {
@@ -321,5 +453,4 @@ mod tests {
         assert_eq!(issues[0].labels, vec!["bug", "ui"]);
         assert_eq!(issues[1].state, IssueState::Closed);
     }
-
 }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -19,6 +19,9 @@ pub enum Action {
     TabChanges,
     TabAllFiles,
     TabPr,
+    TabIssue,
+    /// Cycle the Issue tab filter (open / closed / all).
+    CycleIssueFilter,
     Wrap,
     Preview,
     NavigatorPosition,
@@ -84,7 +87,7 @@ impl std::fmt::Display for Key {
 
 /// Every action with its config name and default keys — the single source the default keymap,
 /// the name lookup, and the config error message are built from.
-const ACTIONS: [(Action, &str, &[Key]); 33] = [
+const ACTIONS: [(Action, &str, &[Key]); 35] = [
     (Action::Down, "down", &[Key::plain('j')]),
     (Action::Up, "up", &[Key::plain('k')]),
     (Action::NextHunk, "next-hunk", &[Key::plain(']')]),
@@ -97,6 +100,8 @@ const ACTIONS: [(Action, &str, &[Key]); 33] = [
     (Action::TabChanges, "tab-changes", &[Key::plain('1')]),
     (Action::TabAllFiles, "tab-all-files", &[Key::plain('2')]),
     (Action::TabPr, "tab-pr", &[Key::plain('3')]),
+    (Action::TabIssue, "tab-issue", &[Key::plain('4')]),
+    (Action::CycleIssueFilter, "issue-filter", &[Key::plain('i')]),
     (Action::Wrap, "wrap", &[Key::plain('w')]),
     (Action::Preview, "preview", &[Key::plain('m')]),
     (Action::NavigatorPosition, "navigator-position", &[Key::plain('p')]),
@@ -252,6 +257,8 @@ mod tests {
         assert_eq!(keymap.action_for(Key::plain('?')), Some(Action::Keys));
         assert_eq!(keymap.hint(Action::Send), Key::plain('s'));
         assert_eq!(keymap.hint(Action::TabPr), Key::plain('3'));
+        assert_eq!(keymap.hint(Action::TabIssue), Key::plain('4'));
+        assert_eq!(keymap.hint(Action::CycleIssueFilter), Key::plain('i'));
         assert_eq!(Action::by_config_name("list-wider"), Some(Action::NavigatorGrow));
         assert_eq!(Action::by_config_name("list-narrower"), Some(Action::NavigatorShrink));
     }

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -20,8 +20,12 @@ pub enum Action {
     TabAllFiles,
     TabPr,
     TabIssue,
-    /// Cycle the Issue tab filter (open / closed / all).
+    /// Cycle the Issue tab state filter (open / closed / all).
     CycleIssueFilter,
+    /// Cycle the Issue tab assignee filter (all / mine).
+    CycleIssueAssignee,
+    /// Cycle the Issue tab priority-label filter (any / p0 / p1 / p2).
+    CycleIssuePriority,
     Wrap,
     Preview,
     NavigatorPosition,
@@ -87,7 +91,7 @@ impl std::fmt::Display for Key {
 
 /// Every action with its config name and default keys — the single source the default keymap,
 /// the name lookup, and the config error message are built from.
-const ACTIONS: [(Action, &str, &[Key]); 35] = [
+const ACTIONS: [(Action, &str, &[Key]); 37] = [
     (Action::Down, "down", &[Key::plain('j')]),
     (Action::Up, "up", &[Key::plain('k')]),
     (Action::NextHunk, "next-hunk", &[Key::plain(']')]),
@@ -102,6 +106,8 @@ const ACTIONS: [(Action, &str, &[Key]); 35] = [
     (Action::TabPr, "tab-pr", &[Key::plain('3')]),
     (Action::TabIssue, "tab-issue", &[Key::plain('4')]),
     (Action::CycleIssueFilter, "issue-filter", &[Key::plain('i')]),
+    (Action::CycleIssueAssignee, "issue-assignee", &[Key::plain('a')]),
+    (Action::CycleIssuePriority, "issue-priority", &[Key::plain('L')]),
     (Action::Wrap, "wrap", &[Key::plain('w')]),
     (Action::Preview, "preview", &[Key::plain('m')]),
     (Action::NavigatorPosition, "navigator-position", &[Key::plain('p')]),
@@ -259,6 +265,8 @@ mod tests {
         assert_eq!(keymap.hint(Action::TabPr), Key::plain('3'));
         assert_eq!(keymap.hint(Action::TabIssue), Key::plain('4'));
         assert_eq!(keymap.hint(Action::CycleIssueFilter), Key::plain('i'));
+        assert_eq!(keymap.hint(Action::CycleIssueAssignee), Key::plain('a'));
+        assert_eq!(keymap.hint(Action::CycleIssuePriority), Key::plain('L'));
         assert_eq!(Action::by_config_name("list-wider"), Some(Action::NavigatorGrow));
         assert_eq!(Action::by_config_name("list-narrower"), Some(Action::NavigatorShrink));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod git;
 pub mod gitlab;
 pub mod herdr;
 pub mod highlight;
+pub mod issue;
 pub mod keymap;
 #[macro_use]
 pub mod log;
@@ -203,6 +204,9 @@ const STATUS_TTL: Duration = Duration::from_secs(4);
 /// actions refresh sooner, on the worktree's turn-end, so this cadence is the slow safety net
 /// (specs/forge-host.md).
 const PR_POLL: Duration = Duration::from_mins(1);
+
+/// While the `Issue` tab is active, refetch the issue list at least this often.
+const ISSUE_POLL: Duration = Duration::from_mins(1);
 
 /// How long an in-flight PR fetch may run before a refresh trigger stops waiting on it.
 /// Generous against slow forges, short enough that the fallback poll recovers a wedged
@@ -426,6 +430,96 @@ fn drain_pr_shutdown(
 fn schedule_poll_probe(pr: &mut PrCoordinator, tab: crate::app::Tab) {
     if tab == crate::app::Tab::Pr {
         pr.probe_pending = true;
+    }
+}
+
+/// Owns one in-flight GitHub issue list fetch. Simpler than the PR coordinator: no hold gate,
+/// no multi-input identity — filter + repository probe on each fetch is enough for v1.
+#[derive(Debug)]
+struct IssueCoordinator {
+    generation: u64,
+    wait_started: Option<Instant>,
+    active: Option<ActiveIssueFetch>,
+    fetch_needed: bool,
+}
+
+#[derive(Debug)]
+struct ActiveIssueFetch {
+    generation: u64,
+    filter: crate::issue::IssueFilter,
+    cancelled: Arc<AtomicBool>,
+    started: Instant,
+}
+
+#[derive(Debug)]
+struct TaggedIssue {
+    generation: u64,
+    filter: crate::issue::IssueFilter,
+    view: crate::issue::IssueView,
+}
+
+impl IssueCoordinator {
+    fn new(ready: bool) -> Self {
+        Self {
+            generation: 1,
+            wait_started: ready.then(Instant::now),
+            active: None,
+            fetch_needed: ready,
+        }
+    }
+
+    fn stop(&mut self) {
+        self.cancel();
+        self.fetch_needed = false;
+        self.wait_started = None;
+    }
+
+    fn recover(&mut self) {
+        self.cancel();
+        self.generation = self.generation.wrapping_add(1);
+        self.fetch_needed = true;
+        self.wait_started = Some(Instant::now());
+    }
+
+    fn request(&mut self, kind: crate::app::RefreshKind) {
+        self.wait_started.get_or_insert_with(Instant::now);
+        let hung = self
+            .active
+            .as_ref()
+            .is_some_and(|active| active.started.elapsed() >= FETCH_HANG);
+        if kind == crate::app::RefreshKind::Ambient && !hung && self.active.is_some() {
+            return;
+        }
+        self.cancel();
+        if hung {
+            self.active = None;
+        }
+        self.generation = self.generation.wrapping_add(1);
+        self.fetch_needed = true;
+    }
+
+    fn cancel(&self) {
+        if let Some(active) = &self.active {
+            active.cancelled.store(true, Ordering::Release);
+        }
+    }
+
+    fn can_start(&self, config_ready: bool) -> bool {
+        self.fetch_needed && self.active.is_none() && config_ready
+    }
+
+    fn accepts(&self, tagged: &TaggedIssue, current_filter: crate::issue::IssueFilter) -> bool {
+        self.active.as_ref().is_some_and(|active| {
+            active.generation == tagged.generation
+                && active.filter == tagged.filter
+                && tagged.filter == current_filter
+        })
+    }
+}
+
+impl Drop for IssueCoordinator {
+    fn drop(&mut self) {
+        self.cancel();
     }
 }
 
@@ -683,6 +777,7 @@ fn event_loop(
     let poll = cfg.poll;
     let mut last_poll = Instant::now();
     let mut last_pr_poll = Instant::now();
+    let mut last_issue_poll = Instant::now();
     // Local input probes and forge reads run on workers. A completed fetch is applied only after
     // a fresh probe proves its complete input still matches (`specs/forge-host.md`).
     let (probe_tx, probe_rx) =
@@ -691,6 +786,8 @@ fn event_loop(
     let mut recovery_inflight = false;
     let (pr_tx, pr_rx) = mpsc::channel::<TaggedPr>();
     let mut pr = PrCoordinator::new(app.plugin_config().is_some());
+    let (issue_tx, issue_rx) = mpsc::channel::<TaggedIssue>();
+    let mut issue = IssueCoordinator::new(false);
     // The world worker owns every refresh build and the turn tracker; the loop sends
     // input-tagged jobs and reconciles the completions (specs/tui.md).
     let (world_tx, world_job_rx) = mpsc::channel::<crate::world::WorldJob>();
@@ -728,6 +825,7 @@ fn event_loop(
                             recovered.carry_authored_state_from(app);
                             *app = recovered;
                             pr.recover();
+                            issue.recover();
                         }
                         Ok(_) => {}
                         Err(error) => {
@@ -737,6 +835,7 @@ fn event_loop(
                             }
                             app.set_config_error(message);
                             pr.stop();
+                            issue.stop();
                         }
                     }
                 }
@@ -756,16 +855,22 @@ fn event_loop(
                 app.set_pr_refreshing(true);
                 pr.wait_started = None;
             }
+            if issue.wait_started.is_some_and(|started| started.elapsed() >= INDICATOR_DELAY) {
+                app.set_issue_refreshing(true);
+                issue.wait_started = None;
+            }
             // The tab-strip refresh glyph (specs/tui.md): a commanded refresh lights it
             // immediately, an ambient one past the appear delay, each tab only for its own
             // refresh. Once lit it holds a minimum, so a fast landing still reads.
             if std::mem::take(&mut app.refresh_commanded) {
                 glyph_since.get_or_insert_with(Instant::now);
             }
-            let glyph_due = if app.tab == crate::app::Tab::Pr {
-                app.pr_refreshing()
-            } else {
-                world_indicator(world_inflight.map(|(started, builds)| (started.elapsed(), builds)))
+            let glyph_due = match app.tab {
+                crate::app::Tab::Pr => app.pr_refreshing(),
+                crate::app::Tab::Issue => app.issue_refreshing(),
+                _ => world_indicator(
+                    world_inflight.map(|(started, builds)| (started.elapsed(), builds)),
+                ),
             };
             let mut glyph_wake = None;
             if glyph_due {
@@ -935,6 +1040,60 @@ fn event_loop(
                 pr.request_refresh(kind);
             }
 
+            let issue_fallback =
+                app.tab == crate::app::Tab::Issue && last_issue_poll.elapsed() >= ISSUE_POLL;
+            let issue_refresh = app
+                .issue_pending
+                .take()
+                .or(issue_fallback.then_some(crate::app::RefreshKind::Ambient));
+            if let Some(kind) = issue_refresh {
+                last_issue_poll = Instant::now();
+                issue.request(kind);
+            }
+
+            if let Ok(tagged) = issue_rx.try_recv() {
+                if issue.accepts(&tagged, app.issue_filter) {
+                    issue.active = None;
+                    app.apply_issue(tagged.view);
+                    issue.wait_started = None;
+                } else if issue.active.as_ref().is_some_and(|a| a.generation == tagged.generation) {
+                    issue.active = None;
+                }
+            }
+
+            if issue.can_start(app.plugin_config().is_some()) {
+                issue.fetch_needed = false;
+                let generation = issue.generation;
+                let filter = app.issue_filter;
+                let cancelled = Arc::new(AtomicBool::new(false));
+                issue.active = Some(ActiveIssueFetch {
+                    generation,
+                    filter,
+                    cancelled: cancelled.clone(),
+                    started: Instant::now(),
+                });
+                issue.wait_started.get_or_insert_with(Instant::now);
+                let (tx, repo, base, plugin_config) = (
+                    issue_tx.clone(),
+                    app.repo.clone(),
+                    app.base.clone(),
+                    app.plugin_config().expect("config checked above").clone(),
+                );
+                thread::spawn(move || {
+                    let view = match crate::forge::fetch_input(&repo, base.as_deref(), &plugin_config)
+                    {
+                        Ok(input) => {
+                            crate::issue::fetch(&repo, &input, filter, &cancelled)
+                        }
+                        Err(crate::forge::PrInputError::TargetRead(message))
+                        | Err(crate::forge::PrInputError::BranchState { message, .. }) => {
+                            crate::issue::IssueView::GitError(message)
+                        }
+                    };
+                    let _ = tx.send(TaggedIssue { generation, filter, view });
+                });
+            }
+
             // A fetch completion waits for a fresh local-input probe before it may paint.
             if let Ok(completion) = pr_rx.try_recv() {
                 let tag = (completion.generation, completion.config_epoch);
@@ -1048,7 +1207,8 @@ fn event_loop(
             // While a fetch is in flight, wake often so its result paints promptly when it
             // lands. A world refresh usually lands within tens of milliseconds, so its wake
             // is tighter — the landing paints near the build's own speed.
-            if pr.active_fetch.is_some() || pr.active_probe_epoch.is_some() {
+            if pr.active_fetch.is_some() || pr.active_probe_epoch.is_some() || issue.active.is_some()
+            {
                 timeout = timeout.min(Duration::from_millis(100));
             }
             if let Some((_, builds)) = world_inflight {
@@ -1061,6 +1221,9 @@ fn event_loop(
                 timeout = timeout.min(wake.max(Duration::from_millis(15)));
             }
             if let Some(started) = pr.wait_started {
+                timeout = timeout.min(INDICATOR_DELAY.saturating_sub(started.elapsed()));
+            }
+            if let Some(started) = issue.wait_started {
                 timeout = timeout.min(INDICATOR_DELAY.saturating_sub(started.elapsed()));
             }
             if event::poll(timeout)? {
@@ -1516,6 +1679,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             }
             (Some(K::TabChanges), _) => app.set_tab(crate::app::Tab::Changes)?,
             (Some(K::TabAllFiles), _) => app.set_tab(crate::app::Tab::AllFiles)?,
+            (Some(K::TabIssue), _) => app.set_tab(crate::app::Tab::Issue)?,
             (Some(K::OpenPr), _) => app.pr_open(),
             (Some(K::Search), _) => app.open_search(),
             (Some(K::NavigatorPosition), _) => app.cycle_navigator_position(),
@@ -1530,6 +1694,37 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             (_, PageUp) if app.focus == Focus::Files => app.pr_scroll_nav(-PAGE),
             (_, PageDown) => app.pr_scroll_read(PAGE),
             (_, PageUp) => app.pr_scroll_read(-PAGE),
+            _ => {}
+        }
+        return Ok(());
+    }
+
+    // The read-only Issue tab: list + body, filter cycle, open selected issue.
+    if app.tab == crate::app::Tab::Issue {
+        match (action, key.code) {
+            (Some(K::Quit), _) => app.should_quit = true,
+            (Some(K::Refresh), _) => {
+                app.request_issue_refresh(crate::app::RefreshKind::Forced);
+                app.refresh_commanded = true;
+            }
+            (Some(K::TabChanges), _) => app.set_tab(crate::app::Tab::Changes)?,
+            (Some(K::TabAllFiles), _) => app.set_tab(crate::app::Tab::AllFiles)?,
+            (Some(K::TabPr), _) => app.set_tab(crate::app::Tab::Pr)?,
+            (Some(K::CycleIssueFilter), _) => app.cycle_issue_filter(),
+            (Some(K::OpenPr), _) => app.issue_open(),
+            (Some(K::Search), _) => app.open_search(),
+            (Some(K::NavigatorPosition), _) => app.cycle_navigator_position(),
+            (Some(K::NavigatorGrow), _) => app.resize_navigator(4),
+            (Some(K::NavigatorShrink), _) => app.resize_navigator(-4),
+            (Some(K::Down), _) => app.issue_move(1),
+            (Some(K::Up), _) => app.issue_move(-1),
+            (Some(K::Keys), _) => app.toggle_keys(),
+            (_, Esc) => app.escape(),
+            (_, Tab) => app.toggle_focus(),
+            (_, PageDown) if app.focus == Focus::Files => app.issue_scroll_nav(PAGE),
+            (_, PageUp) if app.focus == Focus::Files => app.issue_scroll_nav(-PAGE),
+            (_, PageDown) => app.issue_scroll_read(PAGE),
+            (_, PageUp) => app.issue_scroll_read(-PAGE),
             _ => {}
         }
         return Ok(());
@@ -1563,6 +1758,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             K::TabChanges => app.set_tab(crate::app::Tab::Changes)?,
             K::TabAllFiles => app.set_tab(crate::app::Tab::AllFiles)?,
             K::TabPr => app.set_tab(crate::app::Tab::Pr)?,
+            K::TabIssue => app.set_tab(crate::app::Tab::Issue)?,
             K::Down => app.move_cursor(1)?,
             K::Up => app.move_cursor(-1)?,
             K::NextHunk => app.next_hunk(),
@@ -1595,8 +1791,8 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             K::Search => app.open_search(),
             K::Find => app.open_find(),
             K::Keys => app.toggle_keys(),
-            // `edit`/`delete` off the diff, and `open-pr` off the `PR` tab, are inert.
-            K::Edit | K::Delete | K::OpenPr => {}
+            // `edit`/`delete` off the diff, and forge open/filter off their tabs, are inert.
+            K::Edit | K::Delete | K::OpenPr | K::CycleIssueFilter => {}
         }
         return Ok(());
     }
@@ -1779,6 +1975,41 @@ pub fn handle_mouse(
             }
             MouseEventKind::ScrollDown => app.pr_scroll_read(3),
             MouseEventKind::ScrollUp => app.pr_scroll_read(-3),
+            _ => {}
+        }
+        return Ok(());
+    }
+
+    // The read-only Issue tab: same interaction shape as PR, with a filter chip instead of open.
+    if app.tab == crate::app::Tab::Issue {
+        match m.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(url) = app.painted_link_at(m.column, m.row) {
+                    app.focus = Focus::Diff;
+                    app.open_link(&url);
+                } else if let Some(ui::HeaderHit::Tab(tab)) =
+                    ui::hit_header(area, app, keymap, m.column, m.row)
+                {
+                    app.set_tab(tab)?;
+                } else if ui::hit_issue_filter(area, app, m.column, m.row) {
+                    app.cycle_issue_filter();
+                } else if ui::in_files_pane(area, app, m.column, m.row) {
+                    app.focus = Focus::Files;
+                    if let Some(i) = ui::issue_nav_hit(area, app, m.column, m.row) {
+                        app.issue_select(i);
+                    }
+                } else if ui::in_diff_pane(area, app, m.column, m.row) {
+                    app.focus = Focus::Diff;
+                }
+            }
+            MouseEventKind::ScrollDown if ui::in_files_pane(area, app, m.column, m.row) => {
+                app.issue_scroll_nav(3);
+            }
+            MouseEventKind::ScrollUp if ui::in_files_pane(area, app, m.column, m.row) => {
+                app.issue_scroll_nav(-3);
+            }
+            MouseEventKind::ScrollDown => app.issue_scroll_read(3),
+            MouseEventKind::ScrollUp => app.issue_scroll_read(-3),
             _ => {}
         }
         return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,7 +434,7 @@ fn schedule_poll_probe(pr: &mut PrCoordinator, tab: crate::app::Tab) {
 }
 
 /// Owns one in-flight GitHub issue list fetch. Simpler than the PR coordinator: no hold gate,
-/// no multi-input identity — filter + repository probe on each fetch is enough for v1.
+/// no multi-input identity — query + repository probe on each fetch is enough for v1.
 #[derive(Debug)]
 struct IssueCoordinator {
     generation: u64,
@@ -446,7 +446,7 @@ struct IssueCoordinator {
 #[derive(Debug)]
 struct ActiveIssueFetch {
     generation: u64,
-    filter: crate::issue::IssueFilter,
+    query: crate::issue::IssueQuery,
     cancelled: Arc<AtomicBool>,
     started: Instant,
 }
@@ -454,7 +454,7 @@ struct ActiveIssueFetch {
 #[derive(Debug)]
 struct TaggedIssue {
     generation: u64,
-    filter: crate::issue::IssueFilter,
+    query: crate::issue::IssueQuery,
     view: crate::issue::IssueView,
 }
 
@@ -508,11 +508,11 @@ impl IssueCoordinator {
         self.fetch_needed && self.active.is_none() && config_ready
     }
 
-    fn accepts(&self, tagged: &TaggedIssue, current_filter: crate::issue::IssueFilter) -> bool {
+    fn accepts(&self, tagged: &TaggedIssue, current: crate::issue::IssueQuery) -> bool {
         self.active.as_ref().is_some_and(|active| {
             active.generation == tagged.generation
-                && active.filter == tagged.filter
-                && tagged.filter == current_filter
+                && active.query == tagged.query
+                && tagged.query == current
         })
     }
 }
@@ -1040,19 +1040,22 @@ fn event_loop(
                 pr.request_refresh(kind);
             }
 
-            let issue_fallback =
-                app.tab == crate::app::Tab::Issue && last_issue_poll.elapsed() >= ISSUE_POLL;
-            let issue_refresh = app
-                .issue_pending
-                .take()
-                .or(issue_fallback.then_some(crate::app::RefreshKind::Ambient));
-            if let Some(kind) = issue_refresh {
+            // Ambient poll only while the tab is active; resolve_issue_query skips the network
+            // when the active query's cache is still within the TTL (specs/issue-tab.md).
+            if app.issue_pending.is_none()
+                && app.tab == crate::app::Tab::Issue
+                && last_issue_poll.elapsed() >= ISSUE_POLL
+            {
+                last_issue_poll = Instant::now();
+                app.resolve_issue_query(crate::app::RefreshKind::Ambient);
+            }
+            if let Some(kind) = app.issue_pending.take() {
                 last_issue_poll = Instant::now();
                 issue.request(kind);
             }
 
             if let Ok(tagged) = issue_rx.try_recv() {
-                if issue.accepts(&tagged, app.issue_filter) {
+                if issue.accepts(&tagged, app.issue_query) {
                     issue.active = None;
                     app.apply_issue(tagged.view);
                     issue.wait_started = None;
@@ -1064,11 +1067,11 @@ fn event_loop(
             if issue.can_start(app.plugin_config().is_some()) {
                 issue.fetch_needed = false;
                 let generation = issue.generation;
-                let filter = app.issue_filter;
+                let query = app.issue_query;
                 let cancelled = Arc::new(AtomicBool::new(false));
                 issue.active = Some(ActiveIssueFetch {
                     generation,
-                    filter,
+                    query,
                     cancelled: cancelled.clone(),
                     started: Instant::now(),
                 });
@@ -1083,14 +1086,14 @@ fn event_loop(
                     let view = match crate::forge::fetch_input(&repo, base.as_deref(), &plugin_config)
                     {
                         Ok(input) => {
-                            crate::issue::fetch(&repo, &input, filter, &cancelled)
+                            crate::issue::fetch(&repo, &input, query, &cancelled)
                         }
-                        Err(crate::forge::PrInputError::TargetRead(message))
-                        | Err(crate::forge::PrInputError::BranchState { message, .. }) => {
-                            crate::issue::IssueView::GitError(message)
-                        }
+                        Err(
+                            crate::forge::PrInputError::TargetRead(message)
+                            | crate::forge::PrInputError::BranchState { message, .. },
+                        ) => crate::issue::IssueView::GitError(message),
                     };
-                    let _ = tx.send(TaggedIssue { generation, filter, view });
+                    let _ = tx.send(TaggedIssue { generation, query, view });
                 });
             }
 
@@ -1711,6 +1714,8 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             (Some(K::TabAllFiles), _) => app.set_tab(crate::app::Tab::AllFiles)?,
             (Some(K::TabPr), _) => app.set_tab(crate::app::Tab::Pr)?,
             (Some(K::CycleIssueFilter), _) => app.cycle_issue_filter(),
+            (Some(K::CycleIssueAssignee), _) => app.cycle_issue_assignee(),
+            (Some(K::CycleIssuePriority), _) => app.cycle_issue_priority(),
             (Some(K::OpenPr), _) => app.issue_open(),
             (Some(K::Search), _) => app.open_search(),
             (Some(K::NavigatorPosition), _) => app.cycle_navigator_position(),
@@ -1792,7 +1797,12 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             K::Find => app.open_find(),
             K::Keys => app.toggle_keys(),
             // `edit`/`delete` off the diff, and forge open/filter off their tabs, are inert.
-            K::Edit | K::Delete | K::OpenPr | K::CycleIssueFilter => {}
+            K::Edit
+            | K::Delete
+            | K::OpenPr
+            | K::CycleIssueFilter
+            | K::CycleIssueAssignee
+            | K::CycleIssuePriority => {}
         }
         return Ok(());
     }
@@ -1980,7 +1990,7 @@ pub fn handle_mouse(
         return Ok(());
     }
 
-    // The read-only Issue tab: same interaction shape as PR, with a filter chip instead of open.
+    // The read-only Issue tab: same interaction shape as PR, with filter chips instead of open.
     if app.tab == crate::app::Tab::Issue {
         match m.kind {
             MouseEventKind::Down(MouseButton::Left) => {
@@ -1991,8 +2001,12 @@ pub fn handle_mouse(
                     ui::hit_header(area, app, keymap, m.column, m.row)
                 {
                     app.set_tab(tab)?;
-                } else if ui::hit_issue_filter(area, app, m.column, m.row) {
-                    app.cycle_issue_filter();
+                } else if let Some(chip) = ui::hit_issue_chip(area, app, m.column, m.row) {
+                    match chip {
+                        ui::IssueChip::State => app.cycle_issue_filter(),
+                        ui::IssueChip::Assignee => app.cycle_issue_assignee(),
+                        ui::IssueChip::Priority => app.cycle_issue_priority(),
+                    }
                 } else if ui::in_files_pane(area, app, m.column, m.row) {
                     app.focus = Focus::Files;
                     if let Some(i) = ui::issue_nav_hit(area, app, m.column, m.row) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1703,6 +1703,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
     }
 
     // The read-only Issue tab: list + body, filter cycle, open selected issue.
+    // `→` enters the detail section (description + comments); `←` returns to the issue list.
     if app.tab == crate::app::Tab::Issue {
         match (action, key.code) {
             (Some(K::Quit), _) => app.should_quit = true,
@@ -1724,10 +1725,18 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             (Some(K::Down), _) => app.issue_move(1),
             (Some(K::Up), _) => app.issue_move(-1),
             (Some(K::Keys), _) => app.toggle_keys(),
-            (_, Esc) => app.escape(),
+            (_, Right) => app.issue_enter_detail(),
+            (_, Left) => app.issue_exit_detail(),
+            (_, Esc) => {
+                if app.issue_detail_focused() {
+                    app.issue_exit_detail();
+                } else {
+                    app.escape();
+                }
+            }
             (_, Tab) => app.toggle_focus(),
-            (_, PageDown) if app.focus == Focus::Files => app.issue_scroll_nav(PAGE),
-            (_, PageUp) if app.focus == Focus::Files => app.issue_scroll_nav(-PAGE),
+            (_, PageDown) if app.focus == Focus::Files => app.issue_scroll_focused_nav(PAGE),
+            (_, PageUp) if app.focus == Focus::Files => app.issue_scroll_focused_nav(-PAGE),
             (_, PageDown) => app.issue_scroll_read(PAGE),
             (_, PageUp) => app.issue_scroll_read(-PAGE),
             _ => {}
@@ -2009,18 +2018,28 @@ pub fn handle_mouse(
                     }
                 } else if ui::in_files_pane(area, app, m.column, m.row) {
                     app.focus = Focus::Files;
-                    if let Some(i) = ui::issue_nav_hit(area, app, m.column, m.row) {
-                        app.issue_select(i);
+                    if let Some(hit) = ui::issue_nav_hit(area, app, m.column, m.row) {
+                        match hit {
+                            ui::IssueNavHit::Issue(i) => app.issue_select(i),
+                            ui::IssueNavHit::Description => app.issue_select_detail(0),
+                            ui::IssueNavHit::Comment(c) => app.issue_select_detail(c + 1),
+                        }
                     }
                 } else if ui::in_diff_pane(area, app, m.column, m.row) {
                     app.focus = Focus::Diff;
                 }
             }
             MouseEventKind::ScrollDown if ui::in_files_pane(area, app, m.column, m.row) => {
-                app.issue_scroll_nav(3);
+                match ui::issue_nav_pane_at(area, app, m.column, m.row) {
+                    Some(ui::IssueNavPane::Detail) => app.issue_scroll_detail_nav(3),
+                    _ => app.issue_scroll_nav(3),
+                }
             }
             MouseEventKind::ScrollUp if ui::in_files_pane(area, app, m.column, m.row) => {
-                app.issue_scroll_nav(-3);
+                match ui::issue_nav_pane_at(area, app, m.column, m.row) {
+                    Some(ui::IssueNavPane::Detail) => app.issue_scroll_detail_nav(-3),
+                    _ => app.issue_scroll_nav(-3),
+                }
             }
             MouseEventKind::ScrollDown => app.issue_scroll_read(3),
             MouseEventKind::ScrollUp => app.issue_scroll_read(-3),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,10 +483,8 @@ impl IssueCoordinator {
 
     fn request(&mut self, kind: crate::app::RefreshKind) {
         self.wait_started.get_or_insert_with(Instant::now);
-        let hung = self
-            .active
-            .as_ref()
-            .is_some_and(|active| active.started.elapsed() >= FETCH_HANG);
+        let hung =
+            self.active.as_ref().is_some_and(|active| active.started.elapsed() >= FETCH_HANG);
         if kind == crate::app::RefreshKind::Ambient && !hung && self.active.is_some() {
             return;
         }
@@ -1083,16 +1081,14 @@ fn event_loop(
                     app.plugin_config().expect("config checked above").clone(),
                 );
                 thread::spawn(move || {
-                    let view = match crate::forge::fetch_input(&repo, base.as_deref(), &plugin_config)
-                    {
-                        Ok(input) => {
-                            crate::issue::fetch(&repo, &input, query, &cancelled)
-                        }
-                        Err(
-                            crate::forge::PrInputError::TargetRead(message)
-                            | crate::forge::PrInputError::BranchState { message, .. },
-                        ) => crate::issue::IssueView::GitError(message),
-                    };
+                    let view =
+                        match crate::forge::fetch_input(&repo, base.as_deref(), &plugin_config) {
+                            Ok(input) => crate::issue::fetch(&repo, &input, query, &cancelled),
+                            Err(
+                                crate::forge::PrInputError::TargetRead(message)
+                                | crate::forge::PrInputError::BranchState { message, .. },
+                            ) => crate::issue::IssueView::GitError(message),
+                        };
                     let _ = tx.send(TaggedIssue { generation, query, view });
                 });
             }
@@ -1210,7 +1206,9 @@ fn event_loop(
             // While a fetch is in flight, wake often so its result paints promptly when it
             // lands. A world refresh usually lands within tens of milliseconds, so its wake
             // is tighter — the landing paints near the build's own speed.
-            if pr.active_fetch.is_some() || pr.active_probe_epoch.is_some() || issue.active.is_some()
+            if pr.active_fetch.is_some()
+                || pr.active_probe_epoch.is_some()
+                || issue.active.is_some()
             {
                 timeout = timeout.min(Duration::from_millis(100));
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1491,7 +1491,9 @@ fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
         A::PickResult => ("↑↓".into(), "pick"),
         A::OpenResult => ("enter".into(), "open"),
         A::OpenPr => (hint(K::OpenPr), "open ↗"),
-        A::IssueFilter => (hint(K::CycleIssueFilter), app.issue_filter.label()),
+        A::IssueFilter => (hint(K::CycleIssueFilter), app.issue_query.state.label()),
+        A::IssueAssignee => (hint(K::CycleIssueAssignee), app.issue_query.assignee.label()),
+        A::IssuePriority => (hint(K::CycleIssuePriority), app.issue_query.priority.label()),
         A::Refresh => (hint(K::Refresh), "refresh"),
         A::Tabs => (
             format!(
@@ -1653,7 +1655,7 @@ fn footer_row1(app: &App, w: usize) -> (Vec<Span<'static>>, Vec<FooterAction>) {
         let budget = w.saturating_sub(used + primary_w + reserve + 4).max(8);
         let more = if s.truncated { "+" } else { "" };
         let text = truncate_width(
-            &format!("{} {} issues{more}   ", s.issues.len(), s.filter.label()),
+            &format!("{} {} issues{more}   ", s.issues.len(), s.query.summary()),
             budget,
         );
         used += text.chars().count();
@@ -3093,28 +3095,57 @@ pub fn hit_pr_open(area: Rect, app: &App, col: u16, row: u16) -> bool {
 
 // --- Issue tab (GitHub issues, read-only) ---------------------------------------
 
-/// Issue tab header: tabs, then a right-aligned filter chip `[open]` and optional selected title.
+/// Which Issue header filter chip a click landed on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IssueChip {
+    State,
+    Assignee,
+    Priority,
+}
+
+/// The three right-anchored chips: `[state] [assignee] [priority]`.
+fn issue_chip_labels(app: &App) -> [String; 3] {
+    [
+        format!("[{}]", app.issue_query.state.label()),
+        format!("[{}]", app.issue_query.assignee.label()),
+        format!("[{}]", app.issue_query.priority.label()),
+    ]
+}
+
+/// Total display width of the chip cluster including single-space gaps between chips.
+fn issue_chips_width(app: &App) -> usize {
+    let chips = issue_chip_labels(app);
+    chips.iter().map(|c| c.width()).sum::<usize>() + chips.len().saturating_sub(1)
+}
+
+/// Issue tab header: tabs, then right-aligned filter chips and optional selected title.
 fn render_issue_header(frame: &mut Frame, app: &App, area: Rect) {
     let p = app.palette();
     let bar = Style::default().bg(p.surface0);
     let mut spans = tab_bar_spans(app);
     let lead_tabs: usize = spans.iter().map(Span::width).sum();
     let w = area.width as usize;
-    let filter = format!("[{}]", app.issue_filter.label());
-    let filter_w = filter.width();
+    let chips = issue_chip_labels(app);
+    let chips_w = issue_chips_width(app);
     let title = app
         .issue_selected()
         .map(|i| format!("#{} {}", i.number, i.title))
         .unwrap_or_default();
-    let name = truncate_width(&title, w.saturating_sub(lead_tabs + filter_w + 2).max(4));
+    let name = truncate_width(&title, w.saturating_sub(lead_tabs + chips_w + 2).max(4));
     let name_w = name.width();
-    let pad = w.saturating_sub(lead_tabs + name_w + if name_w > 0 { 2 } else { 0 } + filter_w);
+    let pad = w.saturating_sub(lead_tabs + name_w + if name_w > 0 { 2 } else { 0 } + chips_w);
     spans.push(Span::styled(" ".repeat(pad), bar));
     if name_w > 0 {
         spans.push(Span::styled(name, bar.fg(p.subtext0)));
         spans.push(Span::styled("  ", bar));
     }
-    spans.push(Span::styled(filter, bar.fg(p.lavender).add_modifier(Modifier::BOLD)));
+    let chip_style = bar.fg(p.lavender).add_modifier(Modifier::BOLD);
+    for (i, chip) in chips.into_iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" ", bar));
+        }
+        spans.push(Span::styled(chip, chip_style));
+    }
     let used: usize = spans.iter().map(Span::width).sum();
     if used < w {
         spans.push(Span::styled(" ".repeat(w - used), bar));
@@ -3122,20 +3153,37 @@ fn render_issue_header(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
-/// Whether a click lands on the Issue header's right-anchored `[filter]` chip.
+/// Which Issue header filter chip contains `(col, row)`, if any.
 #[must_use]
-pub fn hit_issue_filter(area: Rect, app: &App, col: u16, row: u16) -> bool {
+pub fn hit_issue_chip(area: Rect, app: &App, col: u16, row: u16) -> Option<IssueChip> {
     if row != area.y {
-        return false;
+        return None;
     }
-    let filter_w = format!("[{}]", app.issue_filter.label()).width() as u16;
-    col >= area.width.saturating_sub(filter_w) && col < area.width
+    let chips = issue_chip_labels(app);
+    let total = issue_chips_width(app) as u16;
+    if total == 0 || col < area.width.saturating_sub(total) {
+        return None;
+    }
+    // Walk chips from the right edge: priority, assignee, state.
+    let mut right = area.width;
+    let order = [IssueChip::Priority, IssueChip::Assignee, IssueChip::State];
+    for (i, which) in order.into_iter().enumerate() {
+        let label = &chips[2 - i];
+        let w = label.width() as u16;
+        let left = right.saturating_sub(w);
+        if col >= left && col < right {
+            return Some(which);
+        }
+        // Gap of one column between chips (except after the leftmost).
+        right = left.saturating_sub(1);
+    }
+    None
 }
 
 /// Issue navigator: newest-list order from `gh` (updatedAt desc by default).
 fn render_issue_nav(frame: &mut Frame, app: &App, area: Rect) {
     let p = app.palette();
-    let title = format!("Issues · {}", app.issue_filter.label());
+    let title = format!("Issues · {}", app.issue_query.nav_title());
     let block = bordered(&title, app.focus == Focus::Files, p);
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -3303,7 +3351,7 @@ fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
         body_meta = Some((offset, rendered));
     } else {
         let refresh = app.keymap().hint(crate::keymap::Action::Refresh);
-        for piece in wrap_text(&issue_empty_msg(&app.issue, app.issue_filter, refresh), width.max(1))
+        for piece in wrap_text(&issue_empty_msg(&app.issue, app.issue_query, refresh), width.max(1))
         {
             lines.push(Line::from(Span::styled(piece, Style::default().fg(p.overlay0))));
         }
@@ -3326,7 +3374,7 @@ fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
 
 fn issue_empty_msg(
     view: &crate::issue::IssueView,
-    filter: crate::issue::IssueFilter,
+    query: crate::issue::IssueQuery,
     refresh: crate::keymap::Key,
 ) -> String {
     if let Some(message) = view.retry_remedy(refresh) {
@@ -3335,7 +3383,7 @@ fn issue_empty_msg(
     match view {
         crate::issue::IssueView::Loading => "loading…".into(),
         crate::issue::IssueView::Pending | crate::issue::IssueView::List(_) => {
-            format!("No {} issues.", filter.label())
+            format!("No {} issues.", query.summary())
         }
         crate::issue::IssueView::NeedsForgeRemote => {
             "The Issue tab needs a GitHub remote named upstream or origin.".into()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3332,6 +3332,13 @@ fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
     let mut lines: Vec<Line<'static>> = Vec::new();
     let mut body_meta: Option<(usize, crate::markdown::Rendered)> = None;
     if let Some(issue) = app.issue_selected() {
+        // Full title as H1 style — the navigator may truncate it (specs/issue-tab.md).
+        // Styled manually (not via markdown) so characters like `#`/`*` in titles stay literal.
+        let h1 = Style::default().fg(p.mauve).add_modifier(Modifier::BOLD);
+        for piece in wrap_text(&issue.title, width.max(1)) {
+            lines.push(Line::from(Span::styled(piece, h1)));
+        }
+        lines.push(Line::raw(""));
         if !issue.labels.is_empty() {
             let labels = issue.labels.join(", ");
             lines.push(Line::from(Span::styled(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3219,11 +3219,12 @@ fn issue_nav_rows(app: &App, width: usize, now: std::time::SystemTime) -> Vec<Is
         return Vec::new();
     };
     let p = app.palette();
+    let present: std::collections::HashSet<u64> = s.issues.iter().map(|i| i.number).collect();
     s.issues
         .iter()
         .enumerate()
         .map(|(index, issue)| IssueNavRow {
-            spans: issue_row(issue, width, now, p),
+            spans: issue_row(issue, width, now, p, &present),
             cursor: Some(index),
         })
         .collect()
@@ -3234,29 +3235,43 @@ fn issue_row(
     width: usize,
     now: std::time::SystemTime,
     p: &Palette,
+    present: &std::collections::HashSet<u64>,
 ) -> Vec<Span<'static>> {
+    // One nesting level: sub-issues under a parent also in the list (specs/issue-tab.md).
+    let indent = "  ".repeat(issue.tree_depth(present));
     let number = format!("#{} ", issue.number);
     let age = forge::relative_age(&issue.updated_at, now);
     let state_glyph = match issue.state {
         crate::issue::IssueState::Open => ("●", p.green),
         crate::issue::IssueState::Closed => ("○", p.overlay0),
     };
-    let trailing = if age.is_empty() {
-        String::new()
+    // Parent progress from subIssuesSummary, e.g. ` 1/3`, when the issue has children.
+    let progress = if issue.sub_total > 0 {
+        format!(" {}/{}", issue.sub_completed, issue.sub_total)
     } else {
-        format!("  {age}")
+        String::new()
     };
-    let budget = width
-        .saturating_sub(2 + number.width() + trailing.width())
-        .max(1);
+    let trailing = match (progress.is_empty(), age.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => progress,
+        (true, false) => format!("  {age}"),
+        (false, false) => format!("{progress}  {age}"),
+    };
+    let fixed = indent.width() + 2 + number.width() + trailing.width();
+    let budget = width.saturating_sub(fixed).max(1);
     // Titles prefer the leading words (unlike file paths, which elide the head).
     let title = truncate_width(&issue.title, budget);
-    vec![
-        Span::styled(format!("{} ", state_glyph.0), Style::default().fg(state_glyph.1)),
-        Span::styled(number, Style::default().fg(p.yellow)),
-        Span::styled(title, text_style(p)),
-        Span::styled(trailing, Style::default().fg(p.overlay0)),
-    ]
+    let mut spans = Vec::with_capacity(5);
+    if !indent.is_empty() {
+        spans.push(Span::raw(indent));
+    }
+    spans.push(Span::styled(format!("{} ", state_glyph.0), Style::default().fg(state_glyph.1)));
+    spans.push(Span::styled(number, Style::default().fg(p.yellow)));
+    spans.push(Span::styled(title, text_style(p)));
+    if !trailing.is_empty() {
+        spans.push(Span::styled(trailing, Style::default().fg(p.overlay0)));
+    }
+    spans
 }
 
 fn settle_issue_nav_scroll(
@@ -3339,6 +3354,19 @@ fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
             lines.push(Line::from(Span::styled(piece, h1)));
         }
         lines.push(Line::raw(""));
+        if let Some(parent) = issue.parent_number {
+            lines.push(Line::from(Span::styled(
+                format!("sub-issue of #{parent}"),
+                Style::default().fg(p.overlay0),
+            )));
+            lines.push(Line::raw(""));
+        } else if issue.sub_total > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("sub-issues: {}/{}", issue.sub_completed, issue.sub_total),
+                Style::default().fg(p.overlay0),
+            )));
+            lines.push(Line::raw(""));
+        }
         if !issue.labels.is_empty() {
             let labels = issue.labels.join(", ");
             lines.push(Line::from(Span::styled(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3127,10 +3127,8 @@ fn render_issue_header(frame: &mut Frame, app: &App, area: Rect) {
     let w = area.width as usize;
     let chips = issue_chip_labels(app);
     let chips_w = issue_chips_width(app);
-    let title = app
-        .issue_selected()
-        .map(|i| format!("#{} {}", i.number, i.title))
-        .unwrap_or_default();
+    let title =
+        app.issue_selected().map(|i| format!("#{} {}", i.number, i.title)).unwrap_or_default();
     let name = truncate_width(&title, w.saturating_sub(lead_tabs + chips_w + 2).max(4));
     let name_w = name.width();
     let pad = w.saturating_sub(lead_tabs + name_w + if name_w > 0 { 2 } else { 0 } + chips_w);
@@ -3194,7 +3192,12 @@ fn render_issue_nav(frame: &mut Frame, app: &App, area: Rect) {
         let half = split_axis(area.width, 50);
         let issues = Rect::new(area.x, area.y, half, area.height);
         let detail = Rect::new(area.x + half, area.y, area.width - half, area.height);
-        render_issue_list_panel(frame, app, issues, app.focus == Focus::Files && !app.issue_detail_focused());
+        render_issue_list_panel(
+            frame,
+            app,
+            issues,
+            app.focus == Focus::Files && !app.issue_detail_focused(),
+        );
         render_issue_detail_panel(
             frame,
             app,
@@ -3273,9 +3276,8 @@ fn render_issue_detail_panel(frame: &mut Frame, app: &App, area: Rect, focused: 
     let rows = issue_detail_rows(app, width, std::time::SystemTime::now());
     let focus = issue_nav_focus(app);
     let viewport = list_area.height as usize;
-    let can_reveal = viewport > 0
-        && app.issue_detail_focused()
-        && rows.iter().any(|row| row.hit == Some(focus));
+    let can_reveal =
+        viewport > 0 && app.issue_detail_focused() && rows.iter().any(|row| row.hit == Some(focus));
     // Only consume the reveal flag when this pane owns focus; the issues panel may have
     // already taken it when focus is on the list.
     let reveal = can_reveal && app.take_issue_nav_reveal();
@@ -3406,7 +3408,11 @@ fn issue_detail_rows(app: &App, width: usize, now: std::time::SystemTime) -> Vec
 }
 
 /// Combined single-column rows: issues, then optional detail section with a header.
-fn issue_nav_rows_combined(app: &App, width: usize, now: std::time::SystemTime) -> Vec<IssueNavRow> {
+fn issue_nav_rows_combined(
+    app: &App,
+    width: usize,
+    now: std::time::SystemTime,
+) -> Vec<IssueNavRow> {
     let p = app.palette();
     let dim = Style::default().fg(p.overlay0);
     let mut rows = issue_list_rows(app, width, now);
@@ -3415,10 +3421,7 @@ fn issue_nav_rows_combined(app: &App, width: usize, now: std::time::SystemTime) 
     {
         rows.push(IssueNavRow { spans: Vec::new(), hit: None });
         rows.push(IssueNavRow {
-            spans: vec![Span::styled(
-                format!("comments · {}", issue.comments.len()),
-                dim,
-            )],
+            spans: vec![Span::styled(format!("comments · {}", issue.comments.len()), dim)],
             hit: None,
         });
         rows.extend(issue_detail_rows(app, width, now));
@@ -3533,10 +3536,8 @@ fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
     let width = inner.width as usize;
-    let notice_lines = app
-        .issue_notice()
-        .map(|notice| wrap_text(notice, width.max(1)))
-        .unwrap_or_default();
+    let notice_lines =
+        app.issue_notice().map(|notice| wrap_text(notice, width.max(1))).unwrap_or_default();
     let notice_capacity = match inner.height {
         0 => 0,
         1 => 1,
@@ -3576,11 +3577,7 @@ fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
     let mut lines: Vec<Line<'static>> = Vec::new();
     let mut body_meta: Option<(usize, crate::markdown::Rendered)> = None;
     if let Some(cm) = app.issue_selected_comment() {
-        let text = if cm.body.trim().is_empty() {
-            "_No comment body._"
-        } else {
-            cm.body.as_str()
-        };
+        let text = if cm.body.trim().is_empty() { "_No comment body._" } else { cm.body.as_str() };
         let mut rendered = app.markdown_render(text, width.max(1));
         let offset = lines.len();
         lines.append(&mut rendered.lines);
@@ -3614,11 +3611,8 @@ fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
             )));
             lines.push(Line::raw(""));
         }
-        let text = if issue.body.trim().is_empty() {
-            "_No description._"
-        } else {
-            issue.body.as_str()
-        };
+        let text =
+            if issue.body.trim().is_empty() { "_No description._" } else { issue.body.as_str() };
         let mut rendered = app.markdown_render(text, width.max(1));
         let offset = lines.len();
         lines.append(&mut rendered.lines);
@@ -3732,8 +3726,7 @@ pub fn issue_nav_hit(area: Rect, app: &App, col: u16, row: u16) -> Option<IssueN
             if row >= inner.y + list_h {
                 return None; // hint row
             }
-            let rows =
-                issue_detail_rows(app, inner.width as usize, std::time::SystemTime::now());
+            let rows = issue_detail_rows(app, inner.width as usize, std::time::SystemTime::now());
             let scroll = app.issue_detail_nav_scroll();
             return rows.get((row - inner.y) as usize + scroll)?.hit;
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -48,6 +48,8 @@ pub fn render(frame: &mut Frame, app: &App) {
     if app.mode == Mode::Search {
         if app.tab == Tab::Pr {
             render_pr_header(frame, app, p.tab);
+        } else if app.tab == Tab::Issue {
+            render_issue_header(frame, app, p.tab);
         } else {
             render_tab_bar(frame, app, p.tab);
         }
@@ -61,6 +63,10 @@ pub fn render(frame: &mut Frame, app: &App) {
         render_pr_read(frame, app, p.diff);
         // `PR` never hides its navigator (specs/tui.md), so no hidden gate here.
         render_pr_nav(frame, app, p.files);
+    } else if app.tab == Tab::Issue {
+        render_issue_header(frame, app, p.tab);
+        render_issue_read(frame, app, p.diff);
+        render_issue_nav(frame, app, p.files);
     } else {
         render_tab_bar(frame, app, p.tab);
         render_diff_view(frame, app, p.diff);
@@ -474,14 +480,15 @@ pub fn hit_header(area: Rect, app: &App, keymap: &Keymap, col: u16, row: u16) ->
     }
 }
 
-/// The three tabs and their labels, left to right, each led by its `tab-*` action's hint key
+/// The top-level tabs and their labels, left to right, each led by its `tab-*` action's hint key
 /// (`specs/input.md`). Column math uses display width, since a bound hint key can be wide.
-fn tab_labels(keymap: &Keymap) -> [(Tab, String); 3] {
+fn tab_labels(keymap: &Keymap) -> [(Tab, String); 4] {
     use crate::keymap::Action as K;
     [
         (Tab::Changes, format!("{} Changes", keymap.hint(K::TabChanges))),
         (Tab::AllFiles, format!("{} All files", keymap.hint(K::TabAllFiles))),
         (Tab::Pr, format!("{} PR", keymap.hint(K::TabPr))),
+        (Tab::Issue, format!("{} Issue", keymap.hint(K::TabIssue))),
     ]
 }
 const HEADER_LEAD: &str = " ";
@@ -1484,10 +1491,18 @@ fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
         A::PickResult => ("↑↓".into(), "pick"),
         A::OpenResult => ("enter".into(), "open"),
         A::OpenPr => (hint(K::OpenPr), "open ↗"),
+        A::IssueFilter => (hint(K::CycleIssueFilter), app.issue_filter.label()),
         A::Refresh => (hint(K::Refresh), "refresh"),
-        A::Tabs => {
-            (format!("{}·{}·{}", hint(K::TabChanges), hint(K::TabAllFiles), hint(K::TabPr)), "tabs")
-        }
+        A::Tabs => (
+            format!(
+                "{}·{}·{}·{}",
+                hint(K::TabChanges),
+                hint(K::TabAllFiles),
+                hint(K::TabPr),
+                hint(K::TabIssue)
+            ),
+            "tabs",
+        ),
         A::Quit => (hint(K::Quit), "quit"),
     };
     (k, l.into())
@@ -1627,6 +1642,20 @@ fn footer_row1(app: &App, w: usize) -> (Vec<Span<'static>>, Vec<FooterAction>) {
         let primary_w = primary.map_or(0, |a| entry_body_width(app, a));
         let budget = w.saturating_sub(used + primary_w + reserve + 4).max(8);
         let text = truncate_width(&format!("{}   ", pr_state_line(app, s)), budget);
+        used += text.chars().count();
+        spans.push(Span::styled(text, Style::default().fg(p.subtext0)));
+    }
+    // Issue tab: leading count for the active filter.
+    if app.tab == Tab::Issue
+        && let Some(s) = app.issue_snapshot()
+    {
+        let primary_w = primary.map_or(0, |a| entry_body_width(app, a));
+        let budget = w.saturating_sub(used + primary_w + reserve + 4).max(8);
+        let more = if s.truncated { "+" } else { "" };
+        let text = truncate_width(
+            &format!("{} {} issues{more}   ", s.issues.len(), s.filter.label()),
+            budget,
+        );
         used += text.chars().count();
         spans.push(Span::styled(text, Style::default().fg(p.subtext0)));
     }
@@ -3060,6 +3089,285 @@ pub fn hit_pr_open(area: Rect, app: &App, col: u16, row: u16) -> bool {
     let chip_w = pr_chip_width(app, s) as u16;
     // The chip occupies the last `chip_w` columns; `saturating_sub` keeps the bound overflow-free.
     col >= area.width.saturating_sub(chip_w) && col < area.width
+}
+
+// --- Issue tab (GitHub issues, read-only) ---------------------------------------
+
+/// Issue tab header: tabs, then a right-aligned filter chip `[open]` and optional selected title.
+fn render_issue_header(frame: &mut Frame, app: &App, area: Rect) {
+    let p = app.palette();
+    let bar = Style::default().bg(p.surface0);
+    let mut spans = tab_bar_spans(app);
+    let lead_tabs: usize = spans.iter().map(Span::width).sum();
+    let w = area.width as usize;
+    let filter = format!("[{}]", app.issue_filter.label());
+    let filter_w = filter.width();
+    let title = app
+        .issue_selected()
+        .map(|i| format!("#{} {}", i.number, i.title))
+        .unwrap_or_default();
+    let name = truncate_width(&title, w.saturating_sub(lead_tabs + filter_w + 2).max(4));
+    let name_w = name.width();
+    let pad = w.saturating_sub(lead_tabs + name_w + if name_w > 0 { 2 } else { 0 } + filter_w);
+    spans.push(Span::styled(" ".repeat(pad), bar));
+    if name_w > 0 {
+        spans.push(Span::styled(name, bar.fg(p.subtext0)));
+        spans.push(Span::styled("  ", bar));
+    }
+    spans.push(Span::styled(filter, bar.fg(p.lavender).add_modifier(Modifier::BOLD)));
+    let used: usize = spans.iter().map(Span::width).sum();
+    if used < w {
+        spans.push(Span::styled(" ".repeat(w - used), bar));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// Whether a click lands on the Issue header's right-anchored `[filter]` chip.
+#[must_use]
+pub fn hit_issue_filter(area: Rect, app: &App, col: u16, row: u16) -> bool {
+    if row != area.y {
+        return false;
+    }
+    let filter_w = format!("[{}]", app.issue_filter.label()).width() as u16;
+    col >= area.width.saturating_sub(filter_w) && col < area.width
+}
+
+/// Issue navigator: newest-list order from `gh` (updatedAt desc by default).
+fn render_issue_nav(frame: &mut Frame, app: &App, area: Rect) {
+    let p = app.palette();
+    let title = format!("Issues · {}", app.issue_filter.label());
+    let block = bordered(&title, app.focus == Focus::Files, p);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let width = inner.width as usize;
+    let rows = issue_nav_rows(app, width, std::time::SystemTime::now());
+    let viewport = inner.height as usize;
+    let can_reveal =
+        viewport > 0 && rows.iter().any(|row| row.cursor == Some(app.issue_cursor));
+    let reveal = can_reveal && app.take_issue_nav_reveal();
+    let (scroll, max_scroll) =
+        settle_issue_nav_scroll(&rows, app.issue_cursor, viewport, app.issue_nav_scroll(), reveal);
+    app.note_issue_nav_max_scroll(max_scroll);
+    app.set_issue_nav_scroll(scroll);
+    let items: Vec<ListItem> = rows
+        .into_iter()
+        .skip(scroll)
+        .take(viewport)
+        .map(|row| {
+            let selected = row.cursor == Some(app.issue_cursor);
+            selectable_row(p, row.spans, width, selected.then(|| p.cursor_bg(true)))
+        })
+        .collect();
+    frame.render_widget(List::new(items), inner);
+}
+
+struct IssueNavRow {
+    spans: Vec<Span<'static>>,
+    cursor: Option<usize>,
+}
+
+fn issue_nav_rows(app: &App, width: usize, now: std::time::SystemTime) -> Vec<IssueNavRow> {
+    let Some(s) = app.issue_snapshot() else {
+        return Vec::new();
+    };
+    let p = app.palette();
+    s.issues
+        .iter()
+        .enumerate()
+        .map(|(index, issue)| IssueNavRow {
+            spans: issue_row(issue, width, now, p),
+            cursor: Some(index),
+        })
+        .collect()
+}
+
+fn issue_row(
+    issue: &crate::issue::Issue,
+    width: usize,
+    now: std::time::SystemTime,
+    p: &Palette,
+) -> Vec<Span<'static>> {
+    let number = format!("#{} ", issue.number);
+    let age = forge::relative_age(&issue.updated_at, now);
+    let state_glyph = match issue.state {
+        crate::issue::IssueState::Open => ("●", p.green),
+        crate::issue::IssueState::Closed => ("○", p.overlay0),
+    };
+    let trailing = if age.is_empty() {
+        String::new()
+    } else {
+        format!("  {age}")
+    };
+    let budget = width
+        .saturating_sub(2 + number.width() + trailing.width())
+        .max(1);
+    let title = elide_head(&issue.title, budget);
+    vec![
+        Span::styled(format!("{} ", state_glyph.0), Style::default().fg(state_glyph.1)),
+        Span::styled(number, Style::default().fg(p.yellow)),
+        Span::styled(title, text_style(p)),
+        Span::styled(trailing, Style::default().fg(p.overlay0)),
+    ]
+}
+
+fn settle_issue_nav_scroll(
+    rows: &[IssueNavRow],
+    cursor: usize,
+    viewport: usize,
+    current: usize,
+    reveal: bool,
+) -> (usize, usize) {
+    let max = rows.len().saturating_sub(viewport);
+    let mut scroll = current.min(max);
+    if reveal && let Some(target) = rows.iter().position(|row| row.cursor == Some(cursor)) {
+        if target < scroll {
+            scroll = target;
+        } else if target >= scroll.saturating_add(viewport) {
+            scroll = target.saturating_add(1).saturating_sub(viewport);
+        }
+    }
+    (scroll.min(max), max)
+}
+
+/// Issue read pane: selected body as markdown, or empty/degraded message.
+fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
+    let p = app.palette();
+    let title = match app.issue_selected() {
+        Some(issue) => format!("#{} · @{}", issue.number, issue.author),
+        None => "Issue".to_string(),
+    };
+    let block = bordered(&title, app.focus == Focus::Diff, p);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let width = inner.width as usize;
+    let notice_lines = app
+        .issue_notice()
+        .map(|notice| wrap_text(notice, width.max(1)))
+        .unwrap_or_default();
+    let notice_capacity = match inner.height {
+        0 => 0,
+        1 => 1,
+        height => height - 1,
+    } as usize;
+    let notice_lines = if notice_lines.len() <= notice_capacity {
+        notice_lines
+    } else if notice_capacity == 0 {
+        Vec::new()
+    } else if notice_capacity == 1 {
+        notice_lines.into_iter().rev().take(1).collect()
+    } else {
+        let tail = notice_lines.len() - (notice_capacity - 1);
+        std::iter::once(notice_lines[0].clone())
+            .chain(notice_lines.into_iter().skip(tail))
+            .collect()
+    };
+    let notice_height = notice_lines.len() as u16;
+    if notice_height > 0 {
+        let notice_area = Rect::new(inner.x, inner.y, inner.width, notice_height);
+        frame.render_widget(
+            Paragraph::new(
+                notice_lines
+                    .into_iter()
+                    .map(|line| Line::from(Span::styled(line, Style::default().fg(p.yellow))))
+                    .collect::<Vec<_>>(),
+            ),
+            notice_area,
+        );
+    }
+    let body = Rect::new(
+        inner.x,
+        inner.y.saturating_add(notice_height),
+        inner.width,
+        inner.height.saturating_sub(notice_height),
+    );
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut body_meta: Option<(usize, crate::markdown::Rendered)> = None;
+    if let Some(issue) = app.issue_selected() {
+        if !issue.labels.is_empty() {
+            let labels = issue.labels.join(", ");
+            lines.push(Line::from(Span::styled(
+                format!("labels: {labels}"),
+                Style::default().fg(p.overlay0),
+            )));
+            lines.push(Line::raw(""));
+        }
+        let text = if issue.body.trim().is_empty() {
+            "_No description._"
+        } else {
+            issue.body.as_str()
+        };
+        let mut rendered = app.markdown_render(text, width.max(1));
+        let offset = lines.len();
+        lines.append(&mut rendered.lines);
+        body_meta = Some((offset, rendered));
+    } else {
+        let refresh = app.keymap().hint(crate::keymap::Action::Refresh);
+        for piece in wrap_text(&issue_empty_msg(&app.issue, app.issue_filter, refresh), width.max(1))
+        {
+            lines.push(Line::from(Span::styled(piece, Style::default().fg(p.overlay0))));
+        }
+    }
+    let max = lines.len().saturating_sub(body.height as usize);
+    app.note_pr_read_max_scroll(max);
+    let scroll = app.issue_read_scroll.min(max);
+    if let Some((offset, rendered)) = &body_meta {
+        note_markdown_regions(app, rendered, body, scroll, *offset);
+    }
+    frame.render_widget(Paragraph::new(lines).scroll((saturating_row(scroll), 0)), body);
+    render_overflow_scrollbar(
+        frame,
+        Rect::new(area.x, body.y, area.width, body.height),
+        max,
+        scroll,
+        p,
+    );
+}
+
+fn issue_empty_msg(
+    view: &crate::issue::IssueView,
+    filter: crate::issue::IssueFilter,
+    refresh: crate::keymap::Key,
+) -> String {
+    if let Some(message) = view.retry_remedy(refresh) {
+        return message;
+    }
+    match view {
+        crate::issue::IssueView::Loading => "loading…".into(),
+        crate::issue::IssueView::Pending | crate::issue::IssueView::List(_) => {
+            format!("No {} issues.", filter.label())
+        }
+        crate::issue::IssueView::NeedsForgeRemote => {
+            "The Issue tab needs a GitHub remote named upstream or origin.".into()
+        }
+        crate::issue::IssueView::NeedsGitHub => {
+            "Issues are GitHub-only for now. Open a GitHub repository, or use the PR tab on this forge."
+                .into()
+        }
+        crate::issue::IssueView::UnsupportedHost(host) => {
+            format!(
+                "Unsupported host: {host}. Self-hosted GitHub? Set `github_host` in the plugin config."
+            )
+        }
+        crate::issue::IssueView::MalformedOrigin(host) => {
+            format!("The origin remote must point to a repository path on {host}.")
+        }
+        crate::issue::IssueView::NoCli
+        | crate::issue::IssueView::NotAuthed(_)
+        | crate::issue::IssueView::GitError(_)
+        | crate::issue::IssueView::Error(_) => unreachable!("retry failures returned above"),
+    }
+}
+
+/// Cursor-row index for an issue navigator click.
+#[must_use]
+pub fn issue_nav_hit(area: Rect, app: &App, col: u16, row: u16) -> Option<usize> {
+    let inner = inner_rect(panes(area, app).files);
+    if !contains(inner, col, row) {
+        return None;
+    }
+    let rows = issue_nav_rows(app, inner.width as usize, std::time::SystemTime::now());
+    let scroll = app.issue_nav_scroll();
+    rows.get((row - inner.y) as usize + scroll)?.cursor
 }
 
 /// The cursor-row index a click at `(col, row)` lands on — the pinned description at the

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3180,41 +3180,193 @@ pub fn hit_issue_chip(area: Rect, app: &App, col: u16, row: u16) -> Option<Issue
     None
 }
 
-/// Issue navigator: newest-list order from `gh` (updatedAt desc by default).
+/// Whether the Issue navigator splits into issues | comments side-by-side: only when the
+/// body navigator is stacked (top/bottom) and the selected issue has comments
+/// (specs/issue-tab.md).
+fn issue_nav_side_by_side(app: &App) -> bool {
+    app.navigator_position.stacked() && app.issue_has_detail()
+}
+
+/// Issue navigator: issues alone, or issues + detail (`description` + comments). On a
+/// stacked body layout with comments, the detail pane sits to the right at half width.
 fn render_issue_nav(frame: &mut Frame, app: &App, area: Rect) {
+    if issue_nav_side_by_side(app) {
+        let half = split_axis(area.width, 50);
+        let issues = Rect::new(area.x, area.y, half, area.height);
+        let detail = Rect::new(area.x + half, area.y, area.width - half, area.height);
+        render_issue_list_panel(frame, app, issues, app.focus == Focus::Files && !app.issue_detail_focused());
+        render_issue_detail_panel(
+            frame,
+            app,
+            detail,
+            app.focus == Focus::Files && app.issue_detail_focused(),
+        );
+    } else {
+        render_issue_nav_combined(frame, app, area);
+    }
+}
+
+/// Single-column navigator (side body layout, or no comments): issues then detail below.
+fn render_issue_nav_combined(frame: &mut Frame, app: &App, area: Rect) {
     let p = app.palette();
     let title = format!("Issues · {}", app.issue_query.nav_title());
-    let block = bordered(&title, app.focus == Focus::Files, p);
+    let focused = app.focus == Focus::Files;
+    let block = bordered(&title, focused, p);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let has_detail = app.issue_has_detail();
+    // Reserve one row for the ←/→ hint when a detail section exists.
+    let hint_h = u16::from(has_detail && inner.height > 0);
+    let list_h = inner.height.saturating_sub(hint_h);
+    let list_area = Rect::new(inner.x, inner.y, inner.width, list_h);
+    let width = list_area.width as usize;
+    let rows = issue_nav_rows_combined(app, width, std::time::SystemTime::now());
+    let focus = issue_nav_focus(app);
+    let viewport = list_area.height as usize;
+    let can_reveal = viewport > 0 && rows.iter().any(|row| row.hit == Some(focus));
+    let reveal = can_reveal && app.take_issue_nav_reveal();
+    let (scroll, max_scroll) =
+        settle_issue_nav_scroll(&rows, focus, viewport, app.issue_nav_scroll(), reveal);
+    app.note_issue_nav_max_scroll(max_scroll);
+    app.set_issue_nav_scroll(scroll);
+    paint_issue_nav_list(frame, app, list_area, &rows, scroll, viewport, focus);
+    if hint_h > 0 {
+        let hint_area = Rect::new(inner.x, inner.y + list_h, inner.width, 1);
+        frame.render_widget(Paragraph::new(issue_detail_hint_line(app)), hint_area);
+    }
+}
+
+fn render_issue_list_panel(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
+    let p = app.palette();
+    let title = format!("Issues · {}", app.issue_query.nav_title());
+    let block = bordered(&title, focused, p);
     let inner = block.inner(area);
     frame.render_widget(block, area);
     let width = inner.width as usize;
-    let rows = issue_nav_rows(app, width, std::time::SystemTime::now());
+    let rows = issue_list_rows(app, width, std::time::SystemTime::now());
+    let focus = IssueNavHit::Issue(app.issue_cursor);
     let viewport = inner.height as usize;
-    let can_reveal =
-        viewport > 0 && rows.iter().any(|row| row.cursor == Some(app.issue_cursor));
+    let can_reveal = viewport > 0 && !app.issue_detail_focused();
     let reveal = can_reveal && app.take_issue_nav_reveal();
     let (scroll, max_scroll) =
-        settle_issue_nav_scroll(&rows, app.issue_cursor, viewport, app.issue_nav_scroll(), reveal);
+        settle_issue_nav_scroll(&rows, focus, viewport, app.issue_nav_scroll(), reveal);
     app.note_issue_nav_max_scroll(max_scroll);
     app.set_issue_nav_scroll(scroll);
+    paint_issue_nav_list(frame, app, inner, &rows, scroll, viewport, issue_nav_focus(app));
+}
+
+fn render_issue_detail_panel(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
+    let p = app.palette();
+    let n = app.issue_selected_comment_count();
+    let title = format!("comments · {n}");
+    let block = bordered(&title, focused, p);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.height == 0 {
+        return;
+    }
+    // Last row is the ←/→ hint; list uses the rest.
+    let hint_h = 1u16.min(inner.height);
+    let list_h = inner.height.saturating_sub(hint_h);
+    let list_area = Rect::new(inner.x, inner.y, inner.width, list_h);
+    let width = list_area.width as usize;
+    let rows = issue_detail_rows(app, width, std::time::SystemTime::now());
+    let focus = issue_nav_focus(app);
+    let viewport = list_area.height as usize;
+    let can_reveal = viewport > 0
+        && app.issue_detail_focused()
+        && rows.iter().any(|row| row.hit == Some(focus));
+    // Only consume the reveal flag when this pane owns focus; the issues panel may have
+    // already taken it when focus is on the list.
+    let reveal = can_reveal && app.take_issue_nav_reveal();
+    let (scroll, max_scroll) =
+        settle_issue_nav_scroll(&rows, focus, viewport, app.issue_detail_nav_scroll(), reveal);
+    app.note_issue_detail_nav_max_scroll(max_scroll);
+    app.set_issue_detail_nav_scroll(scroll);
+    paint_issue_nav_list(frame, app, list_area, &rows, scroll, viewport, focus);
+    let hint_area = Rect::new(inner.x, inner.y + list_h, inner.width, hint_h);
+    frame.render_widget(Paragraph::new(issue_detail_hint_line(app)), hint_area);
+}
+
+fn paint_issue_nav_list(
+    frame: &mut Frame,
+    app: &App,
+    area: Rect,
+    rows: &[IssueNavRow],
+    scroll: usize,
+    viewport: usize,
+    focus: IssueNavHit,
+) {
+    let p = app.palette();
+    let width = area.width as usize;
+    let detail_focused = app.issue_detail_focused();
     let items: Vec<ListItem> = rows
-        .into_iter()
+        .iter()
         .skip(scroll)
         .take(viewport)
         .map(|row| {
-            let selected = row.cursor == Some(app.issue_cursor);
-            selectable_row(p, row.spans, width, selected.then(|| p.cursor_bg(true)))
+            let fill = match row.hit {
+                Some(IssueNavHit::Issue(i)) if i == app.issue_cursor => {
+                    if detail_focused {
+                        Some(p.surface2)
+                    } else {
+                        Some(p.cursor_bg(true))
+                    }
+                }
+                Some(hit) if detail_focused && hit == focus => Some(p.cursor_bg(true)),
+                _ => None,
+            };
+            selectable_row(p, row.spans.clone(), width, fill)
         })
         .collect();
-    frame.render_widget(List::new(items), inner);
+    frame.render_widget(List::new(items), area);
+}
+
+/// Bottom-of-detail hint: `← issues · → comments`, with the inert direction dimmed.
+fn issue_detail_hint_line(app: &App) -> Line<'static> {
+    let p = app.palette();
+    let active = Style::default().fg(p.subtext0);
+    let inert = Style::default().fg(p.overlay0);
+    let in_detail = app.issue_detail_focused();
+    let has = app.issue_has_detail();
+    // `←` acts only in detail; `→` only from the list when comments exist.
+    let left = if in_detail { active } else { inert };
+    let right = if !in_detail && has { active } else { inert };
+    Line::from(vec![
+        Span::raw(" "),
+        Span::styled("←", left),
+        Span::styled(" issues", left),
+        Span::styled(" · ", inert),
+        Span::styled("→", right),
+        Span::styled(" comments", right),
+    ])
+}
+
+/// A clickable target in the Issue navigator.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IssueNavHit {
+    Issue(usize),
+    /// Pinned description row of the selected issue (detail index 0).
+    Description,
+    /// Comment `i` of the selected issue (detail index `1 + i`).
+    Comment(usize),
 }
 
 struct IssueNavRow {
     spans: Vec<Span<'static>>,
-    cursor: Option<usize>,
+    hit: Option<IssueNavHit>,
 }
 
-fn issue_nav_rows(app: &App, width: usize, now: std::time::SystemTime) -> Vec<IssueNavRow> {
+/// Where keyboard/reveal focus sits: issue list, description, or a comment.
+fn issue_nav_focus(app: &App) -> IssueNavHit {
+    match app.issue_detail_cursor {
+        None => IssueNavHit::Issue(app.issue_cursor),
+        Some(0) => IssueNavHit::Description,
+        Some(n) => IssueNavHit::Comment(n - 1),
+    }
+}
+
+fn issue_list_rows(app: &App, width: usize, now: std::time::SystemTime) -> Vec<IssueNavRow> {
     let Some(s) = app.issue_snapshot() else {
         return Vec::new();
     };
@@ -3225,9 +3377,82 @@ fn issue_nav_rows(app: &App, width: usize, now: std::time::SystemTime) -> Vec<Is
         .enumerate()
         .map(|(index, issue)| IssueNavRow {
             spans: issue_row(issue, width, now, p, &present),
-            cursor: Some(index),
+            hit: Some(IssueNavHit::Issue(index)),
         })
         .collect()
+}
+
+/// Detail rows only: `description` then comments (no section header — the panel title carries it).
+fn issue_detail_rows(app: &App, width: usize, now: std::time::SystemTime) -> Vec<IssueNavRow> {
+    let Some(issue) = app.issue_selected() else {
+        return Vec::new();
+    };
+    if issue.comments.is_empty() {
+        return Vec::new();
+    }
+    let p = app.palette();
+    let mut rows = Vec::with_capacity(1 + issue.comments.len());
+    rows.push(IssueNavRow {
+        spans: vec![Span::styled("description", text_style(p))],
+        hit: Some(IssueNavHit::Description),
+    });
+    for (index, comment) in issue.comments.iter().enumerate() {
+        rows.push(IssueNavRow {
+            spans: issue_comment_row(comment, width, now, p),
+            hit: Some(IssueNavHit::Comment(index)),
+        });
+    }
+    rows
+}
+
+/// Combined single-column rows: issues, then optional detail section with a header.
+fn issue_nav_rows_combined(app: &App, width: usize, now: std::time::SystemTime) -> Vec<IssueNavRow> {
+    let p = app.palette();
+    let dim = Style::default().fg(p.overlay0);
+    let mut rows = issue_list_rows(app, width, now);
+    if let Some(issue) = app.issue_selected()
+        && !issue.comments.is_empty()
+    {
+        rows.push(IssueNavRow { spans: Vec::new(), hit: None });
+        rows.push(IssueNavRow {
+            spans: vec![Span::styled(
+                format!("comments · {}", issue.comments.len()),
+                dim,
+            )],
+            hit: None,
+        });
+        rows.extend(issue_detail_rows(app, width, now));
+    }
+    rows
+}
+
+/// One issue-comment row: `@author` then a trailing age.
+fn issue_comment_row(
+    cm: &crate::issue::IssueComment,
+    width: usize,
+    now: std::time::SystemTime,
+    p: &Palette,
+) -> Vec<Span<'static>> {
+    let author_color = if cm.author_is_bot { p.overlay1 } else { p.peach };
+    let age = forge::relative_age(&cm.created_at, now);
+    let author = format!("@{} ", cm.author);
+    // Keep a short body preview when there is room after author + age.
+    let budget = width.saturating_sub(author.width() + age.width() + 3).max(1);
+    let preview = first_line_preview(&cm.body, budget);
+    let mut spans = vec![Span::styled(author, Style::default().fg(author_color))];
+    if !preview.is_empty() {
+        spans.push(Span::styled(preview, text_style(p)));
+    }
+    if !age.is_empty() {
+        spans.push(Span::styled(format!("  {age}"), Style::default().fg(p.overlay0)));
+    }
+    spans
+}
+
+/// First non-empty line of a comment body, clipped to `budget` display columns.
+fn first_line_preview(body: &str, budget: usize) -> String {
+    let line = body.lines().find(|l| !l.trim().is_empty()).unwrap_or("").trim();
+    truncate_width(line, budget)
 }
 
 fn issue_row(
@@ -3241,9 +3466,10 @@ fn issue_row(
     let indent = "  ".repeat(issue.tree_depth(present));
     let number = format!("#{} ", issue.number);
     let age = forge::relative_age(&issue.updated_at, now);
-    let state_glyph = match issue.state {
-        crate::issue::IssueState::Open => ("●", p.green),
-        crate::issue::IssueState::Closed => ("○", p.overlay0),
+    // Open keeps the accent `#n` color; closed recedes to a secondary dim (specs/issue-tab.md).
+    let number_color = match issue.state {
+        crate::issue::IssueState::Open => p.yellow,
+        crate::issue::IssueState::Closed => p.overlay0,
     };
     // Parent progress from subIssuesSummary, e.g. ` 1/3`, when the issue has children.
     let progress = if issue.sub_total > 0 {
@@ -3257,16 +3483,15 @@ fn issue_row(
         (true, false) => format!("  {age}"),
         (false, false) => format!("{progress}  {age}"),
     };
-    let fixed = indent.width() + 2 + number.width() + trailing.width();
+    let fixed = indent.width() + number.width() + trailing.width();
     let budget = width.saturating_sub(fixed).max(1);
     // Titles prefer the leading words (unlike file paths, which elide the head).
     let title = truncate_width(&issue.title, budget);
-    let mut spans = Vec::with_capacity(5);
+    let mut spans = Vec::with_capacity(4);
     if !indent.is_empty() {
         spans.push(Span::raw(indent));
     }
-    spans.push(Span::styled(format!("{} ", state_glyph.0), Style::default().fg(state_glyph.1)));
-    spans.push(Span::styled(number, Style::default().fg(p.yellow)));
+    spans.push(Span::styled(number, Style::default().fg(number_color)));
     spans.push(Span::styled(title, text_style(p)));
     if !trailing.is_empty() {
         spans.push(Span::styled(trailing, Style::default().fg(p.overlay0)));
@@ -3276,14 +3501,14 @@ fn issue_row(
 
 fn settle_issue_nav_scroll(
     rows: &[IssueNavRow],
-    cursor: usize,
+    selected: IssueNavHit,
     viewport: usize,
     current: usize,
     reveal: bool,
 ) -> (usize, usize) {
     let max = rows.len().saturating_sub(viewport);
     let mut scroll = current.min(max);
-    if reveal && let Some(target) = rows.iter().position(|row| row.cursor == Some(cursor)) {
+    if reveal && let Some(target) = rows.iter().position(|row| row.hit == Some(selected)) {
         if target < scroll {
             scroll = target;
         } else if target >= scroll.saturating_add(viewport) {
@@ -3293,12 +3518,16 @@ fn settle_issue_nav_scroll(
     (scroll.min(max), max)
 }
 
-/// Issue read pane: selected body as markdown, or empty/degraded message.
+/// Issue read pane: selected issue body or comment as markdown, or empty/degraded message.
 fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
     let p = app.palette();
-    let title = match app.issue_selected() {
-        Some(issue) => format!("#{} · @{}", issue.number, issue.author),
-        None => "Issue".to_string(),
+    let title = if let Some(cm) = app.issue_selected_comment() {
+        format!("@{} · comment", cm.author)
+    } else {
+        match app.issue_selected() {
+            Some(issue) => format!("#{} · @{}", issue.number, issue.author),
+            None => "Issue".to_string(),
+        }
     };
     let block = bordered(&title, app.focus == Focus::Diff, p);
     let inner = block.inner(area);
@@ -3346,7 +3575,17 @@ fn render_issue_read(frame: &mut Frame, app: &App, area: Rect) {
     );
     let mut lines: Vec<Line<'static>> = Vec::new();
     let mut body_meta: Option<(usize, crate::markdown::Rendered)> = None;
-    if let Some(issue) = app.issue_selected() {
+    if let Some(cm) = app.issue_selected_comment() {
+        let text = if cm.body.trim().is_empty() {
+            "_No comment body._"
+        } else {
+            cm.body.as_str()
+        };
+        let mut rendered = app.markdown_render(text, width.max(1));
+        let offset = lines.len();
+        lines.append(&mut rendered.lines);
+        body_meta = Some((offset, rendered));
+    } else if let Some(issue) = app.issue_selected() {
         // Full title as H1 style — the navigator may truncate it (specs/issue-tab.md).
         // Styled manually (not via markdown) so characters like `#`/`*` in titles stay literal.
         let h1 = Style::default().fg(p.mauve).add_modifier(Modifier::BOLD);
@@ -3442,16 +3681,83 @@ fn issue_empty_msg(
     }
 }
 
-/// Cursor-row index for an issue navigator click.
+/// Which half of a side-by-side Issue navigator the pointer is over.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IssueNavPane {
+    Issues,
+    Detail,
+}
+
+/// Navigator geometry for hit-testing and wheel routing (matches paint).
+fn issue_nav_geometry(area: Rect, app: &App) -> (Rect, Option<Rect>) {
+    let files = panes(area, app).files;
+    if issue_nav_side_by_side(app) {
+        let half = split_axis(files.width, 50);
+        let issues = Rect::new(files.x, files.y, half, files.height);
+        let detail = Rect::new(files.x + half, files.y, files.width - half, files.height);
+        (issues, Some(detail))
+    } else {
+        (files, None)
+    }
+}
+
+/// Which Issue navigator sub-pane contains `(col, row)`, if any.
 #[must_use]
-pub fn issue_nav_hit(area: Rect, app: &App, col: u16, row: u16) -> Option<usize> {
-    let inner = inner_rect(panes(area, app).files);
+pub fn issue_nav_pane_at(area: Rect, app: &App, col: u16, row: u16) -> Option<IssueNavPane> {
+    let (issues, detail) = issue_nav_geometry(area, app);
+    if let Some(detail) = detail {
+        if contains(detail, col, row) {
+            return Some(IssueNavPane::Detail);
+        }
+        if contains(issues, col, row) {
+            return Some(IssueNavPane::Issues);
+        }
+        return None;
+    }
+    contains(issues, col, row).then_some(IssueNavPane::Issues)
+}
+
+/// Navigator hit for an issue or comment click (specs/issue-tab.md).
+#[must_use]
+pub fn issue_nav_hit(area: Rect, app: &App, col: u16, row: u16) -> Option<IssueNavHit> {
+    let (issues_area, detail_area) = issue_nav_geometry(area, app);
+    if let Some(detail_area) = detail_area {
+        // Side-by-side: hit-test each bordered panel's list region (exclude the hint row).
+        if contains(detail_area, col, row) {
+            let inner = inner_rect(detail_area);
+            if !contains(inner, col, row) || inner.height == 0 {
+                return None;
+            }
+            let list_h = inner.height.saturating_sub(1);
+            if row >= inner.y + list_h {
+                return None; // hint row
+            }
+            let rows =
+                issue_detail_rows(app, inner.width as usize, std::time::SystemTime::now());
+            let scroll = app.issue_detail_nav_scroll();
+            return rows.get((row - inner.y) as usize + scroll)?.hit;
+        }
+        let inner = inner_rect(issues_area);
+        if !contains(inner, col, row) {
+            return None;
+        }
+        let rows = issue_list_rows(app, inner.width as usize, std::time::SystemTime::now());
+        let scroll = app.issue_nav_scroll();
+        return rows.get((row - inner.y) as usize + scroll)?.hit;
+    }
+    // Combined column: one list, optional bottom hint row.
+    let inner = inner_rect(issues_area);
     if !contains(inner, col, row) {
         return None;
     }
-    let rows = issue_nav_rows(app, inner.width as usize, std::time::SystemTime::now());
+    let hint_h = u16::from(app.issue_has_detail() && inner.height > 0);
+    let list_h = inner.height.saturating_sub(hint_h);
+    if row >= inner.y + list_h {
+        return None;
+    }
+    let rows = issue_nav_rows_combined(app, inner.width as usize, std::time::SystemTime::now());
     let scroll = app.issue_nav_scroll();
-    rows.get((row - inner.y) as usize + scroll)?.cursor
+    rows.get((row - inner.y) as usize + scroll)?.hit
 }
 
 /// The cursor-row index a click at `(col, row)` lands on — the pinned description at the

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3201,7 +3201,8 @@ fn issue_row(
     let budget = width
         .saturating_sub(2 + number.width() + trailing.width())
         .max(1);
-    let title = elide_head(&issue.title, budget);
+    // Titles prefer the leading words (unlike file paths, which elide the head).
+    let title = truncate_width(&issue.title, budget);
     vec![
         Span::styled(format!("{} ", state_glyph.0), Style::default().fg(state_glyph.1)),
         Span::styled(number, Style::default().fg(p.yellow)),

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2825,17 +2825,14 @@ fn issue_tab_shows_filter_chip_and_empty_state() {
     assert!(out.contains("Fix the pane"), "issue title in list and read pane:\n{out}");
     // Read-pane title is H1-styled (bold mauve); presence is enough — style is unit-covered in markdown.
     assert!(out.contains("labels: bug"), "labels in read pane:\n{out}");
-    assert!(
-        !out.contains("comments ·"),
-        "no comments section when the issue has none:\n{out}"
-    );
+    assert!(!out.contains("comments ·"), "no comments section when the issue has none:\n{out}");
     assert!(out.contains("i open") || out.contains("open"), "state filter in footer:\n{out}");
+    assert!(out.contains("a all") || out.contains("a mine"), "assignee filter in footer:\n{out}");
     assert!(
-        out.contains("a all") || out.contains("a mine"),
-        "assignee filter in footer:\n{out}"
-    );
-    assert!(
-        out.contains("L any") || out.contains("L p0") || out.contains("L p1") || out.contains("L p2"),
+        out.contains("L any")
+            || out.contains("L p0")
+            || out.contains("L p1")
+            || out.contains("L p2"),
         "priority filter in footer:\n{out}"
     );
 }
@@ -3017,10 +3014,7 @@ fn issue_nav_shows_comments_for_selected_issue() {
     app.issue_select(0);
     app.issue_enter_detail();
     assert!(app.issue_detail_focused(), "→ enters detail when comments exist");
-    assert!(
-        app.issue_showing_description(),
-        "detail lands on description first"
-    );
+    assert!(app.issue_showing_description(), "detail lands on description first");
     let on_desc = dump(&render_size(&app, 100, 24));
     assert!(on_desc.contains("Issue body"), "description still shows the issue body:\n{on_desc}");
 
@@ -3089,7 +3083,10 @@ fn issue_nav_side_by_side_on_stacked_layout() {
     assert!(out.contains("description"), "description row in detail panel:\n{out}");
     assert!(out.contains("@bob"), "comment row visible beside issues:\n{out}");
     assert!(
-        out.contains("←") && out.contains("→") && out.contains("issues") && out.contains("comments"),
+        out.contains("←")
+            && out.contains("→")
+            && out.contains("issues")
+            && out.contains("comments"),
         "detail hint shows left/right affordances:\n{out}"
     );
 }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2875,3 +2875,57 @@ fn issue_list_prefers_title_head_when_narrow() {
     assert!(nav.contains('…'), "clipped title marks the cut with a trailing ellipsis:\n{nav}");
 }
 
+#[test]
+fn issue_list_indents_sub_issues_under_parent() {
+    use herdr_reviewr::app::Tab;
+    use herdr_reviewr::issue::{Issue, IssueQuery, IssueSnapshot, IssueState, IssueView};
+    let r = Repo::init();
+    r.write("x.rs", "y\n");
+    r.commit_all("init");
+    let mut app = app_on(&r);
+    app.set_tab(Tab::Issue).unwrap();
+    // Tree order already applied by fetch; paint with parent first, child second.
+    app.issue = IssueView::List(IssueSnapshot {
+        query: IssueQuery::default(),
+        issues: vec![
+            Issue {
+                number: 10,
+                title: "Parent epic".into(),
+                body: String::new(),
+                state: IssueState::Open,
+                author: "alice".into(),
+                updated_at: "2026-08-01T12:00:00Z".into(),
+                url: "https://github.com/o/r/issues/10".into(),
+                labels: vec![],
+                parent_number: None,
+                sub_completed: 1,
+                sub_total: 2,
+            },
+            Issue {
+                number: 12,
+                title: "Child task".into(),
+                body: String::new(),
+                state: IssueState::Open,
+                author: "alice".into(),
+                updated_at: "2026-08-01T12:00:00Z".into(),
+                url: "https://github.com/o/r/issues/12".into(),
+                labels: vec![],
+                parent_number: Some(10),
+                sub_completed: 0,
+                sub_total: 0,
+            },
+        ],
+        truncated: false,
+    });
+    let nav = right_column(&dump(&render_size(&app, 100, 20)), 60);
+    assert!(nav.contains("1/2"), "parent shows sub-issue progress:\n{nav}");
+    // Child row is indented (leading spaces before ● on the child line).
+    let child_line = nav
+        .lines()
+        .find(|l| l.contains("#12") && l.contains("Child"))
+        .unwrap_or_else(|| panic!("child row present:\n{nav}"));
+    assert!(
+        child_line.trim_start() != child_line && child_line.contains('●'),
+        "child row is indented:\n{child_line}"
+    );
+}

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2792,14 +2792,14 @@ fn a_click_on_a_picker_row_moves_the_highlight_and_misses_stay_inert() {
 #[test]
 fn issue_tab_shows_filter_chip_and_empty_state() {
     use herdr_reviewr::app::Tab;
-    use herdr_reviewr::issue::{Issue, IssueFilter, IssueSnapshot, IssueState, IssueView};
+    use herdr_reviewr::issue::{Issue, IssueQuery, IssueSnapshot, IssueState, IssueView};
     let r = Repo::init();
     r.write("x.rs", "y\n");
     r.commit_all("init");
     let mut app = app_on(&r);
     app.set_tab(Tab::Issue).unwrap();
     app.issue = IssueView::List(IssueSnapshot {
-        filter: IssueFilter::Open,
+        query: IssueQuery::default(),
         issues: vec![Issue {
             number: 42,
             title: "Fix the pane".into(),
@@ -2814,11 +2814,21 @@ fn issue_tab_shows_filter_chip_and_empty_state() {
     });
     let out = render(&app);
     assert!(out.contains("4 Issue"), "tab label:\n{out}");
-    assert!(out.contains("[open]"), "filter chip:\n{out}");
+    assert!(out.contains("[open]"), "state chip:\n{out}");
+    assert!(out.contains("[all]"), "assignee chip:\n{out}");
+    assert!(out.contains("[any]"), "priority chip:\n{out}");
     assert!(out.contains("#42"), "issue number:\n{out}");
     assert!(out.contains("Fix the pane"), "issue title in list:\n{out}");
     assert!(out.contains("labels: bug"), "labels in read pane:\n{out}");
-    assert!(out.contains("i open") || out.contains("open"), "filter action in footer:\n{out}");
+    assert!(out.contains("i open") || out.contains("open"), "state filter in footer:\n{out}");
+    assert!(
+        out.contains("a all") || out.contains("a mine"),
+        "assignee filter in footer:\n{out}"
+    );
+    assert!(
+        out.contains("L any") || out.contains("L p0") || out.contains("L p1") || out.contains("L p2"),
+        "priority filter in footer:\n{out}"
+    );
 }
 
 #[test]
@@ -2826,7 +2836,7 @@ fn issue_list_prefers_title_head_when_narrow() {
     // Issue titles are prose: keep the leading words and trail with `…`, never path-style
     // head elision that would show only the unreadable tail.
     use herdr_reviewr::app::Tab;
-    use herdr_reviewr::issue::{Issue, IssueFilter, IssueSnapshot, IssueState, IssueView};
+    use herdr_reviewr::issue::{Issue, IssueQuery, IssueSnapshot, IssueState, IssueView};
     let r = Repo::init();
     r.write("x.rs", "y\n");
     r.commit_all("init");
@@ -2836,7 +2846,7 @@ fn issue_list_prefers_title_head_when_narrow() {
     let head = "HEADKEEP";
     let tail = "UNIQUETAILMARKERXYZZY";
     app.issue = IssueView::List(IssueSnapshot {
-        filter: IssueFilter::Open,
+        query: IssueQuery::default(),
         issues: vec![Issue {
             number: 1,
             title: format!(

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2809,6 +2809,9 @@ fn issue_tab_shows_filter_chip_and_empty_state() {
             updated_at: "2026-08-01T12:00:00Z".into(),
             url: "https://github.com/o/r/issues/42".into(),
             labels: vec!["bug".into()],
+            parent_number: None,
+            sub_completed: 0,
+            sub_total: 0,
         }],
         truncated: false,
     });
@@ -2859,6 +2862,9 @@ fn issue_list_prefers_title_head_when_narrow() {
             updated_at: "2026-08-01T12:00:00Z".into(),
             url: "https://github.com/o/r/issues/1".into(),
             labels: vec![],
+            parent_number: None,
+            sub_completed: 0,
+            sub_total: 0,
         }],
         truncated: false,
     });
@@ -2868,3 +2874,4 @@ fn issue_list_prefers_title_head_when_narrow() {
     assert!(!nav.contains(tail), "title tail must elide, not crowd the head:\n{nav}");
     assert!(nav.contains('…'), "clipped title marks the cut with a trailing ellipsis:\n{nav}");
 }
+

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2818,7 +2818,8 @@ fn issue_tab_shows_filter_chip_and_empty_state() {
     assert!(out.contains("[all]"), "assignee chip:\n{out}");
     assert!(out.contains("[any]"), "priority chip:\n{out}");
     assert!(out.contains("#42"), "issue number:\n{out}");
-    assert!(out.contains("Fix the pane"), "issue title in list:\n{out}");
+    assert!(out.contains("Fix the pane"), "issue title in list and read pane:\n{out}");
+    // Read-pane title is H1-styled (bold mauve); presence is enough — style is unit-covered in markdown.
     assert!(out.contains("labels: bug"), "labels in read pane:\n{out}");
     assert!(out.contains("i open") || out.contains("open"), "state filter in footer:\n{out}");
     assert!(

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -427,10 +427,10 @@ fn the_header_totals_the_scope_and_hides_them_at_zero() {
     r.write("untracked.rs", "one\ntwo\n");
     let app = app_on(&r);
 
-    // 64 columns is the exact fit (the tab strip ends in the two-column reserved
-    // indicator cell). The totals' `−` is multi-byte, so this breaks if the header
-    // measures bytes instead of display width.
-    let header = render_at(&app, 64).lines().next().unwrap().to_string();
+    // 73 columns is the exact fit with four tabs (the strip ends in the two-column
+    // reserved indicator cell). The totals' `−` is multi-byte, so this breaks if the
+    // header measures bytes instead of display width.
+    let header = render_at(&app, 73).lines().next().unwrap().to_string();
     assert!(header.contains("2 changed  +3 −1"), "count, then the totals:\n{header}");
 
     let clean = Repo::init();
@@ -731,8 +731,9 @@ fn pr_header_names_the_resolved_branch_and_marks_a_fork() {
     let header = render(&app).lines().next().unwrap().to_string();
     assert!(header.contains("⑂ persiyanov/feature"), "fork head is marked:\n{header}");
     // Narrow bars drop the branch first; the chip's number stays.
+    // Width accounts for the four-tab strip (`4 Issue` adds columns vs the old three-tab bar).
     app.pr = snap(false);
-    let narrow = render_at(&app, 46).lines().next().unwrap().to_string();
+    let narrow = render_at(&app, 55).lines().next().unwrap().to_string();
     assert!(!narrow.contains("persiyanov/feature"), "branch drops when narrow:\n{narrow}");
     assert!(narrow.contains("#226"), "the chip survives a narrow bar:\n{narrow}");
 
@@ -1311,7 +1312,7 @@ fn header_hits_use_the_frame_keymap_not_the_live_one() {
     use herdr_reviewr::keymap::default_keymap;
     // The live keymap has a wide tab-changes hint, shifting every span right by one column.
     let app = rebound_app("tab-changes = [\"ㅊ\"]\n");
-    for tab in [Tab::Changes, Tab::AllFiles, Tab::Pr] {
+    for tab in [Tab::Changes, Tab::AllFiles, Tab::Pr, Tab::Issue] {
         assert_ne!(
             tab_hit_cols(&app, default_keymap(), tab),
             tab_hit_cols(&app, app.keymap(), tab),
@@ -1331,9 +1332,12 @@ fn header_tab_hits_align_with_wide_hint_keys() {
     let row0 = out.lines().next().unwrap().to_string();
     let col_of = |needle: &str| row0[..row0.find(needle).unwrap()].chars().count() as u16;
     let area = Rect::new(0, 0, 140, 40);
-    for (needle, tab) in
-        [("Changes", Tab::Changes), ("2 All files", Tab::AllFiles), ("3 PR", Tab::Pr)]
-    {
+    for (needle, tab) in [
+        ("Changes", Tab::Changes),
+        ("2 All files", Tab::AllFiles),
+        ("3 PR", Tab::Pr),
+        ("4 Issue", Tab::Issue),
+    ] {
         assert_eq!(
             ui::hit_header(area, &app, app.keymap(), col_of(needle), 0),
             Some(HeaderHit::Tab(tab)),
@@ -2783,4 +2787,36 @@ fn a_click_on_a_picker_row_moves_the_highlight_and_misses_stay_inert() {
     )
     .unwrap();
     assert_eq!(app.picker_cursor, 2, "a click moves the highlight to the clicked row");
+}
+
+#[test]
+fn issue_tab_shows_filter_chip_and_empty_state() {
+    use herdr_reviewr::app::Tab;
+    use herdr_reviewr::issue::{Issue, IssueFilter, IssueSnapshot, IssueState, IssueView};
+    let r = Repo::init();
+    r.write("x.rs", "y\n");
+    r.commit_all("init");
+    let mut app = app_on(&r);
+    app.set_tab(Tab::Issue).unwrap();
+    app.issue = IssueView::List(IssueSnapshot {
+        filter: IssueFilter::Open,
+        issues: vec![Issue {
+            number: 42,
+            title: "Fix the pane".into(),
+            body: "Hello **world**".into(),
+            state: IssueState::Open,
+            author: "alice".into(),
+            updated_at: "2026-08-01T12:00:00Z".into(),
+            url: "https://github.com/o/r/issues/42".into(),
+            labels: vec!["bug".into()],
+        }],
+        truncated: false,
+    });
+    let out = render(&app);
+    assert!(out.contains("4 Issue"), "tab label:\n{out}");
+    assert!(out.contains("[open]"), "filter chip:\n{out}");
+    assert!(out.contains("#42"), "issue number:\n{out}");
+    assert!(out.contains("Fix the pane"), "issue title in list:\n{out}");
+    assert!(out.contains("labels: bug"), "labels in read pane:\n{out}");
+    assert!(out.contains("i open") || out.contains("open"), "filter action in footer:\n{out}");
 }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2820,3 +2820,40 @@ fn issue_tab_shows_filter_chip_and_empty_state() {
     assert!(out.contains("labels: bug"), "labels in read pane:\n{out}");
     assert!(out.contains("i open") || out.contains("open"), "filter action in footer:\n{out}");
 }
+
+#[test]
+fn issue_list_prefers_title_head_when_narrow() {
+    // Issue titles are prose: keep the leading words and trail with `…`, never path-style
+    // head elision that would show only the unreadable tail.
+    use herdr_reviewr::app::Tab;
+    use herdr_reviewr::issue::{Issue, IssueFilter, IssueSnapshot, IssueState, IssueView};
+    let r = Repo::init();
+    r.write("x.rs", "y\n");
+    r.commit_all("init");
+    let mut app = app_on(&r);
+    app.set_tab(Tab::Issue).unwrap();
+    // Short head token still fits after `#n ` and the age; long unique tail must not.
+    let head = "HEADKEEP";
+    let tail = "UNIQUETAILMARKERXYZZY";
+    app.issue = IssueView::List(IssueSnapshot {
+        filter: IssueFilter::Open,
+        issues: vec![Issue {
+            number: 1,
+            title: format!(
+                "{head} middle filler words that pad the row past the navigator width {tail}"
+            ),
+            body: String::new(),
+            state: IssueState::Open,
+            author: "alice".into(),
+            updated_at: "2026-08-01T12:00:00Z".into(),
+            url: "https://github.com/o/r/issues/1".into(),
+            labels: vec![],
+        }],
+        truncated: false,
+    });
+    // Default navigator is the right ~32%; take its column so the read pane cannot false-positive.
+    let nav = right_column(&dump(&render_size(&app, 90, 20)), 65);
+    assert!(nav.contains(head), "title head must stay visible:\n{nav}");
+    assert!(!nav.contains(tail), "title tail must elide, not crowd the head:\n{nav}");
+    assert!(nav.contains('…'), "clipped title marks the cut with a trailing ellipsis:\n{nav}");
+}

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2812,6 +2812,7 @@ fn issue_tab_shows_filter_chip_and_empty_state() {
             parent_number: None,
             sub_completed: 0,
             sub_total: 0,
+            comments: vec![],
         }],
         truncated: false,
     });
@@ -2824,6 +2825,10 @@ fn issue_tab_shows_filter_chip_and_empty_state() {
     assert!(out.contains("Fix the pane"), "issue title in list and read pane:\n{out}");
     // Read-pane title is H1-styled (bold mauve); presence is enough — style is unit-covered in markdown.
     assert!(out.contains("labels: bug"), "labels in read pane:\n{out}");
+    assert!(
+        !out.contains("comments ·"),
+        "no comments section when the issue has none:\n{out}"
+    );
     assert!(out.contains("i open") || out.contains("open"), "state filter in footer:\n{out}");
     assert!(
         out.contains("a all") || out.contains("a mine"),
@@ -2865,6 +2870,7 @@ fn issue_list_prefers_title_head_when_narrow() {
             parent_number: None,
             sub_completed: 0,
             sub_total: 0,
+            comments: vec![],
         }],
         truncated: false,
     });
@@ -2900,6 +2906,7 @@ fn issue_list_indents_sub_issues_under_parent() {
                 parent_number: None,
                 sub_completed: 1,
                 sub_total: 2,
+                comments: vec![],
             },
             Issue {
                 number: 12,
@@ -2913,19 +2920,176 @@ fn issue_list_indents_sub_issues_under_parent() {
                 parent_number: Some(10),
                 sub_completed: 0,
                 sub_total: 0,
+                comments: vec![],
             },
         ],
         truncated: false,
     });
     let nav = right_column(&dump(&render_size(&app, 100, 20)), 60);
     assert!(nav.contains("1/2"), "parent shows sub-issue progress:\n{nav}");
-    // Child row is indented (leading spaces before ● on the child line).
+    // Child row is indented (leading spaces before `#12` on the child line).
     let child_line = nav
         .lines()
         .find(|l| l.contains("#12") && l.contains("Child"))
         .unwrap_or_else(|| panic!("child row present:\n{nav}"));
     assert!(
-        child_line.trim_start() != child_line && child_line.contains('●'),
+        child_line.trim_start() != child_line && child_line.contains("#12"),
         "child row is indented:\n{child_line}"
+    );
+}
+
+#[test]
+fn issue_nav_shows_comments_for_selected_issue() {
+    use herdr_reviewr::app::Tab;
+    use herdr_reviewr::issue::{
+        Issue, IssueComment, IssueQuery, IssueSnapshot, IssueState, IssueView,
+    };
+    let r = Repo::init();
+    r.write("x.rs", "y\n");
+    r.commit_all("init");
+    let mut app = app_on(&r);
+    app.set_tab(Tab::Issue).unwrap();
+    app.issue = IssueView::List(IssueSnapshot {
+        query: IssueQuery::default(),
+        issues: vec![
+            Issue {
+                number: 1,
+                title: "With comments".into(),
+                body: "Issue body".into(),
+                state: IssueState::Open,
+                author: "alice".into(),
+                updated_at: "2026-08-01T12:00:00Z".into(),
+                url: "https://github.com/o/r/issues/1".into(),
+                labels: vec![],
+                parent_number: None,
+                sub_completed: 0,
+                sub_total: 0,
+                comments: vec![
+                    IssueComment {
+                        author: "bob".into(),
+                        author_is_bot: false,
+                        body: "Newest comment body text".into(),
+                        created_at: "2026-08-02T12:00:00Z".into(),
+                        url: "https://github.com/o/r/issues/1#issuecomment-2".into(),
+                    },
+                    IssueComment {
+                        author: "carol".into(),
+                        author_is_bot: false,
+                        body: "Older comment".into(),
+                        created_at: "2026-08-01T12:00:00Z".into(),
+                        url: "https://github.com/o/r/issues/1#issuecomment-1".into(),
+                    },
+                ],
+            },
+            Issue {
+                number: 2,
+                title: "No comments".into(),
+                body: "Other body".into(),
+                state: IssueState::Open,
+                author: "alice".into(),
+                updated_at: "2026-08-01T12:00:00Z".into(),
+                url: "https://github.com/o/r/issues/2".into(),
+                labels: vec![],
+                parent_number: None,
+                sub_completed: 0,
+                sub_total: 0,
+                comments: vec![],
+            },
+        ],
+        truncated: false,
+    });
+    let nav = right_column(&dump(&render_size(&app, 100, 24)), 55);
+    assert!(nav.contains("comments · 2"), "comments header for selected issue:\n{nav}");
+    assert!(nav.contains("description"), "description row leads the detail section:\n{nav}");
+    assert!(nav.contains("@bob"), "comment author in nav:\n{nav}");
+    assert!(nav.contains("@carol"), "second comment author:\n{nav}");
+
+    // Selecting the second issue (no comments) hides the section.
+    app.issue_select(1);
+    let nav2 = right_column(&dump(&render_size(&app, 100, 24)), 55);
+    assert!(
+        !nav2.contains("comments ·"),
+        "comments section omitted when selected issue has none:\n{nav2}"
+    );
+    assert!(!nav2.contains("description"), "no description row without comments:\n{nav2}");
+
+    // Right-arrow enters detail on description; j moves to the first comment.
+    app.issue_select(0);
+    app.issue_enter_detail();
+    assert!(app.issue_detail_focused(), "→ enters detail when comments exist");
+    assert!(
+        app.issue_showing_description(),
+        "detail lands on description first"
+    );
+    let on_desc = dump(&render_size(&app, 100, 24));
+    assert!(on_desc.contains("Issue body"), "description still shows the issue body:\n{on_desc}");
+
+    app.issue_move(1);
+    let out = dump(&render_size(&app, 100, 24));
+    assert!(out.contains("Newest comment body text"), "comment body in read pane:\n{out}");
+    assert!(out.contains("@bob · comment"), "comment title in read pane:\n{out}");
+
+    // Left-arrow returns to the issue list; issue body is shown again.
+    app.issue_exit_detail();
+    assert!(!app.issue_detail_focused());
+    let back = dump(&render_size(&app, 100, 24));
+    assert!(back.contains("Issue body"), "← restores the issue description:\n{back}");
+
+    // → is inert when the issue has no comments.
+    app.issue_select(1);
+    app.issue_enter_detail();
+    assert!(!app.issue_detail_focused(), "→ does nothing without comments");
+}
+
+#[test]
+fn issue_nav_side_by_side_on_stacked_layout() {
+    use herdr_reviewr::app::Tab;
+    use herdr_reviewr::config::NavigatorPosition;
+    use herdr_reviewr::issue::{
+        Issue, IssueComment, IssueQuery, IssueSnapshot, IssueState, IssueView,
+    };
+    let r = Repo::init();
+    r.write("x.rs", "y\n");
+    r.commit_all("init");
+    let mut app = app_on(&r);
+    app.set_tab(Tab::Issue).unwrap();
+    app.navigator_position = NavigatorPosition::Bottom;
+    // Stacked default share is short; grow it so the half-width detail panel can show
+    // description + a comment + the hint row.
+    for _ in 0..8 {
+        app.resize_navigator(4);
+    }
+    app.issue = IssueView::List(IssueSnapshot {
+        query: IssueQuery::default(),
+        issues: vec![Issue {
+            number: 1,
+            title: "With comments".into(),
+            body: "Issue body".into(),
+            state: IssueState::Open,
+            author: "alice".into(),
+            updated_at: "2026-08-01T12:00:00Z".into(),
+            url: "https://github.com/o/r/issues/1".into(),
+            labels: vec![],
+            parent_number: None,
+            sub_completed: 0,
+            sub_total: 0,
+            comments: vec![IssueComment {
+                author: "bob".into(),
+                author_is_bot: false,
+                body: "A thread note".into(),
+                created_at: "2026-08-02T12:00:00Z".into(),
+                url: "https://github.com/o/r/issues/1#issuecomment-2".into(),
+            }],
+        }],
+        truncated: false,
+    });
+    // Wide enough for a half-width comments panel.
+    let out = dump(&render_size(&app, 120, 24));
+    assert!(out.contains("comments · 1"), "detail panel title:\n{out}");
+    assert!(out.contains("description"), "description row in detail panel:\n{out}");
+    assert!(out.contains("@bob"), "comment row visible beside issues:\n{out}");
+    assert!(
+        out.contains("←") && out.contains("→") && out.contains("issues") && out.contains("comments"),
+        "detail hint shows left/right affordances:\n{out}"
     );
 }


### PR DESCRIPTION
## Summary

Adds a fourth tab, **Issue**, that mirrors open (default) GitHub issues for the current repository through `gh`, next to Changes / All files / PR. Read-only: list, filter, open in browser, read body and thread comments — no write/edit/close.

Also scopes `toggle` / `open` / `close` to the current herdr tab when `HERDR_TAB_ID` is set, so each tab can keep its own reviewr instance.

## Issue tab

- **Tab `4 Issue`** (rebindable as `tab-issue`).
- **Filters** (orthogonal, one composed `gh issue list`):
  - `i` — open → closed → all
  - `a` — all assignees → mine (`--assignee @me`)
  - `L` — any → p0 → p1 → p2 (`--label`)
- **Navigator**: `#n title` with open/closed on the `#n` color; parent/sub-issues nest (one level, indent + `done/total` when both appear in the list). Titles keep the head when they clip.
- **Detail** when the selected issue has comments: pinned **description** then comments (newest first). `→` enters detail, `←` / `esc` returns to the issue list; `j`/`k` stay in the active zone. The selected issue stays highlighted.
- **Stacked navigator** (`top`/`bottom`): issues | comments side-by-side at half width, with a bottom hint `← issues · → comments`.
- **Cache**: successful lists keyed by full query, **1 minute** TTL; ambient refresh skips `gh` while fresh; `r` always refetches.
- **Degradation**: missing `gh`, auth, non-GitHub forge, etc., with clear remedies.
- **Non-goals**: writing comments, multi-forge issues, arbitrary label pickers.

## Per-tab reviewr panes

When `HERDR_TAB_ID` is set and `toggle_placement` is not `tab`, `toggle` / `open` / `close` only manage reviewr panes in the current herdr tab. `placement = tab` and `auto_open` stay workspace-scoped.

- Script: `herdr/pane.sh`
- Local fork note: `LOCAL-PATCH.md` (documents the patch path for linked checkouts)

## Specs / docs

- New contract: `specs/issue-tab.md` (wired from overview / input / tui).
- README controls table; `CHANGELOG.md` under `[Unreleased]`.

## Tests

- Unit coverage in `src/issue.rs` (parse, filters, tree order).
- Render coverage in `tests/render.rs` (chips, title clip, nesting, comments, stacked side-by-side).
- `just ci` green (fmt, clippy `-D warnings`, tests, release build).

## Notes for reviewers

- Issue identity and fetch follow the same repository probe as the PR tab (`forge::fetch_input`).
- Priority uses `L` so it does not take `l` (comments list on other tabs).
- No upstream issue to close; this is a net-new surface (plus the pane scoping patch).
- CONTRIBUTING prefers one concern per PR — happy to split Issue tab vs per-tab pane if you prefer.

## Test plan

- [x] `just ci`
- [x] Open Issue tab on a GitHub repo with open issues; filter `i` / `a` / `L`; `r` refreshes
- [x] Select an issue with comments: `→` → description → `j` through comments → `←` back
- [x] `p` to bottom/top layout: comments pane appears beside the issue list
- [ ] Non-GitHub remote / missing `gh`: empty-state remedy
- [x] `o` opens the selected issue URL
- [x] With two herdr tabs and `HERDR_TAB_ID` set: toggle open in each; close in one tab leaves the other open