### PR TITLE
feat: run the reviewr pane on bohay too 

### DIFF
--- a/bohay-module.toml
+++ b/bohay-module.toml
@@ -1,0 +1,68 @@
+id = "persiyanov.reviewr"
+name = "reviewr"
+version = "0.29.0"
+min_bohay_version = "0.9.6"
+platforms = ["macos", "linux"]
+description = "Review agent-written diffs beside the chat and add line comments to the agent input."
+
+# ── Settings (Settings → Modules → reviewr) ──────────────────────────────────
+# Delivered to the pane/actions as BOHAY_SETTING_<KEY>, so the shell never parses JSON.
+
+[[settings]]
+key = "placement"
+title = "Where the toggle opens the pane"
+type = "enum"
+options = ["split", "tab", "overlay"]
+default = "split"
+
+[[settings]]
+key = "auto_open"
+title = "Open a reviewr pane for each new workspace"
+type = "bool"
+default = false
+
+# ── Build ────────────────────────────────────────────────────────────────────
+# On `bohay module install`, download the prebuilt `herdr-reviewr` binary for this
+# platform from the matching GitHub Release into $BOHAY_MODULE_ROOT/bin (no Rust
+# toolchain needed). `bohay module link` skips the build step; for a local checkout,
+# build it yourself with `cargo build --release` (or `cargo install --path .`) and
+# copy the binary to ./bin/herdr-reviewr.
+
+[[build]]
+command = ["bash", "bohay/install.sh"]
+
+# ── The review pane ──────────────────────────────────────────────────────────
+# A module pane runs its argv in the module root, so we cd to the focused
+# workspace's cwd (the repo under review) before exec. The binary reviews its cwd.
+
+[[panes]]
+id = "pane"
+title = "reviewr"
+placement = "split"
+command = ["sh", "-c", "cd \"${BOHAY_WORKSPACE_CWD:-$PWD}\" 2>/dev/null; exec \"$BOHAY_MODULE_ROOT/bin/herdr-reviewr\""]
+
+# ── Right-click a pane or workspace → toggle / open / close the pane ──────────
+
+[[actions]]
+id = "toggle"
+title = "reviewr: toggle pane"
+contexts = ["pane", "workspace"]
+command = ["bash", "bohay/pane.sh", "toggle"]
+
+[[actions]]
+id = "open"
+title = "reviewr: open pane"
+contexts = ["pane", "workspace"]
+command = ["bash", "bohay/pane.sh", "open"]
+
+[[actions]]
+id = "close"
+title = "reviewr: close pane"
+contexts = ["pane", "workspace"]
+command = ["bash", "bohay/pane.sh", "close"]
+
+# ── Auto-open for a freshly created workspace (gated by the auto_open setting) ─
+
+[[events]]
+on = "workspace.created"
+command = ["bash", "bohay/pane.sh", "auto-open"]

--- a/bohay/install.sh
+++ b/bohay/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# bohay `[[build]]` step: download the prebuilt herdr-reviewr binary for this platform from
+# the matching GitHub Release into the module's bin/ dir. Runs on `bohay module install` (a
+# managed checkout); `bohay module link` skips the build step, so for a local checkout build
+# from source with `cargo build --release` and copy target/release/herdr-reviewr to ./bin/.
+#
+# The build runs with the module checkout as the working directory, so we resolve the module
+# root from this script's location rather than $BOHAY_MODULE_ROOT (build commands may not
+# receive the runtime env). At runtime the pane command reads $BOHAY_MODULE_ROOT/bin/herdr-reviewr.
+set -euo pipefail
+
+NAME="herdr-reviewr"
+REPO="persiyanov/herdr-reviewr"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN_DIR="$ROOT/bin"
+
+# The release tag matches the manifest version, so a checkout always pulls its own release.
+VERSION="$(grep -m1 '^version' "$ROOT/bohay-module.toml" | sed -E 's/.*"([^"]+)".*/\1/')"
+TAG="v${VERSION}"
+
+# Map the running platform to the release target triple.
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os-$arch" in
+  Darwin-arm64)                target="aarch64-apple-darwin" ;;
+  Darwin-x86_64)               target="x86_64-apple-darwin" ;;
+  Linux-aarch64 | Linux-arm64) target="aarch64-unknown-linux-musl" ;;
+  Linux-x86_64)                target="x86_64-unknown-linux-musl" ;;
+  *)
+    echo "$NAME: no prebuilt binary for $os-$arch, build from source with 'cargo build --release'" >&2
+    exit 1
+    ;;
+esac
+
+archive="${NAME}-${target}.tar.gz"
+# taiki-e's checksum sidecar drops the archive extension: <name>-<target>.sha256, not <archive>.sha256.
+checksum="${NAME}-${target}.sha256"
+base="https://github.com/${REPO}/releases/download/${TAG}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Release-asset downloads are eventually-consistent: GitHub's CDN can 404 for a few minutes
+# after a release publishes. Retry (incl. on 404) so an install right after a release doesn't
+# fail spuriously.
+dl() { curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors --retry-connrefused "$1" -o "$2"; }
+
+echo "$NAME: downloading $archive ($TAG)"
+dl "$base/$archive" "$tmp/$archive"
+dl "$base/$checksum" "$tmp/$checksum"
+
+echo "$NAME: verifying checksum"
+expected="$(awk '{print $1}' "$tmp/$checksum")"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/$archive" | awk '{print $1}')"
+else
+  actual="$(shasum -a 256 "$tmp/$archive" | awk '{print $1}')"
+fi
+if [ "$expected" != "$actual" ]; then
+  echo "$NAME: checksum mismatch (expected $expected, got $actual)" >&2
+  exit 1
+fi
+
+mkdir -p "$BIN_DIR"
+tar -xzf "$tmp/$archive" -C "$tmp"
+install -m 0755 "$tmp/$NAME" "$BIN_DIR/$NAME"
+echo "$NAME: installed $BIN_DIR/$NAME"

--- a/bohay/pane.sh
+++ b/bohay/pane.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# The reviewr pane actions and event hook for bohay.
+#
+#   pane.sh toggle      open a reviewr pane, or close every one if any is open
+#   pane.sh open        open a reviewr pane, no-op if one is open
+#   pane.sh close       close every reviewr pane, no-op if none
+#   pane.sh auto-open   workspace.created hook: open, gated by the auto_open setting
+#
+# A reviewr pane is any pane bohay opened for this module's `pane` entrypoint, read
+# from `bohay pane list` (each pane carries its {module.id, module.entrypoint}).
+# That is exact, so there is no process inspection here. Actions report successes on
+# stdout and refuse on stderr with a non-zero exit.
+set -uo pipefail
+
+# bohay runs module commands with a minimal PATH; ensure jq/git/bohay resolve.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+mode="${1:-toggle}"
+B="${BOHAY_BIN_PATH:-bohay}"
+MODULE_ID="${BOHAY_MODULE_ID:-persiyanov.reviewr}"
+ENTRYPOINT="pane"
+PLACEMENT="${BOHAY_SETTING_PLACEMENT:-split}"
+
+refuse() {
+  printf 'reviewr: %s\n' "$1" >&2
+  exit 1
+}
+
+# The workspace's open reviewr panes, one pane id per line. A failed or unreadable
+# listing must not read as "nothing open" (that would stack a duplicate on toggle and
+# false-succeed a close), so an unparseable list refuses.
+list_reviewr() {
+  local out
+  out=$("$B" pane list 2>/dev/null) || refuse "bohay pane list failed"
+  printf '%s' "$out" | jq -e '.result.panes' >/dev/null 2>&1 || refuse "bohay pane list unreadable"
+  printf '%s' "$out" | jq -r --arg id "$MODULE_ID" --arg ep "$ENTRYPOINT" \
+    '.result.panes[] | select(.module.id == $id and .module.entrypoint == $ep) | .pane' 2>/dev/null
+}
+
+open_pane() {
+  "$B" module pane open "$MODULE_ID" "$ENTRYPOINT" --placement "$PLACEMENT" >/dev/null 2>&1 ||
+    refuse "bohay module pane open failed"
+  printf 'opened reviewr (%s)\n' "$PLACEMENT"
+}
+
+close_all() {
+  local closed=""
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    "$B" pane close "$p" >/dev/null 2>&1 && closed="$closed $p"
+  done <<EOF
+$1
+EOF
+  printf 'closed%s\n' "${closed:- nothing}"
+}
+
+case "$mode" in
+open)
+  existing="$(list_reviewr)"
+  [ -n "$existing" ] && { printf 'open: already open\n'; exit 0; }
+  open_pane
+  ;;
+close)
+  existing="$(list_reviewr)"
+  [ -n "$existing" ] || { printf 'close: nothing open\n'; exit 0; }
+  close_all "$existing"
+  ;;
+toggle)
+  existing="$(list_reviewr)"
+  if [ -n "$existing" ]; then
+    close_all "$existing"
+  else
+    open_pane
+  fi
+  ;;
+auto-open)
+  # Opt-in only, and never a second pane.
+  [ "${BOHAY_SETTING_AUTO_OPEN:-false}" = "true" ] || exit 0
+  existing="$(list_reviewr)"
+  [ -n "$existing" ] && exit 0
+  open_pane
+  ;;
+*)
+  refuse "unknown mode '$mode' (toggle | open | close | auto-open)"
+  ;;
+esac


### PR DESCRIPTION
## What

reviewr already runs as a herdr plugin. This adds **bohay** ([bohay.dev](https://bohay.dev), a mission control for ai coding agents and terminal multiplexer with a module system) as a second host, so the same binary opens as a review pane there too. It is purely additive: no Rust changes, `herdr-plugin.toml` and the herdr path are untouched, and CI is unaffected.

## How it works

Parallel to the herdr integration, packaged the bohay way:

- `bohay-module.toml` - the module manifest: the `pane` entrypoint, `toggle` / `open` / `close` actions (right-click a pane or workspace), a `workspace.created` event, a `[[build]]` step, and two settings (`placement`, `auto_open`).
- `bohay/install.sh` - the build step: downloads the same prebuilt release binary into `bin/` (git-ignored), mirroring `herdr/install.sh`.
- `bohay/pane.sh` - the actions + event hook over bohay's socket API. It finds open reviewr panes from `bohay pane list` (each pane carries its `{module.id, module.entrypoint}`, so no process inspection is needed) and drives `bohay module pane open` / `bohay pane close`.

Two host differences from herdr, handled in the manifest/script: a bohay module pane starts in the module root, so the pane command `cd`s to `$BOHAY_WORKSPACE_CWD` (the repo under review) before exec, where herdr passed `--cwd` and bohay emits `workspace.created`, mapped to the herdr `worktree.created` auto-open hook.

## Using it on bohay

**Install** (clones and downloads the prebuilt binary, no Rust toolchain):

    bohay module install persiyanov/herdr-reviewr

For a local checkout, `bohay module link path/to/herdr-reviewr` registers the folder `link` skips the build step, so build the binary yourself (`cargo build --release && cp target/release/herdr-reviewr bin/`) or run `bash bohay/install.sh`.

**Open a pane** from any bohay pane via the CLI:

    bohay module pane open persiyanov.reviewr pane                 # split beside the focused pane
    bohay module pane open persiyanov.reviewr pane --placement tab # or a full tab / overlay

or right-click a pane or a workspace in the sidebar and pick **reviewr: open pane** (`toggle` and `close` are there too toggle opens a pane or closes every reviewr pane).

**Inside the pane**, every reviewr key works as documented in the README: tabs `1` `2` `3`, scopes `u` `b` `t`, `v` / `c` / `s` to select, comment, and send, `?` for the live key list, `q` to close. Placement (split / tab / overlay) is the `placement` setting.

**Inside a workspace**, the pane reviews the focused workspace's folder (`$BOHAY_WORKSPACE_CWD`), so open reviewr from the node whose repo you want to read. bohay worktrees are first-class nodes, so opening reviewr inside a worktree node reviews just that worktree's diff, the same one-pane-per-worktree model as herdr. Turn on `auto_open` for a reviewr pane on every new workspace or worktree. Settings live in Settings > Modules > reviewr.

## What is not covered (yet)

The review UI is fully functional on bohay: Changes / All files / PR tabs, scopes, search, find-in-file, markdown preview, themes. **Send-to-agent and last-turn / turn tracking are herdr-CLI-specific** (`src/herdr.rs`, via `$HERDR_BIN_PATH`) on bohay they degrade gracefully (Send reports no agents, it never crashes). A bohay backend for those would be a small, separate follow-up behind the same host seam, happy to do it if you want it in scope.

## Testing

Against a bohay server (its `pane.list` / `module.pane.open` / `pane.close` API):

- manifest validates and links (`bohay module link` -> `runnable: true`)
- the build step downloads and checksum-verifies the binary
- the pane opens and renders the real repo diff (Changes tab, `[uncommitted]` scope, Files panel)
- `open` no-ops when open, `toggle` closes then reopens, `close` is idempotent.


<img width="5304" height="3014" alt="Screenshot 2026-08-07 at 23 10 28" src="https://github.com/user-attachments/assets/9bdd8089-6b1e-4e90-80ae-46804f09d0ca" />
