### PR TITLE
Pick the base branch, and always show it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ herdr-reviewr is a Rust TUI (ratatui) code-review pane: it runs in a [herdr](htt
 
 Load-bearing invariants (specs/overview.md). Cite them by name, never by position in the table:
 
-- **No writes**: reviewr never mutates the worktree, index, or branches. Its only git write is the private baseline ref under `refs/reviewr/`.
+- **No writes**: reviewr never mutates the worktree, index, or branches. Its only git writes are private refs under `refs/reviewr/`: the turn baseline and the base pick.
 - **Comments survive**: comments are never lost to a refresh or the agent's edits, and leave only by explicit export. The comment store is in-memory **by design** — do not propose persisting it.
 - **Continuity**: place state (cursor, scroll, tab, scope, folds, selection, layout) moves only under the user's own input. World events (polls, refreshes, fetch results) may only *reconcile* it: match by identity first (path, comment author+anchor — never row index), fall back to the nearest surviving target, clamp last. Derived state on screen may be stale, never wrong: blank a view only when its identity changed, never because the same thing gained newer content.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Pick the base branch.** `B` opens a picker on the `branch` scope, and so does a click on the
+  base name in the header. Rows are every local and origin branch by recent commit, the open PR's
+  target starred first and the default branch marked `default`. Type to filter, `enter` picks. The
+  choice is remembered per repository, so a repo whose trunk is `dev` stops diffing against `main`.
+- **The header names the base.** The `branch` scope reads `vs dev`, so what the diff compares
+  against is always on screen. A recorded choice whose branch is gone reads `vs main · dev missing`,
+  and a repo where nothing resolves reads `no base`.
+
+### Changed
+- **The base branch resolves through one chain.** `--base`, then your pick, then `origin/HEAD`,
+  and no guessing anywhere in it. A repo with no `origin/HEAD` and no pick shows `no base` and
+  invites a pick instead of silently comparing against `main`.
+- **`base_branches` is retired.** The key no longer exists, and a config still carrying it fails
+  to load like any other unknown key. Drop the key and press `B` to choose a base instead.
+- **The `All files` tab is now `Files`,** and the changed-file count and line totals sit at the
+  right of the header. The header's `Send` button is gone — send with the `send` key or from the
+  comments list.
+
 ## [0.29.0] — 2026-08-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.30.0] — 2026-08-08
+
 ### Added
-- **Pick the base branch.** `B` opens a picker on the `branch` scope, and so does a click on the
-  base name in the header. Rows are every local and origin branch by recent commit, the open PR's
-  target starred first and the default branch marked `default`. Type to filter, `enter` picks. The
-  choice is remembered per repository, so a repo whose trunk is `dev` stops diffing against `main`.
-- **The header names the base.** The `branch` scope reads `vs dev`, so what the diff compares
-  against is always on screen. A recorded choice whose branch is gone reads `vs main · dev missing`,
-  and a repo where nothing resolves reads `no base`.
+- **Base picker.** `B`, or a click on the base name, picks the branch the `branch` scope diffs against, remembered per repository.
+- **The header names the base.** `vs dev` while it resolves, `vs main · dev missing` when a pick stops resolving, `no base` when nothing does.
 
 ### Changed
-- **The base branch resolves through one chain.** `--base`, then your pick, then `origin/HEAD`,
-  and no guessing anywhere in it. A repo with no `origin/HEAD` and no pick shows `no base` and
-  invites a pick instead of silently comparing against `main`.
-- **`base_branches` is retired.** The key no longer exists, and a config still carrying it fails
-  to load like any other unknown key. Drop the key and press `B` to choose a base instead.
-- **The `All files` tab is now `Files`,** and the changed-file count and line totals sit at the
-  right of the header. The header's `Send` button is gone — send with the `send` key or from the
-  comments list.
+- **One resolution chain.** `--base`, then your pick, then `origin/HEAD`, and no guessing anywhere in it.
+- **`base_branches` is retired.** A config still carrying the key fails to load. Drop it and press `B` instead.
+- **The `All files` tab reads `Files`,** the header stats moved to the right, and the header `Send` button is gone.
 
 ## [0.29.0] — 2026-08-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "herdr-reviewr"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-reviewr"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2024"
 rust-version = "1.97"
 description = "A terminal review pane for herdr: browse an agent's changes and send comments back to chat."

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ One persistent pane, pointed at a git worktree:
 - **Markdown preview** — flip a `.md` file between source and rendered view.
 - **Themes** — 18 palettes in dark and light.
 
-It never edits your worktree and sends nothing on its own. Its only git write is a private
-baseline ref under `refs/reviewr/`. The **PR** tab reads GitHub, GitLab, or Azure DevOps and
-never posts.
+It never edits your worktree and sends nothing on its own. Its only git writes are private
+refs under `refs/reviewr/`: the turn baseline and the base pick. The **PR** tab reads GitHub,
+GitLab, or Azure DevOps and never posts.
 
 ## Requirements
 
@@ -106,6 +106,7 @@ The keys below are defaults. You can rebind every action, even to several keys a
 | --- | --- |
 | `1` `2` `3` | Switch tab — Changes / All files / PR |
 | `u` `b` `t` | Switch scope — uncommitted / branch / last turn |
+| `B` | Pick the branch scope's base |
 | `j` `k` · `↑` `↓` | Move cursor |
 | `]` `[` | Jump to next / previous hunk |
 | `f` `F` | Jump to next / previous file |
@@ -175,8 +176,8 @@ opens in your browser (`http`/`https` only), and an anchor link jumps to its hea
 
 - **uncommitted** — the working tree vs `HEAD` (staged, unstaged, and untracked).
 - **branch** — the working tree vs the merge-base with the base branch: **uncommitted** plus
-  the branch's commits. Default base `origin/main`, then `origin/master`, `main`, `master`
-  ([Base branch](#base-branch)).
+  the branch's commits. The base is your repo's default branch until you pick another with
+  `B` ([Base branch](#base-branch)).
 - **last turn** — everything that changed in this worktree since its most recent turn started
   ([Limitations](#limitations)).
 
@@ -193,7 +194,7 @@ CLI flags on the pane command:
 | Flag | Default | Meaning |
 | --- | --- | --- |
 | `--poll <ms>` | `2000` | worktree poll interval (min `200`) |
-| `--base <ref>` | auto | base for `branch` scope, any rev, overrides `base_branches` |
+| `--base <ref>` | auto | base for `branch` scope, any rev, overrides the pick |
 | `--theme <name>` | `catppuccin` | UI + syntax theme (see below) |
 | `--wrap <on\|off>` | `on` | soft-wrap long diff lines (`w` toggles at runtime) |
 
@@ -211,7 +212,6 @@ The file accepts these keys:
 
 ```toml
 theme = "tokyo-night"
-base_branches = ["develop", "main", "master"]
 default_scope = "branch"
 navigator_position = "right"
 toggle_placement = "overlay"
@@ -263,16 +263,19 @@ the navigator altogether and brings it back.
 
 ### Base branch
 
-The **branch** scope diffs against the merge-base with the first base candidate that resolves,
-so one setting works across repos with different trunks. Default `main`, then `master`. Each
-checks `origin/<name>` first, then the local branch. For a `develop` trunk:
+The **branch** scope diffs against the merge-base with your repo's default branch, the one
+`origin/HEAD` names. The header shows the resolved base, `vs main`.
 
-```toml
-base_branches = ["develop", "main", "master"]
-```
+When the trunk is something else, or you review a stacked branch, press `B` (or click the
+base name) and pick the branch. The pick is stored in the repo, shared by every reviewr pane
+on it, and holds until you pick again. Choosing the default branch clears it.
 
-`--base <ref>` wins over the list and takes any rev (a branch, a tag, a SHA). When nothing in
-the list resolves, the branch `origin/HEAD` names is the fallback.
+`--base <ref>` pins the base for the pane and takes any rev (a branch, a tag, a SHA). It
+wins over the pick and disables the picker.
+
+A picked branch that is gone (deleted after a stacked review, or a typo) is skipped, and the
+header says so: `vs main · dev missing`. When nothing resolves, the scope stays empty and the
+header reads `no base`, with the footer offering `B pick base`.
 
 ### Keybindings
 
@@ -297,6 +300,7 @@ The action names and their defaults:
 | `next-hunk` / `prev-hunk` | `]` / `[` |
 | `next-file` / `prev-file` | `f` / `F` |
 | `scope-uncommitted` / `scope-branch` / `scope-last-turn` | `u` / `b` / `t` |
+| `base-pick` | `B` |
 | `tab-changes` / `tab-all-files` / `tab-pr` | `1` / `2` / `3` |
 | `wrap` | `w` |
 | `preview` | `m` |

--- a/docs/plans/2026-08-08-base-picker/plan.md
+++ b/docs/plans/2026-08-08-base-picker/plan.md
@@ -1,0 +1,83 @@
+# Base picker: Plan
+
+Delivers `specs/review-model.md#base-branch`, `specs/input.md#base-picker`, and the `specs/tui.md` header contract (issue #42).
+
+## Problem
+
+The `branch` scope diffs against a fixed lookup: `base_branches` config (default `main`, `master`), then `origin/HEAD`. In a repo whose trunk is `dev`, the scope silently diffs against `main`, and the chosen base is never displayed, so the wrong diff reads as broken autodetection (issue #42, danielo515). The same fixed list blocks stacked branches, where the base is another feature branch. A global config list cannot fix it: one repo's convention poisons another.
+
+## Goal
+
+The base is always a visible, recorded choice: the `--base` flag, else a per-repo pick made in a picker and persisted under `refs/reviewr/`, else `origin/HEAD`. The header names it. The same ship lands the header tidy-up already in the tree: the `Files` tab label, the Send button removal, and right-aligned stats.
+
+## Definition of Done
+
+- [ ] On the `branch` scope the header shows `vs <name>`. A name too long for the leftover width clips with a trailing `…`. A click on it opens the picker, same as `B`. It reads `no base` when nothing resolves and `· <name> missing` when a recorded choice is skipped.
+- [ ] `B` (and the header click) opens the picker on file tabs while `branch` is active and no `--base` was passed. Inert elsewhere and while composing.
+- [ ] Picker rows: local and origin branch names merged, checked-out branch excluded, sorted by last commit, the open PR's target first starred, the default branch next marked `default`. Type-to-filter, `↓`/`↑`, `enter` picks, `esc` cancels, clicks per the agent picker.
+- [ ] A pick applies on the next frame, persists across restarts, is shared by the repo's worktrees, and reaches another pane at its next refresh. Picking the default row clears the pick.
+- [ ] A pick whose branch stops resolving is skipped, not dropped, and reactivates when the branch returns.
+- [ ] `base_branches` in a config file now fails the whole file as an unknown key, with the standard recovery.
+- [ ] The header reads ` 1 Changes  2 Files  3 PR  [scope]` with stats right-aligned and no Send button. `s`/`S` still export.
+- [ ] README's flag table, config sample, and Base branch section match the new behavior.
+
+## Out of Scope
+
+- PR-target auto-follow in the resolution chain. Deferred decision in `specs/review-model.md`; see Replan.
+- Renaming the `All files` concept across specs and config names. Only the header label changes; `tab-all-files` stays the config name.
+- Release packaging and version bump. The user cuts releases.
+
+## Execution Plan
+
+1. [ ] Sync the header tidy-up into `specs/tui.md`: mockup, tab label `Files`, Send button bullet removed, stats right-aligned. Grep `specs/` for Send-button click references.
+2. [ ] `src/git.rs`: replace `resolve_bases` with a resolution returning the winning name, OID, and any skipped recorded name. Chain: `--base` → pick ref → `origin/HEAD` (name via `symbolic-ref refs/remotes/origin/HEAD`, today only its OID is taken). Names resolve `refs/remotes/origin/<name>` then `refs/heads/<name>` (`resolve_base_entry`, git.rs:700).
+3. [ ] `src/git.rs`: pick ref read/write under `refs/reviewr/` via `update-ref`, one ref per repository (no `worktree_key` — shared refs are the sharing mechanism). Store the name as a ref'd blob, precedent `snapshot_worktree`'s object writes (git.rs:799).
+4. [ ] `src/git.rs`: new branch-list helper for the picker: `for-each-ref refs/heads refs/remotes/origin --sort=-committerdate`, names merged, `origin/HEAD` and the checked-out branch excluded. None exists today (`origin_tips` is origin-only, unsorted).
+5. [ ] Thread the resolved base into `WorldSnapshot` and `App` so the header paints it and `reconcile_world` carries it. Drop `base_branches` from `WorldInput` (world.rs:29). A pick calls `reload()` so the changeset rebuilds before the next frame.
+6. [ ] `src/config.rs`: delete `base_branches` (field config.rs:176, default :71, accessor :211, key entry :86, validation :371-408, `to_json` :276). The unknown-key path (config.rs:356) is the migration.
+7. [ ] `src/lib.rs`: config-diff sites that watched `base_branches` (lib.rs:1272, 1338) now watch nothing there; a pick change invalidates the PR worker the way a config change did (epoch bump). `src/forge.rs:475` and `pr_local` take the new resolution, so the PR frontier walk and the branch scope share one base.
+8. [ ] Keymap and footer: `Action::BasePick` row (`base-pick`, `B`) in `ACTIONS` (keymap.rs:87), `FooterAction::BasePick`, label arm in `action_key_label` (ui.rs:1404), `footer_bands` early-return row for the open picker, and the `B pick base` primary on an empty branch scope with no base (app.rs:3319).
+9. [ ] `App`: `Mode::BasePick` with rows, highlight, scroll, query, and caret. Open/close/move/pick after the agent picker (app.rs:3461-3513), highlight opening on the current base. Filtering through `active_field`/`edit_input` (app.rs:2545-2574), the way Search's query edits.
+10. [ ] `src/ui.rs`: base span in `render_tab_bar` with truncation, `HeaderHit::Base` in `hit_header`, popup renderer in the mode dispatch (ui.rs:77, scrim is free), row hit-test per `hit_picker_row` (ui.rs:1918).
+11. [ ] `src/lib.rs`: modal key gate for `Mode::BasePick` beside the agent picker's (lib.rs:1486), mouse arms for the popup and the header base click (lib.rs:1786).
+12. [ ] README: flag table (:196), config sample (:214), Base branch section (:268).
+13. [ ] Tests per Verification, in the same commits as the code they check.
+
+## Likely Files
+
+| file                     | change                                                              |
+| ------------------------ | ------------------------------------------------------------------- |
+| `src/git.rs`             | resolution with names, pick ref, branch-list helper                 |
+| `src/config.rs`          | `base_branches` deleted                                             |
+| `src/app.rs`             | `Mode::BasePick`, picker state and verbs, footer rows, reload wire  |
+| `src/world.rs`           | resolved base in `WorldInput`/`WorldSnapshot`                       |
+| `src/lib.rs`             | key/mouse gates, config-diff and epoch sites                        |
+| `src/ui.rs`              | header base span and hit, picker popup                              |
+| `src/forge.rs`           | `pr_local` on the new resolution                                    |
+| `src/keymap.rs`          | `Action::BasePick`                                                  |
+| `specs/tui.md`           | header tidy-up decisions                                            |
+| `README.md`              | base branch and flag docs                                           |
+| `tests/render.rs`        | header hit and paint tests                                          |
+| `tests/app_flow.rs`      | picker flow and persistence tests                                   |
+| `tests/git_repo.rs`      | resolution chain tests                                              |
+| `tests/pr_candidates.rs` | fixtures off `base_branches`                                        |
+
+## Verification
+
+- `cargo test --test render`: rewrite `header_clicks_map_to_scope_and_send` (render.rs:870) and `a_narrow_overflowing_header_does_not_mis_map_a_click_to_send` (:1225) for the base span instead of Send; add paint tests for `vs <name>`, truncation, `no base`, and the `missing` suffix.
+- `cargo test --test app_flow`: open → filter → pick → changeset rebuilt and header renamed; pick ref written and reread after a fresh `App`; default row clears the ref; picker inert under `--base`; `B pick base` footer on the empty no-base scope.
+- `cargo test --test git_repo`: chain order, skip on a missing branch, reactivate on return, `origin/HEAD` fallback, no-default repo.
+- `src/config.rs` tests: `base_branches` cases (config.rs:743-830) become unknown-key expectations; canonicalization test deleted.
+- `src/lib.rs` test `shell_only_config_changes_do_not_invalidate_runtime_work` (lib.rs:2552): fixture moves off `base_branches` to a surviving runtime key; add the pick-change epoch case.
+- No-writes invariant: the persistence test asserts the only new ref is under `refs/reviewr/` and the worktree, index, and branches are untouched.
+- `python3 scripts/bench_tui.py --binary target/release/herdr-reviewr --fixture` A/B against a rebuilt main binary, quiet system: the reload path changed; medians must hold.
+- `just ci` green.
+- QA: `just qa-install`, user reopens panes. The picker-feel trial here feeds the deferred PR-target decision.
+- Tight: everything the diff adds is exercised by a DoD line. Delete or defer the rest.
+- Gate: promote `specs/review-model.md`, `input.md`, `tui.md`, `config.md`, `overview.md` to Current.
+
+## Replan
+
+- If the QA trial says the base should follow an open PR's target automatically, reopen brainstorming on the deferred tier in `specs/review-model.md` before adding it.
+- If blob-backed pick refs prove awkward (gc, inspection), switch to a symbolic ref form; spec text is storage-agnostic.
+- 2026-08-08: initial plan.

--- a/examples/bench_latency.rs
+++ b/examples/bench_latency.rs
@@ -39,21 +39,21 @@ fn main() {
     let label = args.next().unwrap_or_else(|| repo.display().to_string());
     assert!(git::is_repo(&repo), "not a git repo: {}", repo.display());
     let hl = Highlighter::new(theme::resolve(None).syntax);
-    let bases: Vec<String> = vec!["main".into(), "master".into()];
     println!("== {label} ==");
 
     // --- Components of reload() -------------------------------------------------
-    let changed = git::changed_files(&repo, Scope::Uncommitted, None, &bases).unwrap();
+    let changed = git::changed_files(&repo, Scope::Uncommitted, None).unwrap();
     row(
         "changed_files (uncommitted)",
         sample(5, || {
-            git::changed_files(&repo, Scope::Uncommitted, None, &bases).unwrap();
+            git::changed_files(&repo, Scope::Uncommitted, None).unwrap();
         }),
     );
     row(
-        "changed_files (branch)",
+        "changed_files (branch, incl. resolve)",
         sample(5, || {
-            git::changed_files(&repo, Scope::Branch, None, &bases).unwrap();
+            let base = git::resolve_base(&repo, None).ok().and_then(|r| r.winner);
+            git::changed_files(&repo, Scope::Branch, base.map(|w| w.oid).as_deref()).unwrap();
         }),
     );
     let all = git::all_files(&repo).unwrap();
@@ -160,7 +160,7 @@ fn main() {
     row(
         "TAB SWITCH -> All files (reload, no reopen)",
         sample(3, || {
-            git::changed_files(&repo, Scope::Uncommitted, None, &bases).unwrap();
+            git::changed_files(&repo, Scope::Uncommitted, None).unwrap();
             git::all_files(&repo).unwrap();
         }),
     );

--- a/examples/bench_latency.rs
+++ b/examples/bench_latency.rs
@@ -52,7 +52,7 @@ fn main() {
     row(
         "changed_files (branch, incl. resolve)",
         sample(5, || {
-            let base = git::resolve_base(&repo, None).ok().and_then(|r| r.winner);
+            let base = git::resolve_base(&repo, None).ok().and_then(|r| r.status.winner);
             git::changed_files(&repo, Scope::Branch, base.map(|w| w.oid).as_deref()).unwrap();
         }),
     );

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "persiyanov.reviewr"
 name = "reviewr"
-version = "0.29.0"
+version = "0.30.0"
 # Turn tracking resolves each agent's `cwd` from `herdr agent list` to decide worktree
 # membership, and `cwd` is only verified present from 0.7.5 (docs/herdr-api-notes.md). On an
 # older herdr every agent would parse with no `cwd`, and `last turn` would never track.

--- a/policies/ux-responsiveness.md
+++ b/policies/ux-responsiveness.md
@@ -19,3 +19,4 @@ reviewr runs live beside a working agent, so every action must feel instant and 
 
 - A genuinely slow or hung external call (git under a busy agent, `gh`) may show a delayed loading state and, while it is outstanding, wake the loop more often to deliver promptly.
 - A large file or a first-visit diff may pay a one-time inline cost when async prefetch is not warranted; note it rather than building speculative machinery.
+- Opening the base picker reads its branch list inline, measured at ~30ms (`specs/input.md`). This is a deliberate, permanent exception: an async open would either flash an empty list or blank the frame, both of which this policy forbids above.

--- a/specs/config.md
+++ b/specs/config.md
@@ -1,5 +1,5 @@
 ---
-Status: Draft
+Status: Current
 Created: 2026-07-10
 Last edited: 2026-08-08
 ---

--- a/specs/config.md
+++ b/specs/config.md
@@ -1,7 +1,7 @@
 ---
-Status: Current
+Status: Draft
 Created: 2026-07-10
-Last edited: 2026-07-31
+Last edited: 2026-08-08
 ---
 
 # Configuration
@@ -14,7 +14,6 @@ A valid file may set any subset of the supported keys. A missing file and an omi
 
 ```toml
 theme = "tokyo-night"
-base_branches = ["develop", "main", "master"]
 default_scope = "branch"
 navigator_position = "bottom"
 toggle_placement = "overlay"
@@ -33,7 +32,6 @@ find    = ["ctrl+f"]
 | key                  | value                                                                              |
 | -------------------- | ---------------------------------------------------------------------------------- |
 | `theme`              | one name from the theme set in `theme.md`                                          |
-| `base_branches`      | non-empty array of non-empty branch names, `origin/` and `refs/` prefixes accepted |
 | `default_scope`      | `uncommitted`, `branch`, or `last-turn`                                            |
 | `navigator_position` | `right`, `left`, `top`, or `bottom`                                                |
 | `toggle_placement`   | `split`, `overlay`, `zoomed`, or `tab`                                             |
@@ -88,8 +86,6 @@ An error names the config path and the read, syntax, key, or value failure. It s
 An invalid first read blocks the plugin exactly like a later invalid read. A blocked pane keeps rereading the file and answers only the default `quit` key. A valid read clears the error and rebuilds the pane from fresh inputs without a reinstall or restart (`tui.md`).
 
 ## Key semantics
-
-Each `base_branches` entry canonicalizes to one bare branch name: a leading `refs/heads/`, `refs/remotes/origin/`, or `origin/` prefix is stripped. Duplicate entries collapse to the first occurrence. A consumer resolves an entry through `refs/remotes/origin/<name>`, then `refs/heads/<name>` (`review-model.md`). A repository may lack every ref a valid `base_branches` list names. That is runtime absence, never an invalid config.
 
 A hostname is recognized by at most one forge. A host key naming another host key's value, or any forge's built-in host, `*.visualstudio.com` included, is an invalid value (→ CFG-WHOLE-FILE).
 

--- a/specs/forge-host.md
+++ b/specs/forge-host.md
@@ -85,7 +85,7 @@ The tab shows the newest PR opened from the current branch. No branch, or no PR,
 A PR can live under a different branch name than the local one, so reviewr searches by up to three kinds of name:
 
 - the branch's own name,
-- the branch it tracks, unless that is a resolved base branch (tracking `main` is not publishing to it),
+- the branch it tracks, unless that name is a resolved or recorded base (tracking `main` is not publishing to it, and a pick that fails to resolve still names a base),
 - any `origin` branch pointing at this branch's work, so `git push origin HEAD:other-name` still finds the PR. A branch pointing at base history carries no work and does not count.
 
 Among the PRs found under those names, in the resolved repository only:

--- a/specs/input.md
+++ b/specs/input.md
@@ -1,7 +1,7 @@
 ---
-Status: Current
+Status: Draft
 Created: 2026-07-17
-Last edited: 2026-07-31
+Last edited: 2026-08-08
 ---
 
 # Input
@@ -20,6 +20,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 - A key hint in the header or the footer shows its action's first bound key.
 - The comments list acts through the same bindings and closes on `esc` and the `comments` binding.
 - The agent picker acts through the `down` / `up` bindings and closes on `esc`.
+- The base picker filters through typed characters, moves through the arrows, and closes on `esc`.
 - Prose and mockups elsewhere show the default keys.
 
 | action                                                   | does                                        | keys                                        | mouse                         |
@@ -33,6 +34,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 | —                                                        | scroll the viewport, selection put          | —                                           | wheel over the pane           |
 | —                                                        | scroll the diff horizontally (wrap off)     | `←` / `→`                                   | —                             |
 | `scope-uncommitted` / `scope-branch` / `scope-last-turn` | switch scope                                | `u` / `b` / `t`                             | click the scope chip to cycle |
+| `base-pick`                                              | open the base picker                        | `B`                                         | click the base name           |
 | `tab-changes` / `tab-all-files` / `tab-pr`               | switch tab                                  | `1` / `2` / `3`                             | click a tab name              |
 | —                                                        | expand the fold under the cursor            | `→`                                         | click the `⋯` row             |
 | —                                                        | open a link in rendered markdown            | —                                           | click the link                |
@@ -63,7 +65,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 
 `navigator-hide` hides the navigator and shows it again in place (`tui.md`). On the file tabs it is never inert in `Normal` mode, so the way back is always the key that hid it. On `PR` it is inert and stays out of the footer (`tui.md`). While the navigator is hidden, `navigator-position`, `navigator-grow`, and `navigator-shrink` are inert. In `Normal` mode, `tab` then shows the navigator and focuses it. Every other mode keeps its own `tab` meaning (`search.md`).
 
-Outside the hidden-state rules above, these four navigator actions work from either main pane on every tab. While the comment editor is open, their printable characters are text. In the comments list and the agent picker they are inert. Those local modes omit the navigator actions from the footer.
+Outside the hidden-state rules above, these four navigator actions work from either main pane on every tab. While the comment editor is open, their printable characters are text. In the comments list, the agent picker, and the base picker they are inert. Those local modes omit the navigator actions from the footer.
 
 A divider drag belongs to the navigator position and split axis at mouse-down. A keypress, terminal resize, or config-driven layout change cancels it. A cancelled drag keeps its last painted share, and the cancelling keypress still performs its own action. After cancellation, drag events are consumed until mouse-up rather than becoming a selection in the read pane.
 
@@ -94,7 +96,7 @@ The steps and the skips share the rest:
 - Adjacency is the list's visible order, so a collapsed subtree is skipped.
 - Opening a file this way moves the list selection onto it.
 - With no target in the pressed direction, a press does nothing.
-- Both are inert while a line selection is live and while the comments list or the agent picker is open.
+- Both are inert while a line selection is live and while the comments list, the agent picker, or the base picker is open.
 - The `PR` tab has neither.
 
 ### Footer
@@ -142,8 +144,9 @@ The `?` expansion:
 
 - It lists every shortcut applicable in the current context that is not already on row 1, wrapped
   below row 1 in three labeled bands, each a dim label then its keys. `do`: the cursor's actions.
-  `go`: the global actions, each shown only where it works — scope, search, find, wrap, the comments
-  list, copy, refresh, the tabs, the pane toggle, the navigator position and hide keys, quit. `move`:
+  `go`: the global actions, each shown only where it works — scope, the base picker, search, find,
+  wrap, the comments list, copy, refresh, the tabs, the pane toggle, the navigator position and hide
+  keys, quit. `move`:
   down and up, the hunk and file steps, the page keys. An empty band is dropped, and a key that would
   not work in the current state never appears. The hunk step shows only where it works, the `Changes`
   diff and never a preview (see Changeset traversal). `PR` has no hunk or file steps. The hide key's
@@ -173,6 +176,7 @@ Row 1's primary and actions follow the cursor:
 | a collapsed directory                    | `→ expand`                     | `z hide`                          |
 | an expanded directory                    | `← collapse`                   | `z hide`                          |
 | nothing to review (awaiting turn)        | `u/b/t scope`                  | `r refresh`                       |
+| the `branch` scope with no base          | `B pick base`                  | `u/t scope · r refresh`           |
 | an empty read pane, navigator hidden     | `z show`                       | `tab files`                       |
 
 - An armed crossing outranks the cursor's own action and leads row 1, since only the footer says the next press leaves the file. It is the one movement key on row 1 (see Changeset traversal). While it is armed, the `move` band drops the hunk step, whose key row 1 now shows.
@@ -180,8 +184,8 @@ Row 1's primary and actions follow the cursor:
 - When the awaiting-turn state and the hidden empty read pane match at once, the awaiting-turn row wins, and `z show` still joins its actions.
 - `scope`, `search`, and `find` are global, not cursor actions, so the `go` band carries them, never row 1 — `search` in every context, `find` wherever the read pane has content (`search.md`, `find-in-file.md`). `scope` leads row 1 only where nothing else does, an empty or notice diff.
 - Movement keys never sit on row 1. The `move` band shows them.
-- The comment editor, the comments list, the agent picker, the search screen, and the find band show their own one-row footer, without `?`. The expansion's open state is kept and restored when they close.
-- `?` (the `keys` action) toggles the expansion in `Normal` mode only. It is text in the comment editor and the search and find inputs, and inert in the comments list and the agent picker.
+- The comment editor, the comments list, the agent picker, the base picker, the search screen, and the find band show their own one-row footer, without `?`. The expansion's open state is kept and restored when they close.
+- `?` (the `keys` action) toggles the expansion in `Normal` mode only. It is text in the comment editor, the search and find inputs, and the base picker's filter, and inert in the comments list and the agent picker.
 - The changed-file count and line totals live in the header. The footer carries only the comment count, inside `s send N`.
 - On `PR` row 1 carries the PR state line and `o open ↗` per `pr-tab.md`, and `?` expands to the rest.
 
@@ -232,6 +236,30 @@ Only the unmodified `enter` sends. `Alt+Enter` and `Shift+Enter` insert a newlin
 - `esc` cancels with or without a modifier, so no keystroke traps the reviewer in the picker.
 - A picker taller than the pane scrolls with the highlight.
 - `esc` returns to the view the send was issued from, the comments list and the find band included.
+
+### Base picker
+
+`base-pick` opens the picker over the body, like the comments list (`tui.md`). It works on the file tabs while the `branch` scope is active and no `--base` flag was passed. Elsewhere it is inert and stays out of the footer. While the comment editor is open, the base-name click is inert like the key.
+
+The list holds one row per branch name, remote-tracking and local names merged. The checked-out branch is not listed. Rows sort by most recent commit. Two rows outrank that order:
+
+- The open PR's target sorts first, starred (`forge-host.md`).
+- The default branch sorts next, marked `default`. Choosing it clears the pick (`review-model.md`).
+
+The highlight opens on the current base, else the first row. The highlight is place state (`overview.md`).
+
+| key               | does                                             |
+| ----------------- | ------------------------------------------------ |
+| typed character   | narrow the list, matching anywhere in the name   |
+| `backspace`       | delete the last filter character                 |
+| `↓` / `↑`         | move the highlight                               |
+| `enter`           | pick the highlighted branch                      |
+| `esc`             | cancel                                           |
+
+- A click moves the highlight. A click on the highlighted row picks.
+- A filter matching no branch shows `no branches match`, and `enter` does nothing.
+- A pick applies immediately: the changeset rebuilds and the header renames (`review-model.md`).
+- A picker taller than the pane scrolls with the highlight.
 
 ## Non-goals
 

--- a/specs/input.md
+++ b/specs/input.md
@@ -53,7 +53,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 | `search`                                                 | open the search screen (`search.md`)        | `/`                                         | —                             |
 | `find`                                                   | open in-file find (`find-in-file.md`)       | `ctrl+f`                                    | —                             |
 | `keys`                                                   | toggle the footer's full shortcut list      | `?`                                         | —                             |
-| `send`                                                   | send all comments to the agent              | `s` / `S`                                   | click `Send`                  |
+| `send`                                                   | send all comments to the agent              | `s` / `S`                                   | —                             |
 | `copy`                                                   | copy all comments to the clipboard          | `y` / `Y`                                   | —                             |
 | `open-pr`                                                | open the PR in the browser (`pr-tab.md`)    | `o`                                         | click the status chip         |
 | `refresh`                                                | refresh now                                 | `r`                                         | —                             |

--- a/specs/input.md
+++ b/specs/input.md
@@ -1,5 +1,5 @@
 ---
-Status: Draft
+Status: Current
 Created: 2026-07-17
 Last edited: 2026-08-08
 ---
@@ -20,7 +20,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 - A key hint in the header or the footer shows its action's first bound key.
 - The comments list acts through the same bindings and closes on `esc` and the `comments` binding.
 - The agent picker acts through the `down` / `up` bindings and closes on `esc`.
-- The base picker filters through typed characters, moves through the arrows, and closes on `esc`.
+- The base picker filters through a text field with the comment editor's controls, moves through the arrows, and closes on `esc`.
 - Prose and mockups elsewhere show the default keys.
 
 | action                                                   | does                                        | keys                                        | mouse                         |
@@ -191,7 +191,7 @@ Row 1's primary and actions follow the cursor:
 
 ### Comment editor
 
-A plain-text field that edits at the caret, not only at the end. The search input shares these controls, without the newline inserts (`search.md`). An empty box shows a dim `Leave a comment…` placeholder. `e` preloads the existing text with the caret at the end.
+A plain-text field that edits at the caret, not only at the end. The search input and the base picker's filter share these controls, without the newline inserts (`search.md`). An empty box shows a dim `Leave a comment…` placeholder. `e` preloads the existing text with the caret at the end.
 
 ```
 ┌ comment · llm_registry.py:41 ───────────┐
@@ -248,13 +248,15 @@ The list holds one row per branch name, remote-tracking and local names merged. 
 
 The highlight opens on the current base, else the first row. The highlight is place state (`overview.md`).
 
-| key               | does                                             |
-| ----------------- | ------------------------------------------------ |
-| typed character   | narrow the list, matching anywhere in the name   |
-| `backspace`       | delete the last filter character                 |
-| `↓` / `↑`         | move the highlight                               |
-| `enter`           | pick the highlighted branch                      |
-| `esc`             | cancel                                           |
+| key                 | does                                            |
+| ------------------- | ----------------------------------------------- |
+| typed character     | narrow the list, matching anywhere in the name  |
+| `↓` / `↑`           | move the highlight                              |
+| `ctrl+n` / `ctrl+p` | move the highlight                              |
+| `enter`             | pick the highlighted branch                     |
+| `esc`               | cancel                                          |
+
+The filter is a text field with the comment editor's controls, above. `↑` and `↓` move the highlight, so the single-line filter keeps `←` and `→` for its caret.
 
 - A click moves the highlight. A click on the highlighted row picks.
 - A filter matching no branch shows `no branches match`, and `enter` does nothing.

--- a/specs/input.md
+++ b/specs/input.md
@@ -256,7 +256,7 @@ The highlight opens on the current base, else the first row. The highlight is pl
 | `enter`             | pick the highlighted branch                     |
 | `esc`               | cancel                                          |
 
-The filter is a text field with the comment editor's controls, above. `↑` and `↓` move the highlight, so the single-line filter keeps `←` and `→` for its caret.
+The filter is a text field with the comment editor's controls, above. `↑` and `↓` move the highlight, so the single-line filter keeps `←` and `→` for its caret. A pasted newline drops, so a branch name copied with its line ending filters as the bare name.
 
 - A click moves the highlight. A click on the highlighted row picks.
 - A filter matching no branch shows `no branches match`, and `enter` does nothing.

--- a/specs/input.md
+++ b/specs/input.md
@@ -241,7 +241,7 @@ Only the unmodified `enter` sends. `Alt+Enter` and `Shift+Enter` insert a newlin
 
 `base-pick` opens the picker over the body, like the comments list (`tui.md`). It works on the file tabs while the `branch` scope is active and no `--base` flag was passed. Elsewhere it is inert and stays out of the footer. While the comment editor is open, the base-name click is inert like the key.
 
-The list holds one row per branch name, remote-tracking and local names merged. The checked-out branch is not listed. Rows sort by most recent commit. Two rows outrank that order:
+The list holds one row per branch name, remote-tracking and local names merged. The checked-out branch is not listed, unless it is the default branch, whose row must stay reachable to clear a pick. Rows sort by most recent commit. Two rows outrank that order:
 
 - The open PR's target sorts first, starred (`forge-host.md`).
 - The default branch sorts next, marked `default`. Choosing it clears the pick (`review-model.md`).

--- a/specs/overview.md
+++ b/specs/overview.md
@@ -1,5 +1,5 @@
 ---
-Status: Draft
+Status: Current
 Created: 2026-06-23
 Last edited: 2026-08-08
 ---

--- a/specs/overview.md
+++ b/specs/overview.md
@@ -1,7 +1,7 @@
 ---
-Status: Current
+Status: Draft
 Created: 2026-06-23
-Last edited: 2026-07-31
+Last edited: 2026-08-08
 ---
 
 # herdr-reviewr
@@ -89,7 +89,7 @@ Newer content paints over the old in place, reconciling the reviewer's place as 
 
 | Always true                                                                                                                                                 |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| reviewr never commits, stages, or mutates the worktree, the index, or any branch. Its one git write is the private baseline ref under `refs/reviewr/`.      |
+| reviewr never commits, stages, or mutates the worktree, the index, or any branch. Its only git writes are private refs under `refs/reviewr/`: the turn baseline and the base pick.  |
 | reviewr never writes to a forge. It reads the pull request through the forge's official CLI and opens links in the browser, nothing more.                   |
 | A comment, saved or being typed, is never lost to a refresh or the agent's edits. Only the reviewer removes it, and only an explicit export takes it out.   |
 

--- a/specs/pr-tab.md
+++ b/specs/pr-tab.md
@@ -1,5 +1,5 @@
 ---
-Status: Draft
+Status: Current
 Created: 2026-07-17
 Last edited: 2026-08-08
 ---

--- a/specs/pr-tab.md
+++ b/specs/pr-tab.md
@@ -1,7 +1,7 @@
 ---
-Status: Current
+Status: Draft
 Created: 2026-07-17
-Last edited: 2026-07-31
+Last edited: 2026-08-08
 ---
 
 # PR tab
@@ -15,7 +15,7 @@ The navigator shows checks and selects the description or a comment. The read pa
 The tab is labeled `PR` on every forge. Body text, the chip, the read pane's title, and the footer use the resolved forge's vocabulary (`forge-providers.md`). A repository that resolves to no forge takes the default vocabulary. A `finding` from a forge that returns no code context shows its body alone.
 
 ```
- 1 Changes  2 All files  3 PR    Deep research: GPT-5.5/5.4-mini upgrade…  deep-research  merged #226 ↗
+ 1 Changes  2 Files  3 PR    Deep research: GPT-5.5/5.4-mini upgrade…  deep-research  merged #226 ↗
 ╭─ @codex · manager.py:115 ──────────────────────────╮╭─ Checks & comments ──────────╮
 │ -    if primary_result.status == PERM_FAILURE:        ││ description                  │
 │ -        return primary_result                        ││                              │

--- a/specs/review-model.md
+++ b/specs/review-model.md
@@ -63,6 +63,8 @@ The header names the base while the `branch` scope is active (`tui.md`). A base 
 
 Open decision: whether an open PR's target branch (`forge-host.md`) joins the chain between the pick and `origin/HEAD`, pending an interaction trial. The picker stars the PR target either way (`input.md`).
 
+Open decision: whether a name that exists both locally and on origin should resolve local first. Origin first diffs a stacked branch against a stale pushed tip. Local first diffs against a stale local `main`. The two failures are symmetric, so the order stays as it is until one is shown to hurt more.
+
 The installed pane passes no arguments, so `--base` serves standalone and dev runs.
 
 ### Ignored paths

--- a/specs/review-model.md
+++ b/specs/review-model.md
@@ -1,5 +1,5 @@
 ---
-Status: Draft
+Status: Current
 Created: 2026-06-23
 Last edited: 2026-08-08
 ---

--- a/specs/review-model.md
+++ b/specs/review-model.md
@@ -1,7 +1,7 @@
 ---
-Status: Current
+Status: Draft
 Created: 2026-06-23
-Last edited: 2026-07-31
+Last edited: 2026-08-08
 ---
 
 # Review model
@@ -39,21 +39,31 @@ A scope selects which changes `Changes` shows and which files `All files` annota
 
 ### Base branch
 
-The `branch` scope diffs against the merge-base of the base branch and `HEAD`. The first source with a resolving entry wins:
+The `branch` scope diffs against the merge-base of the base branch and `HEAD`. The base is always a recorded choice, never inferred. The first source that resolves wins:
 
-| # | source                           | base is                                               |
-| - | -------------------------------- | ----------------------------------------------------- |
-| 1 | `--base <ref>` flag              | any rev, resolved verbatim, else as a canonical entry |
-| 2 | `base_branches` in `config.toml` | the first listed entry that resolves                  |
-| 3 | `origin/HEAD`                    | the default branch it names, when present             |
+| # | source              | base is                                            |
+| - | ------------------- | -------------------------------------------------- |
+| 1 | `--base <ref>` flag | any rev, resolved verbatim, else as a branch name  |
+| 2 | the repo pick       | the branch chosen in the base picker (`input.md`)  |
+| 3 | `origin/HEAD`       | the default branch it names, when present          |
 
-`base_branches` defaults to `["main", "master"]`, and entries canonicalize and resolve per `config.md`.
+A branch name resolves through `refs/remotes/origin/<name>`, then `refs/heads/<name>`. A leading `refs/heads/`, `refs/remotes/origin/`, or `origin/` prefix on a `--base` name is stripped first. A source that resolves to no ref is skipped, never an error. When no source resolves, `branch` shows nothing and the footer offers the picker (`input.md`). The other scopes are unaffected.
 
-- The list is re-read on refresh.
-- A listed entry that resolves to no ref is skipped, never an error.
-- When no candidate exists, `branch` shows nothing. The other scopes are unaffected.
-- The installed pane passes no arguments, so `--base` serves standalone and dev runs.
-- With no config directory (`config.md`), reviewr reads no config file.
+The pick:
+
+- The pick is one branch name per repository, shared by its worktrees.
+- The pick persists in a private ref under `refs/reviewr/` and survives pane restarts (`overview.md`).
+- The pick applies only after its ref write lands.
+- The pick reaches every other pane of the repository at that pane's next refresh.
+- The pick clears when the chosen branch is the one `origin/HEAD` names.
+- The pick is kept and skipped while its branch does not resolve. It reactivates when the branch resolves again.
+- The pick can only be replaced, never cleared, in a repository with no default branch.
+
+The header names the base while the `branch` scope is active (`tui.md`). A base change rebuilds the changeset on the next frame, never waiting for a poll.
+
+Open decision: whether an open PR's target branch (`forge-host.md`) joins the chain between the pick and `origin/HEAD`, pending an interaction trial. The picker stars the PR target either way (`input.md`).
+
+The installed pane passes no arguments, so `--base` serves standalone and dev runs.
 
 ### Ignored paths
 
@@ -146,6 +156,8 @@ How the agent pane is found and filled is in `herdr-host.md`.
 - No categories, severities, or threads. Text only.
 - No line-number rebasing as the diff shifts.
 - No auto-submit of the agent prompt.
+- No inferred base branch. The reflog and the commit graph never choose a base.
+- No global base list. A base is chosen per repository, never once for every repository.
 
 ## Related specs
 

--- a/specs/search.md
+++ b/specs/search.md
@@ -1,5 +1,5 @@
 ---
-Status: Draft
+Status: Current
 Created: 2026-07-18
 Last edited: 2026-08-08
 ---

--- a/specs/search.md
+++ b/specs/search.md
@@ -1,7 +1,7 @@
 ---
-Status: Current
+Status: Draft
 Created: 2026-07-18
-Last edited: 2026-07-31
+Last edited: 2026-08-08
 ---
 
 # Search
@@ -14,7 +14,7 @@ Full-screen file and code search over the worktree, opened with `/` from any tab
 above a full-width live preview. `tab` flips between the two search modes, keeping the query.
 
 ```
-┌ 1 Changes  2 All files  3 PR  [uncommitted]                                  ┐
+┌ 1 Changes  2 Files  3 PR  [uncommitted]                                      ┐
 │ > registry resolve█                                       files 3 │ code 37+ │
 │ ┌ results ────────────────────────────────────────────────────────────────┐ │
 │ │ src/llm_registry.py                                                     │ │

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -29,7 +29,7 @@ The terminal frame: the pane layout, the tabs, and how the view stays current.
 - The header carries the three tabs with the active one highlighted, the active scope, and the changed-file count with the scope's `+added −removed` totals, right-aligned one cell off the pane edge.
 - The `All files` tab's header label reads `Files`.
 - On the `branch` scope the header names the base after the scope, `vs dev`, the bare branch name however it resolved. Clicking it opens the base picker (`input.md`). With no resolving base it reads `no base`.
-- A skipped pick or `--base` shows after the base, `vs main · dev missing`.
+- A skipped pick or `--base` shows after the base, `vs main · dev missing` — and after the empty state too, `no base · dev missing`, so a dormant choice never reads as never-chosen.
 - A base name the header cannot fit truncates with a trailing `…`. The picker always shows it whole.
 - The header's line totals drop a zero side and vanish when nothing changed, like a file row's stats (`file-list.md`).
 - The active tab sets both panes: diff and changed files in `Changes`, content and repo tree in `All files`, checks and comments in `PR` (`diff-view.md`, `pr-tab.md`).

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -11,7 +11,7 @@ The terminal frame: the pane layout, the tabs, and how the view stays current.
 ## Overview
 
 ```
-┌ 1 Changes  2 All files  3 PR  [uncommitted]  9 changed  +42 −18 [ Send (3) ] ┐
+┌ 1 Changes  2 Files  3 PR  [uncommitted]                    9 changed  +42 −18 ┐
 │ ⋯  11 unmodified lines                       │ M llm_registry.py  +18 -8  │
 │ 40    def resolve(self, name):               │ M deep_research.py +155-62 │
 │ 41 ▌  from .z import w                         │ D old_runner.py    -47     │
@@ -26,7 +26,8 @@ The terminal frame: the pane layout, the tabs, and how the view stays current.
 └────────────────────────────────────────────────────────────────────────────┘
 ```
 
-- The header carries the three tabs with the active one highlighted, the active scope, the changed-file count with the scope's `+added −removed` totals, and a clickable `Send` button with the comment count (`input.md`).
+- The header carries the three tabs with the active one highlighted, the active scope, and the changed-file count with the scope's `+added −removed` totals, right-aligned one cell off the pane edge.
+- The `All files` tab's header label reads `Files`.
 - On the `branch` scope the header names the base after the scope, `vs dev`, the bare branch name however it resolved. Clicking it opens the base picker (`input.md`). With no resolving base it reads `no base`.
 - A skipped pick or `--base` shows after the base, `vs main · dev missing`.
 - A base name the header cannot fit truncates with a trailing `…`. The picker always shows it whole.
@@ -103,6 +104,7 @@ A layout change moves nothing else (`overview.md`), and both remembered shares p
 - No automatic position or content-sized navigator. Layout changes only through config, `p`, `z`, resize keys, or dragging.
 - No configured hidden default. The navigator starts visible, and only `navigator-hide` hides it.
 - No multi-file review stream. Each read pane shows one selected item.
+- No header `Send` button. Send lives on its keys and the footer (`input.md`).
 
 ## Related specs
 

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -1,7 +1,7 @@
 ---
-Status: Current
+Status: Draft
 Created: 2026-06-23
-Last edited: 2026-07-31
+Last edited: 2026-08-08
 ---
 
 # TUI
@@ -27,11 +27,14 @@ The terminal frame: the pane layout, the tabs, and how the view stays current.
 ```
 
 - The header carries the three tabs with the active one highlighted, the active scope, the changed-file count with the scope's `+added −removed` totals, and a clickable `Send` button with the comment count (`input.md`).
+- On the `branch` scope the header names the base after the scope, `vs dev`, the bare branch name however it resolved. Clicking it opens the base picker (`input.md`). With no resolving base it reads `no base`.
+- A skipped pick or `--base` shows after the base, `vs main · dev missing`.
+- A base name the header cannot fit truncates with a trailing `…`. The picker always shows it whole.
 - The header's line totals drop a zero side and vanish when nothing changed, like a file row's stats (`file-list.md`).
 - The active tab sets both panes: diff and changed files in `Changes`, content and repo tree in `All files`, checks and comments in `PR` (`diff-view.md`, `pr-tab.md`).
 - The comment input opens inline, directly under the last line of the selection, and grows as you type (`input.md`). It is never a footer band.
 - The footer is a live action bar (`input.md`).
-- The comments list and the agent picker open as popups over the body (`input.md`, `herdr-host.md`). While one is open, every painted color in the header and the body recedes halfway to the theme base. The footer stays bright.
+- The comments list, the agent picker, and the base picker open as popups over the body (`input.md`, `herdr-host.md`). While one is open, every painted color in the header and the body recedes halfway to the theme base. The footer stays bright.
 - The review loop is the same in `Changes` and `All files`. `PR` is a read-only mirror. Comments are one set across the authoring tabs and export together.
 
 The navigator has one global position across all tabs, and the position derives the split direction.
@@ -86,7 +89,7 @@ A layout change moves nothing else (`overview.md`), and both remembered shares p
 ## Failure semantics
 
 - A poll never touches the comment input or saved comments. Draft text and caret survive every refresh.
-- A config error and its automatic-reload remedy replace the view. Saved comments, an open composer or comments list, and the footer's shortcut expansion all survive it (`config.md`).
+- A config error and its automatic-reload remedy replace the view. Saved comments, an open composer, comments list, or base picker, and the footer's shortcut expansion all survive it (`config.md`).
 - A poll that finds no change makes no visible update: no flicker, no lost selection or scroll.
 - A refresh in flight never delays input or a paint.
 - A first open of a very large file can briefly block.

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -1,5 +1,5 @@
 ---
-Status: Draft
+Status: Current
 Created: 2026-06-23
 Last edited: 2026-08-08
 ---
@@ -30,7 +30,7 @@ The terminal frame: the pane layout, the tabs, and how the view stays current.
 - The `All files` tab's header label reads `Files`.
 - On the `branch` scope the header names the base after the scope, `vs dev`, the bare branch name however it resolved. Clicking it opens the base picker (`input.md`). With no resolving base it reads `no base`.
 - A skipped pick or `--base` shows after the base, `vs main · dev missing` — and after the empty state too, `no base · dev missing`, so a dormant choice never reads as never-chosen.
-- A base name the header cannot fit truncates with a trailing `…`. The picker always shows it whole.
+- A base name the header cannot fit truncates with a trailing `…`. The picker always shows it whole. Too narrow for even one column of the name, the base leaves the header rather than paint a nameless `vs`.
 - The header's line totals drop a zero side and vanish when nothing changed, like a file row's stats (`file-list.md`).
 - The active tab sets both panes: diff and changed files in `Changes`, content and repo tree in `All files`, checks and comments in `PR` (`diff-view.md`, `pr-tab.md`).
 - The comment input opens inline, directly under the last line of the selection, and grows as you type (`input.md`). It is never a footer band.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1057,6 +1057,16 @@ impl App {
         }
     }
 
+    /// Adopt a build's base outcome — the one rule for both writers (the landed snapshot
+    /// and the scope switch's synchronous rebuild): only the `branch` scope owns a base,
+    /// and the base and the changeset it produced land together, so the header name and
+    /// the list it heads never disagree (specs/tui.md).
+    fn adopt_branch_base(&mut self, base: git::BaseStatus) {
+        if self.scope == Scope::Branch {
+            self.branch_base = base;
+        }
+    }
+
     /// Reconcile a built snapshot into the view — the one place a world result touches place
     /// state, by identity first, then fallback, then clamp (`specs/overview.md` Continuity).
     pub fn reconcile_world(&mut self, snapshot: crate::world::WorldSnapshot) {
@@ -1066,11 +1076,7 @@ impl App {
         let open = self.diff_path.clone();
         self.changed = snapshot.changed;
         self.entries = snapshot.entries;
-        // The base and the changeset it produced land together, so the header name and the
-        // list it heads never disagree (specs/tui.md).
-        if self.scope == Scope::Branch {
-            self.branch_base = snapshot.branch_base;
-        }
+        self.adopt_branch_base(snapshot.branch_base);
         self.rebuild_file_rows();
         self.file_cursor = anchor
             .and_then(|a| self.row_of_anchor(&a))
@@ -1839,9 +1845,7 @@ impl App {
             // `All files` keeps its tree; only the changed set rebuilds before the frame.
             // The tree's annotations refresh behind it via the worker (specs/tui.md).
             let (branch_base, changed) = crate::world::build_changed(&self.world_input())?;
-            if self.scope == Scope::Branch {
-                self.branch_base = branch_base;
-            }
+            self.adopt_branch_base(branch_base);
             self.changed = crate::world::annotate(&changed);
             // Re-mark the tree in place — the rows are base-independent, only their
             // badges move, so the switch frame never shows the old base's badges
@@ -3621,7 +3625,8 @@ impl App {
         if !self.base_pick_available() || self.mode != Mode::Normal {
             return;
         }
-        let names = match git::list_branches(&self.repo) {
+        let default = git::default_branch_name(&self.repo).ok().flatten();
+        let names = match git::list_branches(&self.repo, default.as_deref()) {
             Ok(names) => names,
             Err(e) => {
                 self.status = e.0;
@@ -3634,7 +3639,6 @@ impl App {
             self.status = "no branches to pick".to_string();
             return;
         }
-        let default = git::default_branch_name(&self.repo).ok().flatten();
         let target = self
             .pr_snapshot()
             .filter(|s| s.state == forge::PrState::Open)
@@ -4033,7 +4037,6 @@ mod tests {
             winner: Some(crate::git::ResolvedBase {
                 name: "main".to_string(),
                 oid: "0".repeat(40),
-                source: crate::git::BaseSource::DefaultBranch,
             }),
             skipped: None,
         };

--- a/src/app.rs
+++ b/src/app.rs
@@ -119,6 +119,39 @@ struct ArmedCross {
     path: String,
 }
 
+/// The base picker's state while it is open (`specs/input.md` Base picker). The rows freeze
+/// at open; the filter and highlight are the reviewer's own place state.
+#[derive(Clone, Debug)]
+pub struct BasePicker {
+    /// Every pickable branch name: the open PR's target starred first, the default branch
+    /// next, the rest by commit recency, the checked-out branch excluded.
+    pub rows: Vec<BaseChoice>,
+    /// The highlighted row, an index into the filtered view.
+    pub cursor: usize,
+    /// The typed filter, matching anywhere in the name.
+    pub query: String,
+}
+
+/// One base picker row (`specs/input.md` Base picker).
+#[derive(Clone, Debug)]
+pub struct BaseChoice {
+    pub name: String,
+    /// The open PR's target, shown starred.
+    pub starred: bool,
+    /// The default branch, marked `default`. Choosing it clears the pick
+    /// (`specs/review-model.md`).
+    pub is_default: bool,
+}
+
+impl BasePicker {
+    /// The filtered view: indices into `rows` whose names contain the query, the
+    /// case-insensitive anywhere-match the key table names (`specs/input.md`).
+    pub fn filtered(&self) -> Vec<usize> {
+        let q = self.query.to_lowercase();
+        (0..self.rows.len()).filter(|&i| self.rows[i].name.to_lowercase().contains(&q)).collect()
+    }
+}
+
 /// The interaction mode the UI is in.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Mode {
@@ -132,6 +165,9 @@ pub enum Mode {
     /// Choosing which agent a `Send` goes to (`specs/herdr-host.md`). Its rows and highlight
     /// live in [`App::picker_rows`] and [`App::picker_cursor`].
     Picker,
+    /// Choosing the `branch` scope's base (`specs/input.md` Base picker). Its state lives in
+    /// [`App::base_picker`].
+    BasePick,
     /// The search screen, replacing the body from any tab (specs/search.md). Its state
     /// lives in [`App::search`].
     Search,
@@ -150,7 +186,7 @@ impl Mode {
     /// `Search` replaces the body rather than holding a place in it, and `Find` is a band the
     /// reviewer navigates the live diff with. Neither freezes anything, so neither is modal here.
     pub fn is_modal(&self) -> bool {
-        matches!(self, Mode::Composing { .. } | Mode::List | Mode::Picker)
+        matches!(self, Mode::Composing { .. } | Mode::List | Mode::Picker | Mode::BasePick)
     }
 }
 
@@ -357,6 +393,15 @@ pub enum FooterAction {
     PickAgent,
     MovePickerRow,
     ClosePicker,
+    /// Open the base picker (`specs/input.md` Base picker).
+    BasePick,
+    /// The base picker's own bar: pick the highlight and move it. Every printable is
+    /// filter text there, so the move hint names the arrows alone.
+    PickBaseRow,
+    MoveBaseRow,
+    /// The two scopes to switch away to, from the branch-scope no-base row — `b` is the
+    /// scope already showing, so its hint would offer a no-op (`specs/input.md`).
+    ScopeOther,
     OpenPr,
     Refresh,
     Tabs,
@@ -498,6 +543,9 @@ pub struct App {
     /// The agent this session last sent to, which arms the picker's highlight. Only a
     /// successful send sets it (`specs/herdr-host.md`).
     pub last_sent_pane: Option<String>,
+    /// The base picker's rows, filter, and highlight while `Mode::BasePick` is open
+    /// (`specs/input.md` Base picker).
+    pub base_picker: Option<BasePicker>,
     pub mode: Mode,
     pub input: String,
     /// The comment editor's caret: a char index into `input` (`0..=chars().count()`).
@@ -661,6 +709,7 @@ impl App {
             picker_cursor: 0,
             picker_over: Mode::Normal,
             last_sent_pane: None,
+            base_picker: None,
             mode: Mode::Normal,
             input: String::new(),
             caret: 0,
@@ -811,7 +860,7 @@ impl App {
             // restored and the picker's frozen rows are not either (specs/search.md,
             // specs/find-in-file.md, specs/herdr-host.md).
             Mode::Normal | Mode::Search | Mode::Find | Mode::Picker => {}
-            Mode::List | Mode::Composing { .. } => {
+            Mode::List | Mode::Composing { .. } | Mode::BasePick => {
                 self.scope = old.scope;
                 self.tab = old.tab;
                 self.active_file_tab = old.active_file_tab;
@@ -842,6 +891,9 @@ impl App {
                 self.mode = old.mode.clone();
                 self.input = std::mem::take(&mut old.input);
                 self.caret = old.caret;
+                // The base picker survives recovery whole — rows, filter, and highlight
+                // (`specs/tui.md`).
+                self.base_picker = old.base_picker.take();
             }
         }
     }
@@ -1740,48 +1792,53 @@ impl App {
         self.ensure_config_ready()?;
         if self.scope != scope && !self.composing() {
             self.scope = scope;
-            // A scope switch changes the Changes changeset (and each file's old side), so the
-            // Changes tab snaps to the top of the new scope: reset its cursor, folds, and diff
-            // scroll, and drop cached diffs. The `All files` listing and File view are
-            // scope-independent (only the annotations move), so its own state is held by `reload`.
-            // The Changes state is the active one on `Changes` and the stashed one while `All
-            // files` is shown — reset whichever holds it, so a return to Changes never lands on a
-            // stale scroll or a pre-expanded fold.
-            self.cache = DiffCache::new();
-            if self.tab == Tab::Changes {
-                self.file_cursor = 0;
-                self.expanded_folds.clear();
-                self.reset_diff_view();
-                // The changed set rebuilds before the frame, so the list never shows another
-                // scope's files under the new scope's label (specs/tui.md). In `Changes` the
-                // changeset is the whole snapshot, so this is the full (cheap) reload.
-                self.reload()?;
-            } else {
-                self.stash.file_cursor = 0;
-                self.stash.expanded_folds.clear();
-                self.stash.diff_cursor = 0;
-                self.stash.diff_scroll = 0;
-                self.stash.h_scroll = 0;
-                self.stash.select_anchor = None;
-                // `All files` keeps its tree; only the changed set rebuilds before the frame.
-                // The tree's annotations refresh behind it via the worker (specs/tui.md).
-                let (branch_base, changed) = crate::world::build_changed(&self.world_input())?;
-                if self.scope == Scope::Branch {
-                    self.branch_base = branch_base;
-                }
-                self.changed = crate::world::annotate(&changed);
-                // Re-mark the tree in place — the rows are scope-independent, only their
-                // badges move, so the switch frame never shows the old scope's badges
-                // under the new scope's header (policies/ux-responsiveness.md). The tree
-                // itself still refreshes behind the switch.
-                for entry in &mut self.entries {
-                    entry.annotation = self.changed.get(&entry.path).cloned();
-                }
-                self.rebuild_file_rows();
-                self.request_world_refresh(false, false);
-            }
+            self.rebase_changes()?;
             // An explicit switch reveals the cursor (a poll does not).
             self.reveal_files = true;
+        }
+        Ok(())
+    }
+
+    /// Rebuild the views after the changeset's base moved — a scope switch or a base pick.
+    /// The change replaces the Changes changeset (and each file's old side), so the Changes
+    /// tab snaps to the top: reset its cursor, folds, and diff scroll, and drop cached diffs.
+    /// The `All files` listing and File view are base-independent (only the annotations
+    /// move), so its own state is held by `reload`. The Changes state is the active one on
+    /// `Changes` and the stashed one while `All files` is shown — reset whichever holds it,
+    /// so a return to Changes never lands on a stale scroll or a pre-expanded fold.
+    fn rebase_changes(&mut self) -> Result<()> {
+        self.cache = DiffCache::new();
+        if self.tab == Tab::Changes {
+            self.file_cursor = 0;
+            self.expanded_folds.clear();
+            self.reset_diff_view();
+            // The changed set rebuilds before the frame, so the list never shows another
+            // base's files under the new base's label (specs/tui.md). In `Changes` the
+            // changeset is the whole snapshot, so this is the full (cheap) reload.
+            self.reload()?;
+        } else {
+            self.stash.file_cursor = 0;
+            self.stash.expanded_folds.clear();
+            self.stash.diff_cursor = 0;
+            self.stash.diff_scroll = 0;
+            self.stash.h_scroll = 0;
+            self.stash.select_anchor = None;
+            // `All files` keeps its tree; only the changed set rebuilds before the frame.
+            // The tree's annotations refresh behind it via the worker (specs/tui.md).
+            let (branch_base, changed) = crate::world::build_changed(&self.world_input())?;
+            if self.scope == Scope::Branch {
+                self.branch_base = branch_base;
+            }
+            self.changed = crate::world::annotate(&changed);
+            // Re-mark the tree in place — the rows are base-independent, only their
+            // badges move, so the switch frame never shows the old base's badges
+            // under the new base's header (policies/ux-responsiveness.md). The tree
+            // itself still refreshes behind the switch.
+            for entry in &mut self.entries {
+                entry.annotation = self.changed.get(&entry.path).cloned();
+            }
+            self.rebuild_file_rows();
+            self.request_world_refresh(false, false);
         }
         Ok(())
     }
@@ -2557,7 +2614,7 @@ impl App {
             Mode::Composing { .. } => Some((&mut self.input, &mut self.caret)),
             Mode::Search => self.search.as_mut().map(|s| (&mut s.query, &mut s.caret)),
             Mode::Find => self.find.as_mut().map(|f| (&mut f.query, &mut f.caret)),
-            Mode::Normal | Mode::List | Mode::Picker => None,
+            Mode::Normal | Mode::List | Mode::Picker | Mode::BasePick => None,
         }
     }
 
@@ -2772,7 +2829,12 @@ impl App {
                 };
                 Some(c.location())
             }
-            Mode::Normal | Mode::List | Mode::Picker | Mode::Search | Mode::Find => None,
+            Mode::Normal
+            | Mode::List
+            | Mode::Picker
+            | Mode::BasePick
+            | Mode::Search
+            | Mode::Find => None,
         }
     }
 
@@ -3262,6 +3324,9 @@ impl App {
             Mode::Picker => {
                 return vec![(A::PickAgent, Primary), (A::ClosePicker, Do), (A::MovePickerRow, Do)];
             }
+            Mode::BasePick => {
+                return vec![(A::PickBaseRow, Primary), (A::ClosePicker, Do), (A::MoveBaseRow, Do)];
+            }
             Mode::Search => {
                 // With nothing pickable — warming, errored, or no matches — only the
                 // mode flip and the exit are offered, so the bar never lists a key that
@@ -3324,6 +3389,16 @@ impl App {
             // scope, send, and band actions. With the file list focused, the tree's own
             // actions apply instead.
             out.push((A::Preview, Primary));
+        } else if self.file_rows.is_empty()
+            && self.branch_base.is_none()
+            && self.base_pick_available()
+        {
+            // The `branch` scope with no base: the picker is the way forward, and `b` would
+            // re-select the scope already showing, so only the other two offer
+            // (`specs/input.md`, `specs/review-model.md`).
+            out.push((A::BasePick, Primary));
+            out.push((A::ScopeOther, Do));
+            out.push((A::Refresh, Do));
         } else if self.file_rows.is_empty() {
             // Nothing in scope to review: only switching scope or refreshing is useful.
             out.push((A::Scope, Primary));
@@ -3385,8 +3460,12 @@ impl App {
         // The `go` band: the keys that work anywhere. `scope` and `refresh` only when they are not
         // already row-1 actions (the empty / no-diff states above lead with them), and the pane
         // toggle only when it is not the primary — so a band never repeats a row-1 key.
-        if !out.iter().any(|&(a, _)| a == A::Scope) {
+        if !out.iter().any(|&(a, _)| a == A::Scope || a == A::ScopeOther) {
             out.push((A::Scope, Go));
+        }
+        // The base picker's key shows only where it works (`specs/input.md`).
+        if self.base_pick_available() && !out.iter().any(|&(a, _)| a == A::BasePick) {
+            out.push((A::BasePick, Go));
         }
         out.push((A::Search, Go));
         // In-file find shows wherever the read pane has content to search (specs/find-in-file.md).
@@ -3513,6 +3592,129 @@ impl App {
         let Some(agent) = self.picker_rows.get(self.picker_cursor).cloned() else { return };
         self.close_picker();
         self.export_to_agent(&agent);
+    }
+
+    /// Whether the base picker can open here: a file tab, the `branch` scope, and no
+    /// `--base` flag (`specs/input.md` Base picker).
+    #[must_use]
+    pub fn base_pick_available(&self) -> bool {
+        self.tab.is_file_tab() && self.scope == Scope::Branch && self.base.is_none()
+    }
+
+    /// Open the base picker: one row per branch name, the open PR's target starred first,
+    /// the default branch next, the rest by commit recency (`specs/input.md` Base picker).
+    /// The highlight opens on the current base, else the first row.
+    pub fn open_base_picker(&mut self) {
+        if !self.base_pick_available() || self.mode != Mode::Normal {
+            return;
+        }
+        let names = match git::list_branches(&self.repo) {
+            Ok(names) => names,
+            Err(e) => {
+                self.status = e.0;
+                return;
+            }
+        };
+        if names.is_empty() {
+            // Nothing to choose: refuse with the cause, like an empty send
+            // (`specs/input.md` Base picker).
+            self.status = "no branches to pick".to_string();
+            return;
+        }
+        let default = git::default_branch_name(&self.repo).ok().flatten();
+        let target = self
+            .pr_snapshot()
+            .filter(|s| s.state == forge::PrState::Open)
+            .map(|s| s.base_ref.clone());
+        let mut rows: Vec<BaseChoice> = names
+            .into_iter()
+            .map(|name| BaseChoice {
+                starred: target.as_deref() == Some(name.as_str()),
+                is_default: default.as_deref() == Some(name.as_str()),
+                name,
+            })
+            .collect();
+        // A stable sort, so recency still orders the promoted pair and the rest alike.
+        rows.sort_by_key(|r| (!r.starred, !r.is_default));
+        let current = self.branch_base.as_ref().map(|b| b.name.as_str());
+        let cursor = current.and_then(|c| rows.iter().position(|r| r.name == c)).unwrap_or(0);
+        self.base_picker = Some(BasePicker { rows, cursor, query: String::new() });
+        self.mode = Mode::BasePick;
+    }
+
+    pub fn close_base_picker(&mut self) {
+        if self.mode == Mode::BasePick {
+            self.mode = Mode::Normal;
+        }
+        self.base_picker = None;
+    }
+
+    /// Move the highlight through the filtered view (`specs/input.md`).
+    pub fn base_picker_move(&mut self, delta: isize) {
+        let Some(bp) = self.base_picker.as_mut() else { return };
+        let len = bp.filtered().len();
+        if len > 0 {
+            bp.cursor = step(bp.cursor.min(len - 1), delta, len);
+        }
+    }
+
+    /// Move the highlight to filtered `row`, for a click. A row past the end is inert
+    /// (`specs/input.md`).
+    pub fn base_picker_goto(&mut self, row: usize) {
+        if let Some(bp) = self.base_picker.as_mut()
+            && row < bp.filtered().len()
+        {
+            bp.cursor = row;
+        }
+    }
+
+    /// Append `ch` to the filter (`specs/input.md`).
+    pub fn base_picker_input(&mut self, ch: char) {
+        self.base_picker_edit(|q| q.push(ch));
+    }
+
+    /// Delete the last filter character (`specs/input.md`).
+    pub fn base_picker_backspace(&mut self) {
+        self.base_picker_edit(|q| {
+            q.pop();
+        });
+    }
+
+    /// Apply one filter edit. The highlight follows its row into the re-filtered view when
+    /// it survives, else rests on the first match (`specs/overview.md` Continuity).
+    fn base_picker_edit(&mut self, f: impl FnOnce(&mut String)) {
+        let Some(bp) = self.base_picker.as_mut() else { return };
+        let highlighted = bp.filtered().get(bp.cursor).copied();
+        f(&mut bp.query);
+        let filtered = bp.filtered();
+        bp.cursor = highlighted.and_then(|h| filtered.iter().position(|&i| i == h)).unwrap_or(0);
+    }
+
+    /// Pick the highlighted branch: persist it as the repo pick — or clear the pick when
+    /// the highlight is the default branch — then rebuild the changeset against it, so the
+    /// list and the header rename together (`specs/input.md`, `specs/review-model.md`).
+    /// With no filter match there is no highlight, and `enter` does nothing.
+    pub fn base_picker_pick(&mut self) -> Result<()> {
+        let Some(bp) = &self.base_picker else { return Ok(()) };
+        let Some(&row) = bp.filtered().get(bp.cursor) else { return Ok(()) };
+        let choice = bp.rows[row].clone();
+        self.close_base_picker();
+        let write = if choice.is_default {
+            git::clear_base_pick(&self.repo)
+        } else {
+            git::write_base_pick(&self.repo, &choice.name)
+        };
+        if let Err(e) = write {
+            self.status = e.0;
+            return Ok(());
+        }
+        self.rebase_changes()?;
+        // The queued refresh's generation bump invalidates any in-flight build that read
+        // the old pick — the pick is derived state, not input identity, so the tag alone
+        // would not reject it (`specs/review-model.md`).
+        self.request_world_refresh(false, false);
+        self.reveal_files = true;
+        Ok(())
     }
 
     /// Export to one decided pane. Nothing re-resolves it, so a pane that closed while the
@@ -3797,6 +3999,30 @@ mod tests {
         assert_eq!(recovered.last_sent_pane.as_deref(), Some("w8:p2"));
         // A picker that was open when the config broke does not come back with it.
         assert_eq!(recovered.mode, Mode::Normal);
+    }
+
+    #[test]
+    fn config_recovery_carries_the_base_picker_whole() {
+        // The base picker survives recovery with its rows, filter, and highlight
+        // (`specs/tui.md`).
+        let mut old = App::blocked(PathBuf::from("."), Scope::Branch, None);
+        old.mode = Mode::BasePick;
+        old.base_picker = Some(super::BasePicker {
+            rows: vec![super::BaseChoice {
+                name: "dev".to_string(),
+                starred: false,
+                is_default: false,
+            }],
+            cursor: 0,
+            query: "d".to_string(),
+        });
+
+        let mut recovered = App::new(PathBuf::from("."), Scope::Branch, None);
+        recovered.carry_authored_state_from(&mut old);
+        assert_eq!(recovered.mode, Mode::BasePick);
+        let bp = recovered.base_picker.as_ref().expect("the picker state is carried");
+        assert_eq!(bp.query, "d");
+        assert_eq!(bp.rows[0].name, "dev");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2691,9 +2691,10 @@ impl App {
         });
     }
 
-    /// Insert pasted `text` at the caret as one unit, normalizing `\r\n`/`\r` to `\n`.
-    /// A single-line field takes newlines as spaces (specs/search.md, specs/input.md) — a
-    /// branch name pasted with its trailing newline still filters.
+    /// Insert pasted `text` at the caret as one unit, normalizing `\r\n`/`\r` to `\n`. The
+    /// single-line search and find queries take a newline as a space (specs/search.md); the
+    /// base picker's filter drops it, so a branch name pasted with the newline it was copied
+    /// with still matches its branch (specs/input.md).
     pub fn input_paste(&mut self, text: &str) {
         let mut norm = text.replace("\r\n", "\n").replace('\r', "\n");
         match self.mode {

--- a/src/app.rs
+++ b/src/app.rs
@@ -383,6 +383,9 @@ pub enum Band {
 pub struct App {
     pub repo: PathBuf,
     pub base: Option<String>,
+    /// The `branch` scope's resolved base, carried by the latest landed snapshot — the
+    /// header names it and the diff builds against its OID (`specs/review-model.md`).
+    pub branch_base: Option<git::ResolvedBase>,
     pub scope: Scope,
     /// The active tab; it drives both panes and selects the per-tab state in play.
     pub tab: Tab,
@@ -612,6 +615,7 @@ impl App {
         Self {
             repo,
             base,
+            branch_base: None,
             scope,
             tab: Tab::Changes,
             active_file_tab: Tab::Changes,
@@ -980,7 +984,6 @@ impl App {
             tab: self.tab,
             scope: self.scope,
             base: self.base.clone(),
-            base_branches: self.config_snapshot().base_branches().to_vec(),
             turn_baseline: self.turn_baseline.clone(),
             // `Changes` never reads the toggled set, so it stays out of that tab's tag —
             // a directory toggle there must not invalidate an in-flight build.
@@ -1001,6 +1004,11 @@ impl App {
         let open = self.diff_path.clone();
         self.changed = snapshot.changed;
         self.entries = snapshot.entries;
+        // The base and the changeset it produced land together, so the header name and the
+        // list it heads never disagree (specs/tui.md).
+        if self.scope == Scope::Branch {
+            self.branch_base = snapshot.branch_base;
+        }
         self.rebuild_file_rows();
         self.file_cursor = anchor
             .and_then(|a| self.row_of_anchor(&a))
@@ -1210,11 +1218,8 @@ impl App {
                 (old, new)
             }
             Scope::Branch => {
-                let mb = git::merge_base(
-                    &self.repo,
-                    self.base.as_deref(),
-                    self.config_snapshot().base_branches(),
-                );
+                let mb =
+                    self.branch_base.as_ref().and_then(|b| git::merge_base(&self.repo, &b.oid));
                 let old =
                     mb.map(|m| git::file_content(&self.repo, &m, old_path)).unwrap_or_default();
                 (old, worktree_content(&self.repo, new_path))
@@ -1760,7 +1765,10 @@ impl App {
                 self.stash.select_anchor = None;
                 // `All files` keeps its tree; only the changed set rebuilds before the frame.
                 // The tree's annotations refresh behind it via the worker (specs/tui.md).
-                let changed = crate::world::build_changed(&self.world_input())?;
+                let (branch_base, changed) = crate::world::build_changed(&self.world_input())?;
+                if self.scope == Scope::Branch {
+                    self.branch_base = branch_base;
+                }
                 self.changed = crate::world::annotate(&changed);
                 // Re-mark the tree in place — the rows are scope-independent, only their
                 // badges move, so the switch frame never shows the old scope's badges

--- a/src/app.rs
+++ b/src/app.rs
@@ -431,6 +431,9 @@ pub struct App {
     /// The `branch` scope's resolved base, carried by the latest landed snapshot — the
     /// header names it and the diff builds against its OID (`specs/review-model.md`).
     pub branch_base: Option<git::ResolvedBase>,
+    /// Bumped by each pick made in this pane, so an in-flight build that read the old pick
+    /// fails the landing's input match instead of reverting the pick (`crate::world::WorldInput`).
+    base_epoch: u64,
     pub scope: Scope,
     /// The active tab; it drives both panes and selects the per-tab state in play.
     pub tab: Tab,
@@ -664,6 +667,7 @@ impl App {
             repo,
             base,
             branch_base: None,
+            base_epoch: 0,
             scope,
             tab: Tab::Changes,
             active_file_tab: Tab::Changes,
@@ -872,6 +876,10 @@ impl App {
                 self.reveal_files = old.reveal_files;
                 self.reveal_diff = old.reveal_diff;
                 self.changed = std::mem::take(&mut old.changed);
+                // The header's base label describes the carried list, so it carries too —
+                // a fresh app would paint `no base` beside a populated frame
+                // (`specs/tui.md`).
+                self.branch_base = old.branch_base.take();
                 self.diff = std::mem::take(&mut old.diff);
                 self.visible = std::mem::take(&mut old.visible);
                 self.expanded_folds = std::mem::take(&mut old.expanded_folds);
@@ -1036,6 +1044,7 @@ impl App {
             tab: self.tab,
             scope: self.scope,
             base: self.base.clone(),
+            base_epoch: self.base_epoch,
             turn_baseline: self.turn_baseline.clone(),
             // `Changes` never reads the toggled set, so it stays out of that tab's tag —
             // a directory toggle there must not invalidate an in-flight build.
@@ -3708,11 +3717,11 @@ impl App {
             self.status = e.0;
             return Ok(());
         }
+        // Epoch first: any build still in flight read the old pick, and the bump makes its
+        // landing fail the input match instead of reverting this one
+        // (`crate::world::WorldInput`).
+        self.base_epoch = self.base_epoch.wrapping_add(1);
         self.rebase_changes()?;
-        // The queued refresh's generation bump invalidates any in-flight build that read
-        // the old pick — the pick is derived state, not input identity, so the tag alone
-        // would not reject it (`specs/review-model.md`).
-        self.request_world_refresh(false, false);
         self.reveal_files = true;
         Ok(())
     }
@@ -4016,6 +4025,12 @@ mod tests {
             cursor: 0,
             query: "d".to_string(),
         });
+        old.branch_base = Some(crate::git::ResolvedBase {
+            name: "main".to_string(),
+            oid: "0".repeat(40),
+            source: crate::git::BaseSource::DefaultBranch,
+            skipped: None,
+        });
 
         let mut recovered = App::new(PathBuf::from("."), Scope::Branch, None);
         recovered.carry_authored_state_from(&mut old);
@@ -4023,6 +4038,10 @@ mod tests {
         let bp = recovered.base_picker.as_ref().expect("the picker state is carried");
         assert_eq!(bp.query, "d");
         assert_eq!(bp.rows[0].name, "dev");
+        // The header's base rides with the carried frame — recovery never paints
+        // `no base` beside a populated list (`specs/tui.md`).
+        let base = recovered.branch_base.as_ref().expect("the resolved base is carried");
+        assert_eq!(base.name, "main");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2692,11 +2692,16 @@ impl App {
     }
 
     /// Insert pasted `text` at the caret as one unit, normalizing `\r\n`/`\r` to `\n`.
-    /// The single-line search input takes newlines as spaces (specs/search.md).
+    /// A single-line field takes newlines as spaces (specs/search.md, specs/input.md) — a
+    /// branch name pasted with its trailing newline still filters.
     pub fn input_paste(&mut self, text: &str) {
         let mut norm = text.replace("\r\n", "\n").replace('\r', "\n");
-        if matches!(self.mode, Mode::Search | Mode::Find) {
-            norm = norm.replace('\n', " ");
+        match self.mode {
+            Mode::Search | Mode::Find => norm = norm.replace('\n', " "),
+            // No branch name holds a newline, so a name pasted with the one it was copied
+            // with filters as the bare name rather than matching nothing.
+            Mode::BasePick => norm.retain(|c| c != '\n'),
+            _ => {}
         }
         let norm: Vec<char> = norm.chars().collect();
         self.edit_input(|v, caret| {

--- a/src/app.rs
+++ b/src/app.rs
@@ -130,6 +130,9 @@ pub struct BasePicker {
     pub cursor: usize,
     /// The typed filter, matching anywhere in the name.
     pub query: String,
+    /// The caret in `query`, a char index — the filter edits with the comment editor's
+    /// controls, like every other text field (`specs/input.md`).
+    pub caret: usize,
 }
 
 /// One base picker row (`specs/input.md` Base picker).
@@ -144,8 +147,8 @@ pub struct BaseChoice {
 }
 
 impl BasePicker {
-    /// The filtered view: indices into `rows` whose names contain the query, the
-    /// case-insensitive anywhere-match the key table names (`specs/input.md`).
+    /// The filtered view: indices into `rows` whose name contains the query, matched
+    /// case-insensitively and anywhere in the name (`specs/input.md` Base picker).
     pub fn filtered(&self) -> Vec<usize> {
         let q = self.query.to_lowercase();
         (0..self.rows.len()).filter(|&i| self.rows[i].name.to_lowercase().contains(&q)).collect()
@@ -2625,13 +2628,14 @@ impl App {
     // character-wise and multi-byte safe.
 
     /// The mode's editable text and caret: the comment draft while composing, the search
-    /// query while the overlay is open, nothing otherwise.
+    /// query, the find query, the base picker's filter, nothing otherwise.
     fn active_field(&mut self) -> Option<(&mut String, &mut usize)> {
         match self.mode {
             Mode::Composing { .. } => Some((&mut self.input, &mut self.caret)),
             Mode::Search => self.search.as_mut().map(|s| (&mut s.query, &mut s.caret)),
             Mode::Find => self.find.as_mut().map(|f| (&mut f.query, &mut f.caret)),
-            Mode::Normal | Mode::List | Mode::Picker | Mode::BasePick => None,
+            Mode::BasePick => self.base_picker.as_mut().map(|b| (&mut b.query, &mut b.caret)),
+            Mode::Normal | Mode::List | Mode::Picker => None,
         }
     }
 
@@ -2642,6 +2646,9 @@ impl App {
     /// (specs/search.md).
     fn edit_input(&mut self, f: impl FnOnce(&mut Vec<char>, &mut usize)) {
         let searching = self.mode == Mode::Search;
+        // The highlighted branch's own row, read before the filter narrows under it.
+        let highlighted =
+            self.base_picker.as_ref().and_then(|bp| bp.filtered().get(bp.cursor).copied());
         let Some((text, caret_ref)) = self.active_field() else { return };
         let mut v: Vec<char> = text.chars().collect();
         let mut caret = (*caret_ref).min(v.len());
@@ -2653,6 +2660,18 @@ impl App {
         if searching && changed {
             self.search_dirty = true;
         }
+        if changed && self.mode == Mode::BasePick {
+            self.refilter_base_picker(highlighted);
+        }
+    }
+
+    /// Re-seat the base picker's highlight after a filter edit: it follows its own row into
+    /// the narrowed view when the row survives, else rests on the first match
+    /// (`specs/overview.md` Continuity).
+    fn refilter_base_picker(&mut self, highlighted: Option<usize>) {
+        let Some(bp) = self.base_picker.as_mut() else { return };
+        let filtered = bp.filtered();
+        bp.cursor = highlighted.and_then(|h| filtered.iter().position(|&i| i == h)).unwrap_or(0);
     }
 
     /// Move the caret with a function of the current `Vec<char>` view; a no-op without an
@@ -3655,7 +3674,7 @@ impl App {
         rows.sort_by_key(|r| (!r.starred, !r.is_default));
         let current = self.branch_base.winner.as_ref().map(|b| b.name.as_str());
         let cursor = current.and_then(|c| rows.iter().position(|r| r.name == c)).unwrap_or(0);
-        self.base_picker = Some(BasePicker { rows, cursor, query: String::new() });
+        self.base_picker = Some(BasePicker { rows, cursor, query: String::new(), caret: 0 });
         self.mode = Mode::BasePick;
     }
 
@@ -3683,28 +3702,6 @@ impl App {
         {
             bp.cursor = row;
         }
-    }
-
-    /// Append `ch` to the filter (`specs/input.md`).
-    pub fn base_picker_input(&mut self, ch: char) {
-        self.base_picker_edit(|q| q.push(ch));
-    }
-
-    /// Delete the last filter character (`specs/input.md`).
-    pub fn base_picker_backspace(&mut self) {
-        self.base_picker_edit(|q| {
-            q.pop();
-        });
-    }
-
-    /// Apply one filter edit. The highlight follows its row into the re-filtered view when
-    /// it survives, else rests on the first match (`specs/overview.md` Continuity).
-    fn base_picker_edit(&mut self, f: impl FnOnce(&mut String)) {
-        let Some(bp) = self.base_picker.as_mut() else { return };
-        let highlighted = bp.filtered().get(bp.cursor).copied();
-        f(&mut bp.query);
-        let filtered = bp.filtered();
-        bp.cursor = highlighted.and_then(|h| filtered.iter().position(|&i| i == h)).unwrap_or(0);
     }
 
     /// Pick the highlighted branch: persist it as the repo pick — or clear the pick when
@@ -4032,6 +4029,7 @@ mod tests {
             }],
             cursor: 0,
             query: "d".to_string(),
+            caret: 1,
         });
         old.branch_base = crate::git::BaseStatus {
             winner: Some(crate::git::ResolvedBase {

--- a/src/app.rs
+++ b/src/app.rs
@@ -428,9 +428,10 @@ pub enum Band {
 pub struct App {
     pub repo: PathBuf,
     pub base: Option<String>,
-    /// The `branch` scope's resolved base, carried by the latest landed snapshot — the
-    /// header names it and the diff builds against its OID (`specs/review-model.md`).
-    pub branch_base: Option<git::ResolvedBase>,
+    /// The `branch` scope's base outcome, carried by the latest landed snapshot — the
+    /// header names its winner (or the skip) and the diff builds against the winner's OID
+    /// (`specs/review-model.md`).
+    pub branch_base: git::BaseStatus,
     /// Bumped by each pick made in this pane, so an in-flight build that read the old pick
     /// fails the landing's input match instead of reverting the pick (`crate::world::WorldInput`).
     base_epoch: u64,
@@ -666,7 +667,7 @@ impl App {
         Self {
             repo,
             base,
-            branch_base: None,
+            branch_base: git::BaseStatus::default(),
             base_epoch: 0,
             scope,
             tab: Tab::Changes,
@@ -879,7 +880,7 @@ impl App {
                 // The header's base label describes the carried list, so it carries too —
                 // a fresh app would paint `no base` beside a populated frame
                 // (`specs/tui.md`).
-                self.branch_base = old.branch_base.take();
+                self.branch_base = std::mem::take(&mut old.branch_base);
                 self.diff = std::mem::take(&mut old.diff);
                 self.visible = std::mem::take(&mut old.visible);
                 self.expanded_folds = std::mem::take(&mut old.expanded_folds);
@@ -1279,8 +1280,11 @@ impl App {
                 (old, new)
             }
             Scope::Branch => {
-                let mb =
-                    self.branch_base.as_ref().and_then(|b| git::merge_base(&self.repo, &b.oid));
+                let mb = self
+                    .branch_base
+                    .winner
+                    .as_ref()
+                    .and_then(|b| git::merge_base(&self.repo, &b.oid));
                 let old =
                     mb.map(|m| git::file_content(&self.repo, &m, old_path)).unwrap_or_default();
                 (old, worktree_content(&self.repo, new_path))
@@ -3399,7 +3403,7 @@ impl App {
             // actions apply instead.
             out.push((A::Preview, Primary));
         } else if self.file_rows.is_empty()
-            && self.branch_base.is_none()
+            && self.branch_base.winner.is_none()
             && self.base_pick_available()
         {
             // The `branch` scope with no base: the picker is the way forward, and `b` would
@@ -3645,7 +3649,7 @@ impl App {
             .collect();
         // A stable sort, so recency still orders the promoted pair and the rest alike.
         rows.sort_by_key(|r| (!r.starred, !r.is_default));
-        let current = self.branch_base.as_ref().map(|b| b.name.as_str());
+        let current = self.branch_base.winner.as_ref().map(|b| b.name.as_str());
         let cursor = current.and_then(|c| rows.iter().position(|r| r.name == c)).unwrap_or(0);
         self.base_picker = Some(BasePicker { rows, cursor, query: String::new() });
         self.mode = Mode::BasePick;
@@ -4025,12 +4029,14 @@ mod tests {
             cursor: 0,
             query: "d".to_string(),
         });
-        old.branch_base = Some(crate::git::ResolvedBase {
-            name: "main".to_string(),
-            oid: "0".repeat(40),
-            source: crate::git::BaseSource::DefaultBranch,
+        old.branch_base = crate::git::BaseStatus {
+            winner: Some(crate::git::ResolvedBase {
+                name: "main".to_string(),
+                oid: "0".repeat(40),
+                source: crate::git::BaseSource::DefaultBranch,
+            }),
             skipped: None,
-        });
+        };
 
         let mut recovered = App::new(PathBuf::from("."), Scope::Branch, None);
         recovered.carry_authored_state_from(&mut old);
@@ -4040,7 +4046,7 @@ mod tests {
         assert_eq!(bp.rows[0].name, "dev");
         // The header's base rides with the carried frame — recovery never paints
         // `no base` beside a populated list (`specs/tui.md`).
-        let base = recovered.branch_base.as_ref().expect("the resolved base is carried");
+        let base = recovered.branch_base.winner.as_ref().expect("the resolved base is carried");
         assert_eq!(base.name, "main");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,24 +66,8 @@ impl Config {
     }
 }
 
-/// The built-in base-branch candidates for the `branch` scope, used when `config.toml`
-/// sets no `base_branches` (`specs/review-model.md`).
-pub const DEFAULT_BASE_BRANCHES: [&str; 2] = ["main", "master"];
-
-/// One `base_branches` entry's canonical bare branch name: a leading `refs/heads/`,
-/// `refs/remotes/origin/`, or `origin/` prefix is stripped (`specs/config.md`).
-pub(crate) fn canonical_base(entry: &str) -> String {
-    entry
-        .strip_prefix("refs/remotes/origin/")
-        .or_else(|| entry.strip_prefix("refs/heads/"))
-        .or_else(|| entry.strip_prefix("origin/"))
-        .unwrap_or(entry)
-        .to_string()
-}
-
-const PLUGIN_CONFIG_KEYS: [&str; 11] = [
+const PLUGIN_CONFIG_KEYS: [&str; 10] = [
     "theme",
-    "base_branches",
     "default_scope",
     "navigator_position",
     "toggle_placement",
@@ -173,7 +157,6 @@ impl ToggleDirection {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PluginConfig {
     theme: String,
-    base_branches: Vec<String>,
     default_scope: crate::model::Scope,
     navigator_position: NavigatorPosition,
     toggle_placement: TogglePlacement,
@@ -189,7 +172,6 @@ impl Default for PluginConfig {
     fn default() -> Self {
         Self {
             theme: crate::theme::DEFAULT.to_owned(),
-            base_branches: DEFAULT_BASE_BRANCHES.iter().map(|s| (*s).to_owned()).collect(),
             default_scope: crate::model::Scope::Uncommitted,
             navigator_position: NavigatorPosition::Right,
             toggle_placement: TogglePlacement::Split,
@@ -206,10 +188,6 @@ impl Default for PluginConfig {
 impl PluginConfig {
     pub fn theme(&self) -> &str {
         &self.theme
-    }
-
-    pub fn base_branches(&self) -> &[String] {
-        &self.base_branches
     }
 
     /// The scope a fresh reviewr pane is built with — startup and config recovery. A reread never
@@ -273,7 +251,6 @@ impl PluginConfig {
             .collect();
         serde_json::json!({
             "theme": self.theme,
-            "base_branches": self.base_branches,
             "default_scope": self.default_scope.name(),
             "navigator_position": self.navigator_position.as_str(),
             "toggle_placement": self.toggle_placement.as_str(),
@@ -367,44 +344,6 @@ fn parse_plugin_config(path: &Path) -> Result<PluginConfig, PluginConfigError> {
             ));
         }
         theme.clone_into(&mut config.theme);
-    }
-    if let Some(value) = table.get("base_branches") {
-        let Some(values) = value.as_array() else {
-            return Err(value_error(
-                path,
-                "base_branches",
-                "a non-empty array of non-empty strings",
-            ));
-        };
-        if values.is_empty() {
-            return Err(value_error(
-                path,
-                "base_branches",
-                "a non-empty array of non-empty strings",
-            ));
-        }
-        let mut branches = Vec::with_capacity(values.len());
-        for value in values {
-            let Some(branch) = value.as_str() else {
-                return Err(value_error(
-                    path,
-                    "base_branches",
-                    "a non-empty array of non-empty strings",
-                ));
-            };
-            if !valid_ref_name(branch) {
-                return Err(value_error(
-                    path,
-                    "base_branches",
-                    "a non-empty array of Git ref names",
-                ));
-            }
-            let canonical = canonical_base(branch);
-            if !branches.contains(&canonical) {
-                branches.push(canonical);
-            }
-        }
-        config.base_branches = branches;
     }
     if let Some(value) = table.get("default_scope") {
         config.default_scope = match string_value(
@@ -648,28 +587,6 @@ pub(crate) fn valid_host_syntax(host: &str) -> bool {
     })
 }
 
-/// Git's `check-ref-format --allow-onelevel` rules, used without spawning Git from the shared
-/// configuration boundary. Base entries are names, not revision expressions.
-fn valid_ref_name(name: &str) -> bool {
-    !name.is_empty()
-        && name != "@"
-        && !name.starts_with('-')
-        && !name.starts_with('/')
-        && !name.ends_with('/')
-        && !name.ends_with('.')
-        && !name.contains("//")
-        && !name.contains("..")
-        && !name.contains("@{")
-        && name
-            .split('/')
-            .all(|part| !part.starts_with('.') && part.strip_suffix(".lock").is_none())
-        && name.bytes().all(|byte| {
-            byte > b' '
-                && byte != 0x7f
-                && !matches!(byte, b'~' | b'^' | b':' | b'?' | b'*' | b'[' | b'\\')
-        })
-}
-
 /// Print the shared normalized configuration for the plugin action script. This is its own
 /// entrypoint (`--resolve-plugin-config`), so it resolves the config directory itself — and
 /// initializes the log itself, or the herdr-side diagnostics of a failed lookup would be
@@ -749,7 +666,6 @@ mod tests {
         std::fs::write(dir.path().join("config.toml"), "theme = \"gruvbox\"\n").unwrap();
         let config = super::plugin_config_in(dir.path()).unwrap();
         assert_eq!(config.theme(), "gruvbox");
-        assert_eq!(config.base_branches(), PluginConfig::default().base_branches());
         assert_eq!(config.default_scope(), Scope::Uncommitted);
         assert_eq!(config.navigator_position(), NavigatorPosition::Right);
         assert_eq!(config.toggle_placement(), TogglePlacement::Split);
@@ -765,7 +681,6 @@ mod tests {
             dir.path().join("config.toml"),
             concat!(
                 "theme = \"tokyo-night\"\n",
-                "base_branches = [\"origin/dev\", \"main\"]\n",
                 "default_scope = \"last-turn\"\n",
                 "navigator_position = \"bottom\"\n",
                 "toggle_placement = \"overlay\"\n",
@@ -777,30 +692,12 @@ mod tests {
         .unwrap();
         let config = super::plugin_config_in(dir.path()).unwrap();
         assert_eq!(config.theme(), "tokyo-night");
-        // Entries canonicalize to bare names at validation (`specs/config.md`).
-        assert_eq!(config.base_branches(), ["dev", "main"]);
         assert_eq!(config.default_scope(), Scope::LastTurn);
         assert_eq!(config.navigator_position(), NavigatorPosition::Bottom);
         assert_eq!(config.toggle_placement(), TogglePlacement::Overlay);
         assert_eq!(config.toggle_direction(), ToggleDirection::Down);
         assert!(!config.auto_open());
         assert_eq!(config.github_host(), Some("github.example.com"));
-    }
-
-    #[test]
-    fn base_entries_canonicalize_and_duplicates_collapse_to_the_first() {
-        assert_eq!(super::canonical_base("origin/main"), "main");
-        assert_eq!(super::canonical_base("refs/heads/main"), "main");
-        assert_eq!(super::canonical_base("refs/remotes/origin/main"), "main");
-        assert_eq!(super::canonical_base("release/1.0"), "release/1.0");
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("config.toml"),
-            "base_branches = [\"origin/main\", \"main\", \"refs/heads/master\"]\n",
-        )
-        .unwrap();
-        let config = super::plugin_config_in(dir.path()).unwrap();
-        assert_eq!(config.base_branches(), ["main", "master"]);
     }
 
     #[test]
@@ -812,6 +709,12 @@ mod tests {
         assert!(error.contains(path.to_str().unwrap()));
         assert!(error.contains("unknown key \"poll\""));
 
+        // The retired `base_branches` key fails like any unknown key: the base is a picked,
+        // per-repo choice now, never configuration (`specs/config.md`, `specs/review-model.md`).
+        std::fs::write(&path, "base_branches = [\"dev\"]\n").unwrap();
+        let error = super::plugin_config_in(dir.path()).unwrap_err().to_string();
+        assert!(error.contains("unknown key \"base_branches\""));
+
         std::fs::write(&path, "theme = [\n").unwrap();
         assert!(
             super::plugin_config_in(dir.path()).unwrap_err().to_string().contains("syntax error")
@@ -822,12 +725,6 @@ mod tests {
     fn every_invalid_value_fails_instead_of_falling_back() {
         let cases = [
             ("theme = \"unknown\"\n", "`theme`"),
-            ("base_branches = []\n", "`base_branches`"),
-            ("base_branches = [\"\"]\n", "`base_branches`"),
-            ("base_branches = [\"main^{commit}\"]\n", "`base_branches`"),
-            ("base_branches = [\"feature branch\"]\n", "`base_branches`"),
-            ("base_branches = [\"-main\"]\n", "`base_branches`"),
-            ("base_branches = [\"main\", 1]\n", "`base_branches`"),
             ("default_scope = \"weekly\"\n", "`default_scope`"),
             ("default_scope = \"last turn\"\n", "`default_scope`"),
             ("navigator_position = \"center\"\n", "`navigator_position`"),

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -472,7 +472,7 @@ fn fetch_input_inner(
             local: crate::git::PrLocalState::default(),
         });
     };
-    let local = match crate::git::pr_local(repo, base, config.base_branches()) {
+    let local = match crate::git::pr_local(repo, base) {
         Ok(local) => local,
         Err(error) => {
             let (current, _) = crate::git::remote_identities(repo, &config.forge_hosts())

--- a/src/git.rs
+++ b/src/git.rs
@@ -927,6 +927,7 @@ fn branch_name_shaped(value: &str) -> bool {
         && !value.starts_with('-')
         && !value.contains("..")
         && !value.contains("@{")
+        && !value.contains(['~', '^', ':', '?', '*', '[', '\\'])
         && value.bytes().all(|byte| byte > b' ' && byte != 0x7f)
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -495,23 +495,20 @@ pub struct PrLocalState {
 
 /// Derive the pinned `HEAD`, the pinned base, and the branch's forge names
 /// (`specs/forge-host.md` Resolution).
-pub fn pr_local(
-    repo: &Path,
-    base_flag: Option<&str>,
-    config_bases: &[String],
-) -> Result<PrLocalState, GitFail> {
+pub fn pr_local(repo: &Path, base_flag: Option<&str>) -> Result<PrLocalState, GitFail> {
     let Some(branch) = git_tristate(repo, &["symbolic-ref", "--quiet", "--short", "HEAD"])? else {
         return Ok(PrLocalState { detached: true, ..PrLocalState::default() });
     };
     let head_oid = git_tristate(repo, &["rev-parse", "--verify", "--quiet", "HEAD^{commit}"])?;
-    let bases = resolve_bases(repo, base_flag, config_bases)?;
+    let resolution = resolve_base(repo, base_flag)?;
+    let bases = resolution.oids();
     let mut names = vec![branch.clone()];
     let push_name = |name: String, names: &mut Vec<String>| {
         if !names.contains(&name) {
             names.push(name);
         }
     };
-    if let Some(upstream) = recorded_upstream(repo, &branch, base_flag, config_bases, &bases)? {
+    if let Some(upstream) = recorded_upstream(repo, &branch, &resolution.names(), &bases)? {
         push_name(upstream, &mut names);
     }
     if let Some(head) = &head_oid
@@ -526,43 +523,137 @@ pub fn pr_local(
     Ok(PrLocalState { head_oid, base_oid: bases.into_iter().next(), names, detached: false })
 }
 
-/// Every resolved base OID in precedence order, deduped: the `--base` flag (verbatim rev
-/// first, then as a canonical entry), each canonical `config_bases` entry, then the default
-/// branch `origin/HEAD` names (`specs/review-model.md`). Frontier names must lie beyond all of them.
-fn resolve_bases(
-    repo: &Path,
-    base_flag: Option<&str>,
-    config_bases: &[String],
-) -> Result<Vec<String>, GitFail> {
-    let mut out: Vec<String> = Vec::new();
-    let push = |oid: Option<String>, out: &mut Vec<String>| {
-        if let Some(oid) = oid
-            && !out.contains(&oid)
-        {
-            out.push(oid);
+/// Where the winning base came from (`specs/review-model.md` Base branch).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BaseSource {
+    Flag,
+    Pick,
+    DefaultBranch,
+}
+
+/// The `branch` scope's base as the header shows it: the winning source's bare name, its
+/// pinned commit, and the first recorded choice the chain skipped because it no longer
+/// resolves (`specs/review-model.md` Base branch, `specs/tui.md`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedBase {
+    pub name: String,
+    pub oid: String,
+    pub source: BaseSource,
+    pub skipped: Option<String>,
+}
+
+/// One pass over the base chain. `candidates` keeps every source that resolved, in
+/// precedence order and deduped by OID — the PR frontier walk needs all of them, not just
+/// the winner (`pr_local`).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BaseResolution {
+    pub winner: Option<ResolvedBase>,
+    pub candidates: Vec<(String, String)>,
+}
+
+impl BaseResolution {
+    pub fn oids(&self) -> Vec<String> {
+        self.candidates.iter().map(|(_, oid)| oid.clone()).collect()
+    }
+    fn names(&self) -> Vec<String> {
+        self.candidates.iter().map(|(name, _)| name.clone()).collect()
+    }
+}
+
+/// Resolve the base chain: the `--base` flag, then the repo pick, then the branch
+/// `origin/HEAD` names (`specs/review-model.md` Base branch). A source that resolves to no
+/// ref is skipped, never an error; a skipped flag or pick that would have outranked the
+/// winner is recorded for the header (`specs/tui.md`).
+pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResolution, GitFail> {
+    let mut candidates: Vec<(String, String, BaseSource)> = Vec::new();
+    let mut skipped: Option<String> = None;
+    let push = |name: String, oid: String, source: BaseSource, c: &mut Vec<_>| {
+        if !c.iter().any(|(_, o, _): &(String, String, BaseSource)| *o == oid) {
+            c.push((name, oid, source));
         }
     };
     if let Some(flag) = base_flag.filter(|b| !b.is_empty()) {
         // The flag is the power-user escape hatch: any rev works verbatim (a SHA, a tag,
-        // `upstream/main`), and a branch-entry spelling falls back to canonical resolution.
+        // `upstream/main`), and a branch-name spelling falls back to prefix-stripped
+        // resolution.
         let probe = format!("{flag}^{{commit}}");
-        let verbatim = git_tristate(repo, &["rev-parse", "--verify", "--quiet", &probe])?;
-        if let Some(oid) = verbatim {
-            push(Some(oid), &mut out);
+        if let Some(oid) = git_tristate(repo, &["rev-parse", "--verify", "--quiet", &probe])? {
+            push(flag.to_string(), oid, BaseSource::Flag, &mut candidates);
         } else {
-            let entry = crate::config::canonical_base(flag);
-            push(resolve_base_entry(repo, &entry)?, &mut out);
+            let entry = strip_base_prefix(flag);
+            match resolve_base_entry(repo, &entry)? {
+                Some(oid) => push(entry, oid, BaseSource::Flag, &mut candidates),
+                None => skipped = Some(flag.to_string()),
+            }
         }
     }
-    for entry in config_bases {
-        push(resolve_base_entry(repo, entry)?, &mut out);
+    if let Some(pick) = read_base_pick(repo)? {
+        match resolve_base_entry(repo, &pick)? {
+            Some(oid) => push(pick, oid, BaseSource::Pick, &mut candidates),
+            // Only a failure that outranks the eventual winner reads as skipped.
+            None if candidates.is_empty() => skipped = skipped.or(Some(pick)),
+            None => {}
+        }
     }
-    let default_branch = git_tristate(
+    if let Some(name) = default_branch_name(repo)?
+        && let Some(oid) = resolve_base_entry(repo, &name)?
+    {
+        push(name, oid, BaseSource::DefaultBranch, &mut candidates);
+    }
+    let winner = candidates.first().map(|(name, oid, source)| ResolvedBase {
+        name: name.clone(),
+        oid: oid.clone(),
+        source: *source,
+        skipped: skipped.clone(),
+    });
+    let candidates = candidates.into_iter().map(|(name, oid, _)| (name, oid)).collect();
+    Ok(BaseResolution { winner, candidates })
+}
+
+/// The branch name `origin/HEAD` points at, when the symref is present
+/// (`specs/review-model.md` Base branch).
+pub fn default_branch_name(repo: &Path) -> Result<Option<String>, GitFail> {
+    let target = git_tristate(repo, &["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])?;
+    Ok(target.and_then(|t| t.strip_prefix("refs/remotes/origin/").map(str::to_string)))
+}
+
+/// Strip the ref prefixes a `--base` branch name may carry (`specs/review-model.md`).
+pub(crate) fn strip_base_prefix(entry: &str) -> String {
+    ["refs/remotes/origin/", "refs/heads/", "origin/"]
+        .iter()
+        .find_map(|p| entry.strip_prefix(p))
+        .unwrap_or(entry)
+        .to_string()
+}
+
+/// Every branch name for the base picker: `refs/heads` and `refs/remotes/origin` merged by
+/// bare name, newest commit first, `origin/HEAD` and the checked-out branch excluded
+/// (`specs/input.md` Base picker).
+pub fn list_branches(repo: &Path) -> Result<Vec<String>, GitFail> {
+    let checked_out = git_tristate(repo, &["symbolic-ref", "--quiet", "--short", "HEAD"])?;
+    let out = git_strict(
         repo,
-        &["rev-parse", "--verify", "--quiet", "refs/remotes/origin/HEAD^{commit}"],
+        &[
+            "for-each-ref",
+            "refs/heads",
+            "refs/remotes/origin",
+            "--sort=-committerdate",
+            "--format=%(refname)",
+        ],
     )?;
-    push(default_branch, &mut out);
-    Ok(out)
+    let mut names: Vec<String> = Vec::new();
+    for line in out.lines() {
+        let name =
+            line.strip_prefix("refs/remotes/origin/").or_else(|| line.strip_prefix("refs/heads/"));
+        let Some(name) = name else { continue };
+        if name == "HEAD" || checked_out.as_deref() == Some(name) {
+            continue;
+        }
+        if !names.iter().any(|n| n == name) {
+            names.push(name.to_string());
+        }
+    }
+    Ok(names)
 }
 
 /// The `origin` remote-tracking tips as `(OID, bare name)`, `origin/HEAD` excluded — one
@@ -695,8 +786,8 @@ fn remote_identity(
     Err(GitFail(format!("git {args:?}: {}", stderr.trim())))
 }
 
-/// One canonical `base_branches` entry pinned to an OID: `refs/remotes/origin/<name>`,
-/// then `refs/heads/<name>` (`specs/config.md`).
+/// One base branch name pinned to an OID: `refs/remotes/origin/<name>`, then
+/// `refs/heads/<name>` (`specs/review-model.md` Base branch).
 fn resolve_base_entry(repo: &Path, name: &str) -> Result<Option<String>, GitFail> {
     for prefix in ["refs/remotes/origin/", "refs/heads/"] {
         let probe = format!("{prefix}{name}^{{commit}}");
@@ -718,8 +809,7 @@ fn resolve_base_entry(repo: &Path, name: &str) -> Result<Option<String>, GitFail
 fn recorded_upstream(
     repo: &Path,
     branch: &str,
-    base_flag: Option<&str>,
-    config_bases: &[String],
+    base_names: &[String],
     base_oids: &[String],
 ) -> Result<Option<String>, GitFail> {
     let out = git_strict(
@@ -729,10 +819,7 @@ fn recorded_upstream(
     let dest = out.lines().next().unwrap_or("").trim();
     let Some(rest) = dest.strip_prefix("refs/remotes/") else { return Ok(None) };
     let Some((_, name)) = rest.split_once('/') else { return Ok(None) };
-    if name.is_empty()
-        || config_bases.iter().any(|entry| entry == name)
-        || base_flag.is_some_and(|flag| crate::config::canonical_base(flag) == name)
-    {
+    if name.is_empty() || base_names.iter().any(|entry| entry == name) {
         return Ok(None);
     }
     // A pruned upstream ref no longer resolves; the record still carries the name
@@ -772,17 +859,79 @@ pub fn ahead_behind_oids(
     Ok(Some((ahead, behind)))
 }
 
-/// The merge-base commit of the winning base and `HEAD` using one base-config snapshot.
-/// Base entries resolve per `specs/review-model.md` precedence, `origin/HEAD` last.
-pub fn merge_base(repo: &Path, base: Option<&str>, config_bases: &[String]) -> Option<String> {
-    let base = resolve_bases(repo, base, config_bases).ok()?.into_iter().next()?;
-    git_line(repo, &["merge-base", &base, "HEAD"])
+/// The merge-base commit of the resolved base OID and `HEAD`
+/// (`specs/review-model.md` Base branch).
+pub fn merge_base(repo: &Path, base_oid: &str) -> Option<String> {
+    git_line(repo, &["merge-base", base_oid, "HEAD"])
 }
 
 /// The content of `path` at `rev` (`git show <rev>:<path>`). Empty when the path does
 /// not exist at that rev — an added file against its old side, say.
 pub fn file_content(repo: &Path, rev: &str, path: &str) -> String {
     git_lenient(repo, &["show", &format!("{rev}:{path}")])
+}
+
+// --- base pick (branch scope) --------------------------------------------------
+//
+// See `specs/review-model.md` Base branch. The pick is one branch name per repository:
+// a blob under one private ref, and refs are shared across a repository's worktrees, so
+// every pane reads the same pick.
+
+const BASE_PICK_REF: &str = "refs/reviewr/base-pick";
+
+/// The recorded pick's branch name, or `None` when no pick is recorded.
+pub fn read_base_pick(repo: &Path) -> Result<Option<String>, GitFail> {
+    if git_tristate(repo, &["rev-parse", "--verify", "--quiet", BASE_PICK_REF])?.is_none() {
+        return Ok(None);
+    }
+    let name = git_strict(repo, &["cat-file", "blob", BASE_PICK_REF])?;
+    let name = name.trim();
+    Ok((!name.is_empty()).then(|| name.to_string()))
+}
+
+/// Record `name` as the repository's pick. The ref write lands before the pick applies
+/// (`specs/review-model.md`), so a crash between the two loses nothing.
+pub fn write_base_pick(repo: &Path, name: &str) -> Result<(), GitFail> {
+    let blob = git_stdin(repo, &["hash-object", "-w", "--stdin"], name)?;
+    git_strict(repo, &["update-ref", BASE_PICK_REF, blob.trim()])?;
+    Ok(())
+}
+
+/// Drop the recorded pick — choosing the default branch clears it
+/// (`specs/review-model.md`).
+pub fn clear_base_pick(repo: &Path) -> Result<(), GitFail> {
+    git_strict(repo, &["update-ref", "-d", BASE_PICK_REF])?;
+    Ok(())
+}
+
+/// Run git with `input` piped to stdin, any non-zero exit a failure.
+fn git_stdin(repo: &Path, args: &[&str], input: &str) -> Result<String, GitFail> {
+    use std::io::Write;
+    use std::process::Stdio;
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .env("LC_ALL", "C")
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| GitFail(format!("git {args:?}: {e}")))?;
+    child
+        .stdin
+        .take()
+        .expect("stdin piped")
+        .write_all(input.as_bytes())
+        .map_err(|e| GitFail(format!("git {args:?}: {e}")))?;
+    let out = child.wait_with_output().map_err(|e| GitFail(format!("git {args:?}: {e}")))?;
+    if !out.status.success() {
+        return Err(GitFail(format!(
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
 // --- turn baseline (last-turn scope) -------------------------------------------
@@ -897,13 +1046,13 @@ fn diff_base(repo: &Path) -> String {
     }
 }
 
-/// The changed files for `scope`, sorted by path. `base` overrides the base-config snapshot.
+/// The changed files for `scope`, sorted by path. `branch_base` is the resolved base OID
+/// for the `branch` scope ([`resolve_base`]'s winner); with none the scope lists nothing.
 /// `last-turn` is resolved separately by [`changed_against_tree`], so it lists nothing here.
 pub fn changed_files(
     repo: &Path,
     scope: Scope,
-    base: Option<&str>,
-    config_bases: &[String],
+    branch_base: Option<&str>,
 ) -> Result<Vec<ChangedFile>> {
     let (numstat, name_status) = match scope {
         Scope::Uncommitted => {
@@ -915,7 +1064,7 @@ pub fn changed_files(
                 git(repo, &["diff", &base, "--name-status", "-z"])?,
             )
         }
-        Scope::Branch => match merge_base(repo, base, config_bases) {
+        Scope::Branch => match branch_base.and_then(|b| merge_base(repo, b)) {
             Some(r) => (
                 git(repo, &["diff", &r, "--numstat", "-z"])?,
                 git(repo, &["diff", &r, "--name-status", "-z"])?,

--- a/src/git.rs
+++ b/src/git.rs
@@ -508,7 +508,7 @@ pub fn pr_local(repo: &Path, base_flag: Option<&str>) -> Result<PrLocalState, Gi
             names.push(name);
         }
     };
-    if let Some(upstream) = recorded_upstream(repo, &branch, &resolution.names(), &bases)? {
+    if let Some(upstream) = recorded_upstream(repo, &branch, &resolution.base_names(), &bases)? {
         push_name(upstream, &mut names);
     }
     if let Some(head) = &head_oid
@@ -544,19 +544,30 @@ pub struct ResolvedBase {
 
 /// One pass over the base chain. `candidates` keeps every source that resolved, in
 /// precedence order and deduped by OID — the PR frontier walk needs all of them, not just
-/// the winner (`pr_local`).
+/// the winner (`pr_local`). `recorded` keeps every source name the chain considered,
+/// resolved or not — a dormant pick still shields its name from the PR name lookup
+/// (`specs/forge-host.md` Resolution).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BaseResolution {
     pub winner: Option<ResolvedBase>,
     pub candidates: Vec<(String, String)>,
+    pub recorded: Vec<String>,
 }
 
 impl BaseResolution {
     pub fn oids(&self) -> Vec<String> {
         self.candidates.iter().map(|(_, oid)| oid.clone()).collect()
     }
-    fn names(&self) -> Vec<String> {
-        self.candidates.iter().map(|(name, _)| name.clone()).collect()
+    /// The names the PR lookup must not treat as this branch's own: every resolved
+    /// candidate and every recorded choice (`specs/forge-host.md` Resolution).
+    fn base_names(&self) -> Vec<String> {
+        let mut names = self.recorded.clone();
+        for (name, _) in &self.candidates {
+            if !names.contains(name) {
+                names.push(name.clone());
+            }
+        }
+        names
     }
 }
 
@@ -566,21 +577,28 @@ impl BaseResolution {
 /// winner is recorded for the header (`specs/tui.md`).
 pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResolution, GitFail> {
     let mut candidates: Vec<(String, String, BaseSource)> = Vec::new();
+    let mut recorded: Vec<String> = Vec::new();
     let mut skipped: Option<String> = None;
     let push = |name: String, oid: String, source: BaseSource, c: &mut Vec<_>| {
         if !c.iter().any(|(_, o, _): &(String, String, BaseSource)| *o == oid) {
             c.push((name, oid, source));
         }
     };
+    let record = |name: String, r: &mut Vec<String>| {
+        if !name.is_empty() && !r.contains(&name) {
+            r.push(name);
+        }
+    };
     if let Some(flag) = base_flag.filter(|b| !b.is_empty()) {
         // The flag is the power-user escape hatch: any rev works verbatim (a SHA, a tag,
         // `upstream/main`), and a branch-name spelling falls back to prefix-stripped
-        // resolution.
+        // resolution. The header and the name shield use the bare spelling either way.
+        let entry = strip_base_prefix(flag);
+        record(entry.clone(), &mut recorded);
         let probe = format!("{flag}^{{commit}}");
         if let Some(oid) = git_tristate(repo, &["rev-parse", "--verify", "--quiet", &probe])? {
-            push(flag.to_string(), oid, BaseSource::Flag, &mut candidates);
+            push(entry, oid, BaseSource::Flag, &mut candidates);
         } else {
-            let entry = strip_base_prefix(flag);
             match resolve_base_entry(repo, &entry)? {
                 Some(oid) => push(entry, oid, BaseSource::Flag, &mut candidates),
                 None => skipped = Some(flag.to_string()),
@@ -588,6 +606,7 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
         }
     }
     if let Some(pick) = read_base_pick(repo)? {
+        record(pick.clone(), &mut recorded);
         match resolve_base_entry(repo, &pick)? {
             Some(oid) => push(pick, oid, BaseSource::Pick, &mut candidates),
             // Only a failure that outranks the eventual winner reads as skipped.
@@ -595,10 +614,11 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
             None => {}
         }
     }
-    if let Some(name) = default_branch_name(repo)?
-        && let Some(oid) = resolve_base_entry(repo, &name)?
-    {
-        push(name, oid, BaseSource::DefaultBranch, &mut candidates);
+    if let Some(name) = default_branch_name(repo)? {
+        record(name.clone(), &mut recorded);
+        if let Some(oid) = resolve_base_entry(repo, &name)? {
+            push(name, oid, BaseSource::DefaultBranch, &mut candidates);
+        }
     }
     let winner = candidates.first().map(|(name, oid, source)| ResolvedBase {
         name: name.clone(),
@@ -607,14 +627,27 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
         skipped: skipped.clone(),
     });
     let candidates = candidates.into_iter().map(|(name, oid, _)| (name, oid)).collect();
-    Ok(BaseResolution { winner, candidates })
+    Ok(BaseResolution { winner, candidates, recorded })
 }
 
-/// The branch name `origin/HEAD` points at, when the symref is present
-/// (`specs/review-model.md` Base branch).
+/// The branch name `origin/HEAD` points at (`specs/review-model.md` Base branch). Some
+/// clones carry `origin/HEAD` as a plain ref instead of a symref — then the name is the
+/// origin tip whose commit matches it.
 pub fn default_branch_name(repo: &Path) -> Result<Option<String>, GitFail> {
     let target = git_tristate(repo, &["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])?;
-    Ok(target.and_then(|t| t.strip_prefix("refs/remotes/origin/").map(str::to_string)))
+    if let Some(name) =
+        target.and_then(|t| t.strip_prefix("refs/remotes/origin/").map(str::to_string))
+    {
+        return Ok(Some(name));
+    }
+    let Some(oid) = git_tristate(
+        repo,
+        &["rev-parse", "--verify", "--quiet", "refs/remotes/origin/HEAD^{commit}"],
+    )?
+    else {
+        return Ok(None);
+    };
+    Ok(origin_tips(repo)?.into_iter().find_map(|(tip, name)| (tip == oid).then_some(name)))
 }
 
 /// Strip the ref prefixes a `--base` branch name may carry (`specs/review-model.md`).
@@ -627,10 +660,13 @@ pub(crate) fn strip_base_prefix(entry: &str) -> String {
 }
 
 /// Every branch name for the base picker: `refs/heads` and `refs/remotes/origin` merged by
-/// bare name, newest commit first, `origin/HEAD` and the checked-out branch excluded
-/// (`specs/input.md` Base picker).
+/// bare name, newest commit first, `origin/HEAD` and the checked-out branch excluded —
+/// except the default branch, which stays listed so its row can clear a pick even while
+/// checked out (`specs/input.md` Base picker).
 pub fn list_branches(repo: &Path) -> Result<Vec<String>, GitFail> {
-    let checked_out = git_tristate(repo, &["symbolic-ref", "--quiet", "--short", "HEAD"])?;
+    let default = default_branch_name(repo)?;
+    let checked_out = git_tristate(repo, &["symbolic-ref", "--quiet", "--short", "HEAD"])?
+        .filter(|name| default.as_deref() != Some(name));
     let out = git_strict(
         repo,
         &[
@@ -879,12 +915,16 @@ pub fn file_content(repo: &Path, rev: &str, path: &str) -> String {
 
 const BASE_PICK_REF: &str = "refs/reviewr/base-pick";
 
-/// The recorded pick's branch name, or `None` when no pick is recorded.
+/// The recorded pick's branch name, or `None` when no pick is recorded. One git call, so a
+/// concurrent clear from another pane can never split the read the way an exists-then-read
+/// pair would; a failed read is no pick, matching the chain's skip-never-error contract
+/// (`specs/review-model.md`).
 pub fn read_base_pick(repo: &Path) -> Result<Option<String>, GitFail> {
-    if git_tristate(repo, &["rev-parse", "--verify", "--quiet", BASE_PICK_REF])?.is_none() {
+    let out = run_git(repo, &["cat-file", "blob", BASE_PICK_REF])?;
+    if !out.status.success() {
         return Ok(None);
     }
-    let name = git_strict(repo, &["cat-file", "blob", BASE_PICK_REF])?;
+    let name = String::from_utf8_lossy(&out.stdout);
     let name = name.trim();
     Ok((!name.is_empty()).then(|| name.to_string()))
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -531,14 +531,22 @@ pub enum BaseSource {
     DefaultBranch,
 }
 
-/// The `branch` scope's base as the header shows it: the winning source's bare name, its
-/// pinned commit, and the first recorded choice the chain skipped because it no longer
-/// resolves (`specs/review-model.md` Base branch, `specs/tui.md`).
+/// The winning base: the source's bare name and its pinned commit
+/// (`specs/review-model.md` Base branch).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedBase {
     pub name: String,
     pub oid: String,
     pub source: BaseSource,
+}
+
+/// The chain outcome the header paints: the winner and the first recorded choice the
+/// chain skipped because it no longer resolves. The skip rides beside the winner, not
+/// inside it, so it survives a chain where nothing resolves at all — a dormant pick
+/// never reads as never-chosen (`specs/tui.md`).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BaseStatus {
+    pub winner: Option<ResolvedBase>,
     pub skipped: Option<String>,
 }
 
@@ -549,7 +557,7 @@ pub struct ResolvedBase {
 /// (`specs/forge-host.md` Resolution).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BaseResolution {
-    pub winner: Option<ResolvedBase>,
+    pub status: BaseStatus,
     pub candidates: Vec<(String, String)>,
     pub recorded: Vec<String>,
 }
@@ -624,10 +632,9 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
         name: name.clone(),
         oid: oid.clone(),
         source: *source,
-        skipped: skipped.clone(),
     });
     let candidates = candidates.into_iter().map(|(name, oid, _)| (name, oid)).collect();
-    Ok(BaseResolution { winner, candidates, recorded })
+    Ok(BaseResolution { status: BaseStatus { winner, skipped }, candidates, recorded })
 }
 
 /// The branch name `origin/HEAD` points at (`specs/review-model.md` Base branch). Some
@@ -638,7 +645,12 @@ pub fn default_branch_name(repo: &Path) -> Result<Option<String>, GitFail> {
     if let Some(name) =
         target.and_then(|t| t.strip_prefix("refs/remotes/origin/").map(str::to_string))
     {
-        return Ok(Some(name));
+        // `fetch --prune` can delete the target and leave the symref dangling: a name
+        // that resolves to nothing is no default, or the picker could never mark the
+        // clearing row and the name shield would carry a phantom (`specs/input.md`).
+        let probe = format!("refs/remotes/origin/{name}^{{commit}}");
+        let resolves = git_tristate(repo, &["rev-parse", "--verify", "--quiet", &probe])?;
+        return Ok(resolves.map(|_| name));
     }
     let Some(oid) = git_tristate(
         repo,

--- a/src/git.rs
+++ b/src/git.rs
@@ -549,12 +549,12 @@ pub struct BaseStatus {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BaseResolution {
     pub status: BaseStatus,
-    pub candidates: Vec<(String, String)>,
-    pub recorded: Vec<String>,
+    candidates: Vec<(String, String)>,
+    recorded: Vec<String>,
 }
 
 impl BaseResolution {
-    pub fn oids(&self) -> Vec<String> {
+    fn oids(&self) -> Vec<String> {
         self.candidates.iter().map(|(_, oid)| oid.clone()).collect()
     }
 }
@@ -589,7 +589,7 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
         } else {
             match resolve_base_entry(repo, &entry)? {
                 Some(oid) => push(entry, oid, &mut candidates),
-                None => skipped = Some(flag.to_string()),
+                None => skipped = Some(entry),
             }
         }
     }
@@ -914,7 +914,20 @@ pub fn read_base_pick(repo: &Path) -> Result<Option<String>, GitFail> {
     }
     let name = String::from_utf8_lossy(&out.stdout);
     let name = name.trim();
-    Ok((!name.is_empty()).then(|| name.to_string()))
+    Ok(branch_name_shaped(name).then(|| name.to_string()))
+}
+
+/// Whether a recorded pick is shaped like the branch name reviewr writes there. The ref is
+/// shared repository state any tool can write, and a pick that resolves to nothing still
+/// paints its name in the header, so a value git could never have produced is no pick at
+/// all — the chain's skip-never-error contract (`specs/review-model.md`), and the rule git
+/// itself applies to a refname.
+fn branch_name_shaped(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with('-')
+        && !value.contains("..")
+        && !value.contains("@{")
+        && value.bytes().all(|byte| byte > b' ' && byte != 0x7f)
 }
 
 /// Record `name` as the repository's pick. The ref write lands before the pick applies

--- a/src/git.rs
+++ b/src/git.rs
@@ -508,7 +508,7 @@ pub fn pr_local(repo: &Path, base_flag: Option<&str>) -> Result<PrLocalState, Gi
             names.push(name);
         }
     };
-    if let Some(upstream) = recorded_upstream(repo, &branch, &resolution.base_names(), &bases)? {
+    if let Some(upstream) = recorded_upstream(repo, &branch, &resolution.recorded, &bases)? {
         push_name(upstream, &mut names);
     }
     if let Some(head) = &head_oid
@@ -523,21 +523,12 @@ pub fn pr_local(repo: &Path, base_flag: Option<&str>) -> Result<PrLocalState, Gi
     Ok(PrLocalState { head_oid, base_oid: bases.into_iter().next(), names, detached: false })
 }
 
-/// Where the winning base came from (`specs/review-model.md` Base branch).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum BaseSource {
-    Flag,
-    Pick,
-    DefaultBranch,
-}
-
 /// The winning base: the source's bare name and its pinned commit
 /// (`specs/review-model.md` Base branch).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedBase {
     pub name: String,
     pub oid: String,
-    pub source: BaseSource,
 }
 
 /// The chain outcome the header paints: the winner and the first recorded choice the
@@ -552,9 +543,9 @@ pub struct BaseStatus {
 
 /// One pass over the base chain. `candidates` keeps every source that resolved, in
 /// precedence order and deduped by OID — the PR frontier walk needs all of them, not just
-/// the winner (`pr_local`). `recorded` keeps every source name the chain considered,
-/// resolved or not — a dormant pick still shields its name from the PR name lookup
-/// (`specs/forge-host.md` Resolution).
+/// the winner (`pr_local`). `recorded` keeps every source name the chain considered —
+/// every candidate's name and every dormant one's, since a pick that fails to resolve
+/// still shields its name from the PR name lookup (`specs/forge-host.md` Resolution).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BaseResolution {
     pub status: BaseStatus,
@@ -566,17 +557,6 @@ impl BaseResolution {
     pub fn oids(&self) -> Vec<String> {
         self.candidates.iter().map(|(_, oid)| oid.clone()).collect()
     }
-    /// The names the PR lookup must not treat as this branch's own: every resolved
-    /// candidate and every recorded choice (`specs/forge-host.md` Resolution).
-    fn base_names(&self) -> Vec<String> {
-        let mut names = self.recorded.clone();
-        for (name, _) in &self.candidates {
-            if !names.contains(name) {
-                names.push(name.clone());
-            }
-        }
-        names
-    }
 }
 
 /// Resolve the base chain: the `--base` flag, then the repo pick, then the branch
@@ -584,12 +564,12 @@ impl BaseResolution {
 /// ref is skipped, never an error; a skipped flag or pick that would have outranked the
 /// winner is recorded for the header (`specs/tui.md`).
 pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResolution, GitFail> {
-    let mut candidates: Vec<(String, String, BaseSource)> = Vec::new();
+    let mut candidates: Vec<(String, String)> = Vec::new();
     let mut recorded: Vec<String> = Vec::new();
     let mut skipped: Option<String> = None;
-    let push = |name: String, oid: String, source: BaseSource, c: &mut Vec<_>| {
-        if !c.iter().any(|(_, o, _): &(String, String, BaseSource)| *o == oid) {
-            c.push((name, oid, source));
+    let push = |name: String, oid: String, c: &mut Vec<(String, String)>| {
+        if !c.iter().any(|(_, o)| *o == oid) {
+            c.push((name, oid));
         }
     };
     let record = |name: String, r: &mut Vec<String>| {
@@ -605,10 +585,10 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
         record(entry.clone(), &mut recorded);
         let probe = format!("{flag}^{{commit}}");
         if let Some(oid) = git_tristate(repo, &["rev-parse", "--verify", "--quiet", &probe])? {
-            push(entry, oid, BaseSource::Flag, &mut candidates);
+            push(entry, oid, &mut candidates);
         } else {
             match resolve_base_entry(repo, &entry)? {
-                Some(oid) => push(entry, oid, BaseSource::Flag, &mut candidates),
+                Some(oid) => push(entry, oid, &mut candidates),
                 None => skipped = Some(flag.to_string()),
             }
         }
@@ -616,7 +596,7 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
     if let Some(pick) = read_base_pick(repo)? {
         record(pick.clone(), &mut recorded);
         match resolve_base_entry(repo, &pick)? {
-            Some(oid) => push(pick, oid, BaseSource::Pick, &mut candidates),
+            Some(oid) => push(pick, oid, &mut candidates),
             // Only a failure that outranks the eventual winner reads as skipped.
             None if candidates.is_empty() => skipped = skipped.or(Some(pick)),
             None => {}
@@ -625,15 +605,11 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
     if let Some(name) = default_branch_name(repo)? {
         record(name.clone(), &mut recorded);
         if let Some(oid) = resolve_base_entry(repo, &name)? {
-            push(name, oid, BaseSource::DefaultBranch, &mut candidates);
+            push(name, oid, &mut candidates);
         }
     }
-    let winner = candidates.first().map(|(name, oid, source)| ResolvedBase {
-        name: name.clone(),
-        oid: oid.clone(),
-        source: *source,
-    });
-    let candidates = candidates.into_iter().map(|(name, oid, _)| (name, oid)).collect();
+    let winner =
+        candidates.first().map(|(name, oid)| ResolvedBase { name: name.clone(), oid: oid.clone() });
     Ok(BaseResolution { status: BaseStatus { winner, skipped }, candidates, recorded })
 }
 
@@ -673,12 +649,12 @@ pub(crate) fn strip_base_prefix(entry: &str) -> String {
 
 /// Every branch name for the base picker: `refs/heads` and `refs/remotes/origin` merged by
 /// bare name, newest commit first, `origin/HEAD` and the checked-out branch excluded —
-/// except the default branch, which stays listed so its row can clear a pick even while
-/// checked out (`specs/input.md` Base picker).
-pub fn list_branches(repo: &Path) -> Result<Vec<String>, GitFail> {
-    let default = default_branch_name(repo)?;
+/// except the `default` branch, which stays listed so its row can clear a pick even while
+/// checked out (`specs/input.md` Base picker). The caller passes the default it already
+/// resolved, so one picker open runs the resolution once.
+pub fn list_branches(repo: &Path, default: Option<&str>) -> Result<Vec<String>, GitFail> {
     let checked_out = git_tristate(repo, &["symbolic-ref", "--quiet", "--short", "HEAD"])?
-        .filter(|name| default.as_deref() != Some(name));
+        .filter(|name| default != Some(name));
     let out = git_strict(
         repo,
         &[

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -16,6 +16,7 @@ pub enum Action {
     ScopeUncommitted,
     ScopeBranch,
     ScopeLastTurn,
+    BasePick,
     TabChanges,
     TabAllFiles,
     TabPr,
@@ -84,7 +85,7 @@ impl std::fmt::Display for Key {
 
 /// Every action with its config name and default keys — the single source the default keymap,
 /// the name lookup, and the config error message are built from.
-const ACTIONS: [(Action, &str, &[Key]); 33] = [
+const ACTIONS: [(Action, &str, &[Key]); 34] = [
     (Action::Down, "down", &[Key::plain('j')]),
     (Action::Up, "up", &[Key::plain('k')]),
     (Action::NextHunk, "next-hunk", &[Key::plain(']')]),
@@ -94,6 +95,7 @@ const ACTIONS: [(Action, &str, &[Key]); 33] = [
     (Action::ScopeUncommitted, "scope-uncommitted", &[Key::plain('u')]),
     (Action::ScopeBranch, "scope-branch", &[Key::plain('b')]),
     (Action::ScopeLastTurn, "scope-last-turn", &[Key::plain('t')]),
+    (Action::BasePick, "base-pick", &[Key::plain('B')]),
     (Action::TabChanges, "tab-changes", &[Key::plain('1')]),
     (Action::TabAllFiles, "tab-all-files", &[Key::plain('2')]),
     (Action::TabPr, "tab-pr", &[Key::plain('3')]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1501,6 +1501,23 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
         return Ok(());
     }
 
+    // The base picker: every printable narrows the filter — the bound shortcuts included, so
+    // a branch named `qa` is typable — the arrows move the highlight, `enter` picks, `esc`
+    // cancels, and everything else is inert (`specs/input.md` Base picker).
+    if app.mode == Mode::BasePick {
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+        match key.code {
+            Esc => app.close_base_picker(),
+            Enter => app.base_picker_pick()?,
+            KeyCode::Backspace => app.base_picker_backspace(),
+            Down => app.base_picker_move(1),
+            Up => app.base_picker_move(-1),
+            Char(c) if !ctrl && !alt => app.base_picker_input(c),
+            _ => {}
+        }
+        return Ok(());
+    }
+
     // The read-only PR tab: navigate the snapshot and open links; authoring actions are inert.
     if app.tab == crate::app::Tab::Pr {
         match (action, key.code) {
@@ -1573,6 +1590,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             K::ScopeUncommitted => app.set_scope(Scope::Uncommitted)?,
             K::ScopeBranch => app.set_scope(Scope::Branch)?,
             K::ScopeLastTurn => app.set_scope(Scope::LastTurn)?,
+            K::BasePick => app.open_base_picker(),
             K::Select => app.toggle_select(),
             K::Comment => app.start_comment(),
             // `edit`/`delete` act on the comment under the diff cursor, so they only fire with
@@ -1698,6 +1716,17 @@ pub fn handle_mouse(
                     None => {}
                 }
             }
+            // Same shape in the base picker: click to highlight, click the highlight to pick
+            // (`specs/input.md` Base picker).
+            MouseEventKind::Down(MouseButton::Left) if app.mode == Mode::BasePick => {
+                match ui::hit_base_picker_row(area, app, m.column, m.row) {
+                    Some(i) if app.base_picker.as_ref().is_some_and(|bp| bp.cursor == i) => {
+                        app.base_picker_pick()?;
+                    }
+                    Some(i) => app.base_picker_goto(i),
+                    None => {}
+                }
+            }
             MouseEventKind::Drag(MouseButton::Left) if app.divider_drag_captured() => {
                 return Ok(());
             }
@@ -1784,6 +1813,9 @@ pub fn handle_mouse(
                 match hit {
                     ui::HeaderHit::Tab(tab) => app.set_tab(tab)?,
                     ui::HeaderHit::Scope => app.set_scope(app.scope.cycle())?,
+                    // Inert when the picker cannot open here — with a `--base` flag the
+                    // label names the base without offering a choice (`specs/input.md`).
+                    ui::HeaderHit::Base => app.open_base_picker(),
                 }
             } else if let Some(i) =
                 ui::hit_file(area, app, m.column, m.row, app.file_rows.len(), app.file_scroll)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1502,18 +1502,21 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
     }
 
     // The base picker: every printable narrows the filter — the bound shortcuts included, so
-    // a branch named `qa` is typable — the arrows move the highlight, `enter` picks, `esc`
-    // cancels, and everything else is inert (`specs/input.md` Base picker).
+    // a branch named `qa` is typable — and the filter edits with the comment editor's
+    // controls, like every other text field. `↑`/`↓` (and `ctrl+n`/`p`) move the highlight,
+    // so the single-line filter keeps `←`/`→` for its caret, `enter` picks, `esc` cancels
+    // (`specs/input.md` Base picker).
     if app.mode == Mode::BasePick {
         let alt = key.modifiers.contains(KeyModifiers::ALT);
+        let word = alt || ctrl;
         match key.code {
             Esc => app.close_base_picker(),
             Enter => app.base_picker_pick()?,
-            KeyCode::Backspace => app.base_picker_backspace(),
             Down => app.base_picker_move(1),
             Up => app.base_picker_move(-1),
-            Char(c) if !ctrl && !alt => app.base_picker_input(c),
-            _ => {}
+            Char('n') if ctrl => app.base_picker_move(1),
+            Char('p') if ctrl => app.base_picker_move(-1),
+            code => apply_text_edit(app, code, ctrl, alt, word),
         }
         return Ok(());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1269,16 +1269,13 @@ fn reconcile_plugin_config(
         return ConfigGate::Unchanged;
     };
 
-    let bases_changed = previous.base_branches() != current.base_branches();
-    let file_changed = bases_changed || previous.theme() != current.theme();
-    let pr_changed = bases_changed || previous.forge_hosts() != current.forge_hosts();
+    let pr_changed = previous.forge_hosts() != current.forge_hosts();
     if pr_changed {
         pr.config_changed(app.tab == crate::app::Tab::Pr);
     }
-    if file_changed {
-        // `base_branches` participates in every Branch-scope derivation, and a theme change
-        // invalidates highlighted diffs. Rebuild before another input or frame can mix states;
-        // `reload` preserves the frozen diff while composing.
+    if previous.theme() != current.theme() {
+        // A theme change invalidates highlighted diffs. Rebuild before another input or
+        // frame can mix states; `reload` preserves the frozen diff while composing.
         if let Err(error) = app.reload() {
             app.status = format!("config refresh failed: {error}");
         }
@@ -1335,9 +1332,7 @@ fn apply_plugin_config_observation(
                 return false;
             } else if changed {
                 let current = app.plugin_config().expect("ready config");
-                if current.base_branches() != next.base_branches()
-                    || current.forge_hosts() != next.forge_hosts()
-                {
+                if current.forge_hosts() != next.forge_hosts() {
                     *epoch = epoch.wrapping_add(1);
                 }
                 app.set_plugin_config(next);
@@ -2569,8 +2564,11 @@ mod refresh_tests {
         assert_eq!(epoch, 0);
         assert!(!app.plugin_config().unwrap().auto_open());
 
-        std::fs::write(config_dir.path().join("config.toml"), "base_branches = [\"develop\"]\n")
-            .unwrap();
+        std::fs::write(
+            config_dir.path().join("config.toml"),
+            "github_host = \"github.example.com\"\n",
+        )
+        .unwrap();
         assert!(apply_plugin_config_observation(
             &mut app,
             &cfg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1789,7 +1789,6 @@ pub fn handle_mouse(
                 match hit {
                     ui::HeaderHit::Tab(tab) => app.set_tab(tab)?,
                     ui::HeaderHit::Scope => app.set_scope(app.scope.cycle())?,
-                    ui::HeaderHit::Send => app.send_to_agent(),
                 }
             } else if let Some(i) =
                 ui::hit_file(area, app, m.column, m.row, app.file_rows.len(), app.file_scroll)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -470,7 +470,7 @@ pub fn hit_header(area: Rect, app: &App, keymap: &Keymap, col: u16, row: u16) ->
         return Some(HeaderHit::Scope);
     }
     if let Some((lead, name, tail)) = base_parts(app, keymap, area.width) {
-        let base_start = scope_end + 1;
+        let base_start = scope_end + BASE_GAP.len() as u16;
         let base_end = base_start + (lead.width() + name.width() + tail.width()) as u16;
         if (base_start..base_end).contains(&col) {
             return Some(HeaderHit::Base);
@@ -492,6 +492,10 @@ fn tab_labels(keymap: &Keymap) -> [(Tab, String); 3] {
 const HEADER_LEAD: &str = " ";
 const TAB_GAP: &str = "  ";
 const HEADER_GAP: &str = "  ";
+/// The gap between the scope chip and the base label — one spelling shared by the paint,
+/// the width math, and the click hit-test, so the painted text and the clickable region
+/// can never drift apart.
+const BASE_GAP: &str = " ";
 /// The reserved indicator cell at the end of the tab strip: one gap column plus one glyph
 /// column, always present so nothing shifts when the glyph appears (specs/tui.md).
 const INDICATOR_CELL: usize = 2;
@@ -554,7 +558,7 @@ fn base_parts(app: &App, keymap: &Keymap, width: u16) -> Option<(String, String,
     // Everything else on the line plus the base's own gap and the suffix's minimum gap.
     let fixed = header_prefix_len(&tab_spans(keymap))
         + scope_chip(app).len()
-        + 1
+        + BASE_GAP.len()
         + lead.width()
         + header_suffix(app).width()
         + HEADER_LEAD.len()
@@ -605,9 +609,9 @@ fn tab_bar_spans(app: &App) -> Vec<Span<'static>> {
 fn render_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
     let chip = scope_chip(app);
     let base = base_parts(app, app.keymap(), area.width);
-    let base_width = base
-        .as_ref()
-        .map_or(0, |(lead, name, tail)| 1 + lead.width() + name.width() + tail.width());
+    let base_width = base.as_ref().map_or(0, |(lead, name, tail)| {
+        BASE_GAP.len() + lead.width() + name.width() + tail.width()
+    });
     let suffix = header_suffix(app);
     let prefix = header_prefix_len(&tab_spans(app.keymap()));
     // The suffix keeps the same edge pad as the tab strip's lead.
@@ -625,7 +629,7 @@ fn render_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
         // An empty lead is the `no base` state, worn as a warning; a resolved name wears the
         // clickable accent, and the skipped tail warns beside it (`specs/tui.md`).
         let warn = lead.is_empty();
-        spans.push(Span::styled(" ", bar));
+        spans.push(Span::styled(BASE_GAP, bar));
         spans.push(Span::styled(lead, bar.fg(p.overlay0)));
         spans.push(Span::styled(name, bar.fg(if warn { p.peach } else { p.lavender })));
         if !tail.is_empty() {
@@ -882,6 +886,31 @@ fn comment_card_lines(c: &Comment, width: usize, p: &Palette) -> Vec<Line<'stati
         Span::styled(format!("╰{}╯", "─".repeat(box_w.saturating_sub(2))), border),
     ]));
     lines
+}
+
+/// Truncate `s` to `max` display columns keeping the tail behind a leading `…` — for
+/// input echoes, where the newest characters are the ones the user must see. Zero
+/// columns fit nothing, not a bare `…`.
+fn truncate_left(s: &str, max: usize) -> String {
+    if s.width() <= max {
+        return s.to_string();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    let mut tail: Vec<char> = Vec::new();
+    let mut w = 0;
+    for ch in s.chars().rev() {
+        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if w + cw > max - 1 {
+            break;
+        }
+        tail.push(ch);
+        w += cw;
+    }
+    let mut out = String::from("…");
+    out.extend(tail.into_iter().rev());
+    out
 }
 
 /// Truncate `s` to `max` display columns, marking a cut with a trailing `…`. Zero columns
@@ -2080,11 +2109,13 @@ fn render_base_picker(frame: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
-    // The filter line: the typed query, or a dim invitation while it is empty.
+    // The filter line: the typed query, or a dim invitation while it is empty. An
+    // overlong query keeps its tail, so what was just typed stays visible.
     let filter = if bp.query.is_empty() {
         Line::from(Span::styled(" type to filter…", Style::default().fg(p.overlay0)))
     } else {
-        Line::from(Span::styled(format!(" {}", bp.query), text_style(p)))
+        let echo = truncate_left(&bp.query, (inner.width as usize).saturating_sub(1));
+        Line::from(Span::styled(format!(" {echo}"), text_style(p)))
     };
     frame.render_widget(Paragraph::new(filter), Rect { height: 1, ..inner });
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -528,21 +528,20 @@ fn scope_chip(app: &App) -> String {
 }
 
 /// The `branch` scope's base label as `(lead, name, tail)`: `vs ` + the bare name however it
-/// resolved, the skipped-choice tail ` · <name> missing`, or the empty-state `no base` alone
-/// in the name slot with no lead (`specs/tui.md`). `None` off the `branch` scope.
+/// resolved, or the empty-state `no base` in the name slot with no lead. The skipped-choice
+/// tail ` · <name> missing` follows either, so a dormant choice never reads as never-chosen
+/// (`specs/tui.md`). `None` off the `branch` scope.
 fn base_label(app: &App) -> Option<(String, String, String)> {
     if app.scope != crate::model::Scope::Branch {
         return None;
     }
-    Some(match &app.branch_base {
-        Some(b) => {
-            let tail = match &b.skipped {
-                Some(missing) => format!(" · {missing} missing"),
-                None => String::new(),
-            };
-            ("vs ".to_string(), b.name.clone(), tail)
-        }
-        None => (String::new(), "no base".to_string(), String::new()),
+    let tail = match &app.branch_base.skipped {
+        Some(missing) => format!(" · {missing} missing"),
+        None => String::new(),
+    };
+    Some(match &app.branch_base.winner {
+        Some(b) => ("vs ".to_string(), b.name.clone(), tail),
+        None => (String::new(), "no base".to_string(), tail),
     })
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -77,6 +77,7 @@ pub fn render(frame: &mut Frame, app: &App) {
     let popup: Option<fn(&mut Frame, &App, Rect)> = match app.mode {
         Mode::List => Some(render_comments_list),
         Mode::Picker => Some(render_agent_picker),
+        Mode::BasePick => Some(render_base_picker),
         Mode::Normal | Mode::Composing { .. } | Mode::Search | Mode::Find => None,
     };
     if let Some(render_popup) = popup {
@@ -444,6 +445,8 @@ fn wrap_text(s: &str, width: usize) -> Vec<String> {
 pub enum HeaderHit {
     Tab(Tab),
     Scope,
+    /// The `branch` scope's base label; the click opens the base picker (`specs/tui.md`).
+    Base,
 }
 
 /// Which header control a click at `(col, row)` lands on, if any. `keymap` must be the keymap
@@ -463,7 +466,17 @@ pub fn hit_header(area: Rect, app: &App, keymap: &Keymap, col: u16, row: u16) ->
     let prefix = header_prefix_len(&spans);
     let scope_start = prefix as u16;
     let scope_end = scope_start + scope_chip(app).len() as u16;
-    if (scope_start..scope_end).contains(&col) { Some(HeaderHit::Scope) } else { None }
+    if (scope_start..scope_end).contains(&col) {
+        return Some(HeaderHit::Scope);
+    }
+    if let Some((lead, name, tail)) = base_parts(app, keymap, area.width) {
+        let base_start = scope_end + 1;
+        let base_end = base_start + (lead.width() + name.width() + tail.width()) as u16;
+        if (base_start..base_end).contains(&col) {
+            return Some(HeaderHit::Base);
+        }
+    }
+    None
 }
 
 /// The three tabs and their labels, left to right, each led by its `tab-*` action's hint key
@@ -514,6 +527,65 @@ fn scope_chip(app: &App) -> String {
     format!("[{}]", app.scope.label())
 }
 
+/// The `branch` scope's base label as `(lead, name, tail)`: `vs ` + the bare name however it
+/// resolved, the skipped-choice tail ` · <name> missing`, or the empty-state `no base` alone
+/// in the name slot with no lead (`specs/tui.md`). `None` off the `branch` scope.
+fn base_label(app: &App) -> Option<(String, String, String)> {
+    if app.scope != crate::model::Scope::Branch {
+        return None;
+    }
+    Some(match &app.branch_base {
+        Some(b) => {
+            let tail = match &b.skipped {
+                Some(missing) => format!(" · {missing} missing"),
+                None => String::new(),
+            };
+            ("vs ".to_string(), b.name.clone(), tail)
+        }
+        None => (String::new(), "no base".to_string(), String::new()),
+    })
+}
+
+/// The base label as painted: the name truncated with a trailing `…` to what the header can
+/// fit (`specs/tui.md`) — one source for the paint and the click hit-test.
+fn base_parts(app: &App, keymap: &Keymap, width: u16) -> Option<(String, String, String)> {
+    let (lead, name, tail) = base_label(app)?;
+    // Everything else on the line plus the base's own gap and the suffix's minimum gap.
+    let fixed = header_prefix_len(&tab_spans(keymap))
+        + scope_chip(app).len()
+        + 1
+        + lead.width()
+        + tail.width()
+        + header_suffix(app).width()
+        + HEADER_LEAD.len()
+        + 1;
+    let name_max = (width as usize).saturating_sub(fixed);
+    Some((lead, truncate_ellipsis(&name, name_max), tail))
+}
+
+/// Truncate `s` to `max` display columns with a trailing `…` (`specs/tui.md`).
+fn truncate_ellipsis(s: &str, max: usize) -> String {
+    if s.width() <= max {
+        return s.to_string();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    let budget = max - 1;
+    let mut out = String::new();
+    let mut w = 0;
+    for ch in s.chars() {
+        let cw = ch.to_string().width();
+        if w + cw > budget {
+            break;
+        }
+        out.push(ch);
+        w += cw;
+    }
+    out.push('…');
+    out
+}
+
 /// The header suffix: the active scope's changed-file count and its aggregate line totals, in
 /// [`stats_str`]'s grammar, so a zero side drops and an empty changeset shows the bare count.
 /// The totals' `−` is multi-byte, so the suffix is measured by display width; the scope chip
@@ -553,10 +625,14 @@ fn tab_bar_spans(app: &App) -> Vec<Span<'static>> {
 
 fn render_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
     let chip = scope_chip(app);
+    let base = base_parts(app, app.keymap(), area.width);
+    let base_width = base
+        .as_ref()
+        .map_or(0, |(lead, name, tail)| 1 + lead.width() + name.width() + tail.width());
     let suffix = header_suffix(app);
     let prefix = header_prefix_len(&tab_spans(app.keymap()));
     // The suffix keeps the same edge pad as the tab strip's lead.
-    let used = prefix + chip.len() + suffix.width() + HEADER_LEAD.len();
+    let used = prefix + chip.len() + base_width + suffix.width() + HEADER_LEAD.len();
     // Right-align the suffix; at least one gap column when the bar overflows.
     let pad = (area.width as usize).saturating_sub(used).max(1);
 
@@ -566,6 +642,17 @@ fn render_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
     let bar = Style::default().bg(p.surface0);
     let mut spans = tab_bar_spans(app);
     spans.push(Span::styled(chip, bar.fg(p.yellow).add_modifier(Modifier::BOLD)));
+    if let Some((lead, name, tail)) = base {
+        // An empty lead is the `no base` state, worn as a warning; a resolved name wears the
+        // clickable accent, and the skipped tail warns beside it (`specs/tui.md`).
+        let warn = lead.is_empty();
+        spans.push(Span::styled(" ", bar));
+        spans.push(Span::styled(lead, bar.fg(p.overlay0)));
+        spans.push(Span::styled(name, bar.fg(if warn { p.peach } else { p.lavender })));
+        if !tail.is_empty() {
+            spans.push(Span::styled(tail, bar.fg(p.peach)));
+        }
+    }
     spans.push(Span::styled(" ".repeat(pad), bar));
     // The suffix repaints in parts so the totals get the file rows' green/red; the parts spell
     // out `header_suffix`, which the alignment math measures.
@@ -1448,6 +1535,24 @@ fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
         // The digits are literal, so they are spelled; the two movement keys are bound, so they
         // read off the keymap like every other hint (`specs/input.md`).
         A::MovePickerRow => (format!("1-9 {} {}", hint(K::Down), hint(K::Up)), "move"),
+        A::BasePick => (hint(K::BasePick), "pick base"),
+        A::PickBaseRow => ("enter".into(), "pick"),
+        // Every printable is filter text in the base picker, so only the arrows move
+        // (`specs/input.md` Base picker).
+        A::MoveBaseRow => ("↑↓".into(), "move"),
+        A::ScopeOther => {
+            use crate::model::Scope;
+            let others: Vec<String> = [
+                (Scope::Uncommitted, K::ScopeUncommitted),
+                (Scope::Branch, K::ScopeBranch),
+                (Scope::LastTurn, K::ScopeLastTurn),
+            ]
+            .into_iter()
+            .filter(|(scope, _)| app.scope != *scope)
+            .map(|(_, action)| hint(action))
+            .collect();
+            (others.join("/"), "scope")
+        }
         A::Search => (hint(K::Search), "search"),
         A::Find => (hint(K::Find), "find"),
         A::Wrap => (hint(K::Wrap), "wrap"),
@@ -1921,6 +2026,125 @@ pub fn hit_picker_row(area: Rect, app: &App, col: u16, row: u16) -> Option<usize
     }
     let index = picker_scroll(app, inner.height as usize) + (row - inner.y) as usize;
     (index < app.picker_rows.len()).then_some(index)
+}
+
+// --- Base picker (specs/input.md Base picker) ----------------------------------------------
+
+/// A row's dim trail: `default` on the default branch, whose pick clears the record
+/// (`specs/input.md` Base picker).
+fn base_trail(row: &crate::app::BaseChoice) -> &'static str {
+    if row.is_default { "default" } else { "" }
+}
+
+/// The names pad to the widest, so the dim `default` mark starts in one column.
+fn base_name_width(bp: &crate::app::BasePicker) -> usize {
+    bp.rows.iter().map(|r| r.name.width()).max().unwrap_or(0)
+}
+
+/// Sized like the agent picker's box, plus the filter line above the rows. The box holds its
+/// full-list size while the filter narrows, so the frame never jumps under typing.
+fn base_picker_popup(area: Rect, app: &App) -> Rect {
+    let Some(bp) = &app.base_picker else { return Rect::default() };
+    let body = panes(area, app).body;
+    let name_width = base_name_width(bp);
+    // The star lead + the padded name + the dim trail, then the two borders.
+    let widest =
+        bp.rows.iter().map(|r| 3 + name_width + 2 + base_trail(r).width()).max().unwrap_or(0);
+    let title = framed_title(BASE_PICKER_TITLE).width() + 2;
+    let w = (widest + 3).max(title).max(PICKER_MIN_WIDTH).min(body.width as usize) as u16;
+    let h = (bp.rows.len().max(1) + 3).min(body.height as usize) as u16;
+    body_popup(area, app, w, h)
+}
+
+const BASE_PICKER_TITLE: &str = "Pick base";
+
+/// The first visible filtered row, so the highlight stays on screen in a picker taller than
+/// the pane (`specs/input.md`).
+fn base_picker_scroll(bp: &crate::app::BasePicker, rows: usize) -> usize {
+    if rows == 0 || bp.cursor < rows {
+        return 0;
+    }
+    (bp.cursor + 1).saturating_sub(rows).min(bp.filtered().len().saturating_sub(rows))
+}
+
+fn render_base_picker(frame: &mut Frame, app: &App, area: Rect) {
+    let Some(bp) = &app.base_picker else { return };
+    let p = app.palette();
+    let popup = base_picker_popup(area, app);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(p.mauve))
+        .title(framed_title(BASE_PICKER_TITLE));
+    let inner = picker_inner(popup);
+    frame.render_widget(block, popup);
+    if inner.height == 0 {
+        return;
+    }
+
+    // The filter line: the typed query, or a dim invitation while it is empty.
+    let filter = if bp.query.is_empty() {
+        Line::from(Span::styled(" type to filter…", Style::default().fg(p.overlay0)))
+    } else {
+        Line::from(Span::styled(format!(" {}", bp.query), text_style(p)))
+    };
+    frame.render_widget(Paragraph::new(filter), Rect { height: 1, ..inner });
+
+    let list_area = Rect { y: inner.y + 1, height: inner.height.saturating_sub(1), ..inner };
+    let filtered = bp.filtered();
+    if filtered.is_empty() {
+        let none = Line::from(Span::styled(" no branches match", Style::default().fg(p.overlay0)));
+        frame.render_widget(Paragraph::new(none), list_area);
+        return;
+    }
+    let name_width = base_name_width(bp);
+    let first = base_picker_scroll(bp, list_area.height as usize);
+    let items: Vec<ListItem> = filtered
+        .iter()
+        .enumerate()
+        .skip(first)
+        .take(list_area.height as usize)
+        .map(|(vi, &ri)| {
+            let row = &bp.rows[ri];
+            // The star marks the open PR's target; the name is the only part at full
+            // brightness, like the agent picker's rows (`specs/input.md`).
+            let lead = if row.starred { " ★ " } else { "   " };
+            let pad = name_width.saturating_sub(row.name.width());
+            let spans = vec![
+                Span::styled(lead.to_string(), Style::default().fg(p.yellow)),
+                Span::styled(row.name.clone(), text_style(p)),
+                Span::styled(
+                    format!("{}  {}", " ".repeat(pad), base_trail(row)),
+                    Style::default().fg(p.overlay0),
+                ),
+            ];
+            selectable_row(
+                p,
+                spans,
+                list_area.width as usize,
+                (vi == bp.cursor).then_some(p.surface2),
+            )
+        })
+        .collect();
+    frame.render_widget(List::new(items), list_area);
+}
+
+/// The filtered base-picker row under the pointer (`specs/input.md`). `None` on the border,
+/// the title, and the filter line, so those clicks stay inert.
+pub fn hit_base_picker_row(area: Rect, app: &App, col: u16, row: u16) -> Option<usize> {
+    let bp = app.base_picker.as_ref()?;
+    let inner = picker_inner(base_picker_popup(area, app));
+    let list_y = inner.y + 1;
+    if col < inner.x
+        || col >= inner.x + inner.width
+        || row < list_y
+        || row >= inner.y + inner.height
+    {
+        return None;
+    }
+    let rows = inner.height.saturating_sub(1) as usize;
+    let index = base_picker_scroll(bp, rows) + (row - list_y) as usize;
+    (index < bp.filtered().len()).then_some(index)
 }
 
 // --- Search screen (specs/search.md) -------------------------------------------------------

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -546,8 +546,10 @@ fn base_label(app: &App) -> Option<(String, String, String)> {
     })
 }
 
-/// The base label as painted: the name truncated with a trailing `…` to what the header can
-/// fit (`specs/tui.md`) — one source for the paint and the click hit-test.
+/// The base label as painted: truncated with a trailing `…` to what the header can fit,
+/// the name first and the skipped tail only in what remains, so a long missing name can
+/// never evict the resolved base (`specs/tui.md`) — one source for the paint and the
+/// click hit-test.
 fn base_parts(app: &App, keymap: &Keymap, width: u16) -> Option<(String, String, String)> {
     let (lead, name, tail) = base_label(app)?;
     // Everything else on the line plus the base's own gap and the suffix's minimum gap.
@@ -555,35 +557,13 @@ fn base_parts(app: &App, keymap: &Keymap, width: u16) -> Option<(String, String,
         + scope_chip(app).len()
         + 1
         + lead.width()
-        + tail.width()
         + header_suffix(app).width()
         + HEADER_LEAD.len()
         + 1;
-    let name_max = (width as usize).saturating_sub(fixed);
-    Some((lead, truncate_ellipsis(&name, name_max), tail))
-}
-
-/// Truncate `s` to `max` display columns with a trailing `…` (`specs/tui.md`).
-fn truncate_ellipsis(s: &str, max: usize) -> String {
-    if s.width() <= max {
-        return s.to_string();
-    }
-    if max == 0 {
-        return String::new();
-    }
-    let budget = max - 1;
-    let mut out = String::new();
-    let mut w = 0;
-    for ch in s.chars() {
-        let cw = ch.to_string().width();
-        if w + cw > budget {
-            break;
-        }
-        out.push(ch);
-        w += cw;
-    }
-    out.push('…');
-    out
+    let budget = (width as usize).saturating_sub(fixed);
+    let name = truncate_width(&name, budget);
+    let tail = truncate_width(&tail, budget.saturating_sub(name.width()));
+    Some((lead, name, tail))
 }
 
 /// The header suffix: the active scope's changed-file count and its aggregate line totals, in
@@ -905,10 +885,14 @@ fn comment_card_lines(c: &Comment, width: usize, p: &Palette) -> Vec<Line<'stati
     lines
 }
 
-/// Truncate `s` to `max` display columns, marking a cut with a trailing `…`.
+/// Truncate `s` to `max` display columns, marking a cut with a trailing `…`. Zero columns
+/// fit nothing, not a bare `…`.
 fn truncate_width(s: &str, max: usize) -> String {
     if s.width() <= max {
         return s.to_string();
+    }
+    if max == 0 {
+        return String::new();
     }
     let mut out = String::new();
     let mut w = 0;
@@ -1913,24 +1897,61 @@ fn body_popup(area: Rect, app: &App, w: u16, h: u16) -> Rect {
 /// Three short rows in an 80%-tall box would be mostly empty (`specs/herdr-host.md`).
 const PICKER_MIN_WIDTH: usize = 34;
 
-fn picker_popup(area: Rect, app: &App) -> Rect {
+/// The box any picker menu paints: `widest` row content plus the two borders and one column
+/// of air — the air sits inside the row, so the selection fill still reaches both borders.
+/// Never narrower than the floor, so a picker of short names still reads as a deliberate
+/// dialog.
+fn menu_popup(area: Rect, app: &App, widest: usize, title: &str, lines: usize) -> Rect {
     let body = panes(area, app).body;
+    let title = framed_title(title).width() + 2;
+    let w = (widest + 3).max(title).max(PICKER_MIN_WIDTH).min(body.width as usize) as u16;
+    let h = lines.min(body.height as usize) as u16;
+    body_popup(area, app, w, h)
+}
+
+/// The first visible row, so the highlight stays on screen in a menu taller than the pane
+/// (`specs/input.md`).
+fn menu_scroll(cursor: usize, total: usize, rows: usize) -> usize {
+    if rows == 0 || cursor < rows {
+        return 0;
+    }
+    (cursor + 1).saturating_sub(rows).min(total.saturating_sub(rows))
+}
+
+/// The menu row under the pointer, its list starting `top` rows below `inner`'s top and
+/// scrolled to `first` — `None` outside the list, so border, title, and filter clicks stay
+/// inert (`specs/input.md`).
+fn menu_hit(
+    inner: Rect,
+    top: u16,
+    first: usize,
+    total: usize,
+    col: u16,
+    row: u16,
+) -> Option<usize> {
+    let list_y = inner.y + top;
+    if col < inner.x
+        || col >= inner.x + inner.width
+        || row < list_y
+        || row >= inner.y + inner.height
+    {
+        return None;
+    }
+    let index = first + (row - list_y) as usize;
+    (index < total).then_some(index)
+}
+
+fn picker_popup(area: Rect, app: &App) -> Rect {
     let name_width = picker_name_width(app);
-    // " N  " + the padded name + "  " + the dim trail, then the two borders. The highlight is
-    // a row fill, not a glyph, so it costs no width.
+    // " N  " + the padded name + "  " + the dim trail. The highlight is a row fill, not a
+    // glyph, so it costs no width.
     let widest = app
         .picker_rows
         .iter()
         .map(|row| 4 + name_width + 2 + picker_trail(app, row).width())
         .max()
         .unwrap_or(0);
-    let title = framed_title(&picker_title(app)).width() + 2;
-    // Rows, the two borders, and one column of air after the longest trail — the air sits
-    // inside the row, so the selection fill still reaches both borders. Never narrower than
-    // the floor, so a picker of short names still reads as a deliberate dialog.
-    let w = (widest + 3).max(title).max(PICKER_MIN_WIDTH).min(body.width as usize) as u16;
-    let h = (app.picker_rows.len() + 2).min(body.height as usize) as u16;
-    body_popup(area, app, w, h)
+    menu_popup(area, app, widest, &picker_title(app), app.picker_rows.len() + 2)
 }
 
 /// The popup's row region, from the same `Block` shape the renderer draws, so the hit test
@@ -1960,13 +1981,8 @@ fn picker_title(app: &App) -> String {
     format!("Send {n} {noun} to")
 }
 
-/// The first visible row, so the highlight stays on screen in a picker taller than the pane
-/// (`specs/input.md`).
 fn picker_scroll(app: &App, rows: usize) -> usize {
-    if rows == 0 || app.picker_cursor < rows {
-        return 0;
-    }
-    (app.picker_cursor + 1).saturating_sub(rows).min(app.picker_rows.len().saturating_sub(rows))
+    menu_scroll(app.picker_cursor, app.picker_rows.len(), rows)
 }
 
 fn render_agent_picker(frame: &mut Frame, app: &App, area: Rect) {
@@ -2013,19 +2029,11 @@ fn render_agent_picker(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(List::new(items), inner);
 }
 
-/// The picker row under the pointer, for click-to-highlight (`specs/input.md`). `None`
-/// anywhere else, including the border and the title, so those clicks stay inert.
+/// The picker row under the pointer, for click-to-highlight (`specs/input.md`).
 pub fn hit_picker_row(area: Rect, app: &App, col: u16, row: u16) -> Option<usize> {
     let inner = picker_inner(picker_popup(area, app));
-    if col < inner.x
-        || col >= inner.x + inner.width
-        || row < inner.y
-        || row >= inner.y + inner.height
-    {
-        return None;
-    }
-    let index = picker_scroll(app, inner.height as usize) + (row - inner.y) as usize;
-    (index < app.picker_rows.len()).then_some(index)
+    let first = picker_scroll(app, inner.height as usize);
+    menu_hit(inner, 0, first, app.picker_rows.len(), col, row)
 }
 
 // --- Base picker (specs/input.md Base picker) ----------------------------------------------
@@ -2045,26 +2053,17 @@ fn base_name_width(bp: &crate::app::BasePicker) -> usize {
 /// full-list size while the filter narrows, so the frame never jumps under typing.
 fn base_picker_popup(area: Rect, app: &App) -> Rect {
     let Some(bp) = &app.base_picker else { return Rect::default() };
-    let body = panes(area, app).body;
     let name_width = base_name_width(bp);
-    // The star lead + the padded name + the dim trail, then the two borders.
+    // The star lead + the padded name + the dim trail.
     let widest =
         bp.rows.iter().map(|r| 3 + name_width + 2 + base_trail(r).width()).max().unwrap_or(0);
-    let title = framed_title(BASE_PICKER_TITLE).width() + 2;
-    let w = (widest + 3).max(title).max(PICKER_MIN_WIDTH).min(body.width as usize) as u16;
-    let h = (bp.rows.len().max(1) + 3).min(body.height as usize) as u16;
-    body_popup(area, app, w, h)
+    menu_popup(area, app, widest, BASE_PICKER_TITLE, bp.rows.len().max(1) + 3)
 }
 
 const BASE_PICKER_TITLE: &str = "Pick base";
 
-/// The first visible filtered row, so the highlight stays on screen in a picker taller than
-/// the pane (`specs/input.md`).
 fn base_picker_scroll(bp: &crate::app::BasePicker, rows: usize) -> usize {
-    if rows == 0 || bp.cursor < rows {
-        return 0;
-    }
-    (bp.cursor + 1).saturating_sub(rows).min(bp.filtered().len().saturating_sub(rows))
+    menu_scroll(bp.cursor, bp.filtered().len(), rows)
 }
 
 fn render_base_picker(frame: &mut Frame, app: &App, area: Rect) {
@@ -2129,22 +2128,13 @@ fn render_base_picker(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(List::new(items), list_area);
 }
 
-/// The filtered base-picker row under the pointer (`specs/input.md`). `None` on the border,
-/// the title, and the filter line, so those clicks stay inert.
+/// The filtered base-picker row under the pointer, the filter line skipped
+/// (`specs/input.md`).
 pub fn hit_base_picker_row(area: Rect, app: &App, col: u16, row: u16) -> Option<usize> {
     let bp = app.base_picker.as_ref()?;
     let inner = picker_inner(base_picker_popup(area, app));
-    let list_y = inner.y + 1;
-    if col < inner.x
-        || col >= inner.x + inner.width
-        || row < list_y
-        || row >= inner.y + inner.height
-    {
-        return None;
-    }
-    let rows = inner.height.saturating_sub(1) as usize;
-    let index = base_picker_scroll(bp, rows) + (row - list_y) as usize;
-    (index < bp.filtered().len()).then_some(index)
+    let first = base_picker_scroll(bp, inner.height.saturating_sub(1) as usize);
+    menu_hit(inner, 1, first, bp.filtered().len(), col, row)
 }
 
 // --- Search screen (specs/search.md) -------------------------------------------------------

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -463,11 +463,7 @@ pub fn hit_header(area: Rect, app: &App, keymap: &Keymap, col: u16, row: u16) ->
     let prefix = header_prefix_len(&spans);
     let scope_start = prefix as u16;
     let scope_end = scope_start + scope_chip(app).len() as u16;
-    if (scope_start..scope_end).contains(&col) {
-        Some(HeaderHit::Scope)
-    } else {
-        None
-    }
+    if (scope_start..scope_end).contains(&col) { Some(HeaderHit::Scope) } else { None }
 }
 
 /// The three tabs and their labels, left to right, each led by its `tab-*` action's hint key

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -444,7 +444,6 @@ fn wrap_text(s: &str, width: usize) -> Vec<String> {
 pub enum HeaderHit {
     Tab(Tab),
     Scope,
-    Send,
 }
 
 /// Which header control a click at `(col, row)` lands on, if any. `keymap` must be the keymap
@@ -464,11 +463,8 @@ pub fn hit_header(area: Rect, app: &App, keymap: &Keymap, col: u16, row: u16) ->
     let prefix = header_prefix_len(&spans);
     let scope_start = prefix as u16;
     let scope_end = scope_start + scope_chip(app).len() as u16;
-    let button_start = send_button_col(app, prefix, area.width as usize) as u16;
     if (scope_start..scope_end).contains(&col) {
         Some(HeaderHit::Scope)
-    } else if col >= button_start && col < area.width {
-        Some(HeaderHit::Send)
     } else {
         None
     }
@@ -480,7 +476,7 @@ fn tab_labels(keymap: &Keymap) -> [(Tab, String); 3] {
     use crate::keymap::Action as K;
     [
         (Tab::Changes, format!("{} Changes", keymap.hint(K::TabChanges))),
-        (Tab::AllFiles, format!("{} All files", keymap.hint(K::TabAllFiles))),
+        (Tab::AllFiles, format!("{} Files", keymap.hint(K::TabAllFiles))),
         (Tab::Pr, format!("{} PR", keymap.hint(K::TabPr))),
     ]
 }
@@ -522,29 +518,15 @@ fn scope_chip(app: &App) -> String {
     format!("[{}]", app.scope.label())
 }
 
-fn send_button(app: &App) -> String {
-    format!("[ Send ({}) ]", app.store.len())
-}
-
 /// The header suffix: the active scope's changed-file count and its aggregate line totals, in
 /// [`stats_str`]'s grammar, so a zero side drops and an empty changeset shows the bare count.
-/// Shared so the painter and the hit-test place the right-aligned `Send` button at the same
-/// column. The totals' `−` is multi-byte, so the suffix is measured by display width; the scope
-/// chip and `Send` button are all-ASCII, so their byte `.len()` equals their display width.
+/// The totals' `−` is multi-byte, so the suffix is measured by display width; the scope chip
+/// is all-ASCII, so its byte `.len()` equals its display width.
 fn header_suffix(app: &App) -> String {
     let (added, removed) = app.changed_totals();
     let stats = stats_str(added, removed);
     let gap = if stats.is_empty() { "" } else { "  " };
-    format!("  {} changed{gap}{stats}", app.changed_count())
-}
-
-/// The column the `Send` button paints at, matching `render_tab_bar`'s layout: right-aligned
-/// when the header fits, packed left right after the suffix when the bar overflows (`pad`
-/// collapses to 0). `hit_header` must use this, not a bare right-alignment, or a `Send` click
-/// mis-fires (and on a narrow pane lands in a tab span) when the header overflows.
-fn send_button_col(app: &App, prefix: usize, width: usize) -> usize {
-    let before = prefix + scope_chip(app).len() + header_suffix(app).width();
-    before + width.saturating_sub(before + send_button(app).len())
+    format!("{} changed{gap}{stats}", app.changed_count())
 }
 
 /// The header's shared left side, painted by both tab bars: the lead pad, the three tab labels
@@ -576,30 +558,29 @@ fn tab_bar_spans(app: &App) -> Vec<Span<'static>> {
 fn render_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
     let chip = scope_chip(app);
     let suffix = header_suffix(app);
-    let button = send_button(app);
     let prefix = header_prefix_len(&tab_spans(app.keymap()));
-    let used = prefix + chip.len() + suffix.width() + button.len();
-    let pad = (area.width as usize).saturating_sub(used);
+    // The suffix keeps the same edge pad as the tab strip's lead.
+    let used = prefix + chip.len() + suffix.width() + HEADER_LEAD.len();
+    // Right-align the suffix; at least one gap column when the bar overflows.
+    let pad = (area.width as usize).saturating_sub(used).max(1);
 
     // A quiet surface bar: the active tab in bright lavender, the inactive one dimmed, the
-    // clickable scope and Send controls accented so they read as buttons.
+    // clickable scope control accented so it reads as a button.
     let p = app.palette();
     let bar = Style::default().bg(p.surface0);
     let mut spans = tab_bar_spans(app);
     spans.push(Span::styled(chip, bar.fg(p.yellow).add_modifier(Modifier::BOLD)));
+    spans.push(Span::styled(" ".repeat(pad), bar));
     // The suffix repaints in parts so the totals get the file rows' green/red; the parts spell
-    // out `header_suffix`, which the `Send` column math measures.
+    // out `header_suffix`, which the alignment math measures.
     let (added, removed) = app.changed_totals();
-    spans.push(Span::styled(format!("  {} changed", app.changed_count()), bar.fg(p.overlay0)));
+    spans.push(Span::styled(format!("{} changed", app.changed_count()), bar.fg(p.overlay0)));
     let stats = stats_spans(added, removed, p);
     if !stats.is_empty() {
         spans.push(Span::styled("  ", bar));
         spans.extend(stats.into_iter().map(|s| Span::styled(s.content, s.style.bg(p.surface0))));
     }
-
-    let send_fg = if app.store.is_empty() { p.overlay0 } else { p.green };
-    spans.push(Span::styled(" ".repeat(pad), bar));
-    spans.push(Span::styled(button, bar.fg(send_fg).add_modifier(Modifier::BOLD)));
+    spans.push(Span::styled(HEADER_LEAD, bar));
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -565,6 +565,11 @@ fn base_parts(app: &App, keymap: &Keymap, width: u16) -> Option<(String, String,
         + 1;
     let budget = (width as usize).saturating_sub(fixed);
     let name = truncate_width(&name, budget);
+    if name.is_empty() {
+        // Not even one column for the name: the base leaves the header whole rather than
+        // paint a nameless `vs` the click would still claim (`specs/tui.md`).
+        return None;
+    }
     let tail = truncate_width(&tail, budget.saturating_sub(name.width()));
     Some((lead, name, tail))
 }
@@ -886,31 +891,6 @@ fn comment_card_lines(c: &Comment, width: usize, p: &Palette) -> Vec<Line<'stati
         Span::styled(format!("╰{}╯", "─".repeat(box_w.saturating_sub(2))), border),
     ]));
     lines
-}
-
-/// Truncate `s` to `max` display columns keeping the tail behind a leading `…` — for
-/// input echoes, where the newest characters are the ones the user must see. Zero
-/// columns fit nothing, not a bare `…`.
-fn truncate_left(s: &str, max: usize) -> String {
-    if s.width() <= max {
-        return s.to_string();
-    }
-    if max == 0 {
-        return String::new();
-    }
-    let mut tail: Vec<char> = Vec::new();
-    let mut w = 0;
-    for ch in s.chars().rev() {
-        let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if w + cw > max - 1 {
-            break;
-        }
-        tail.push(ch);
-        w += cw;
-    }
-    let mut out = String::from("…");
-    out.extend(tail.into_iter().rev());
-    out
 }
 
 /// Truncate `s` to `max` display columns, marking a cut with a trailing `…`. Zero columns
@@ -2088,7 +2068,7 @@ fn base_picker_popup(area: Rect, app: &App) -> Rect {
     menu_popup(area, app, widest, BASE_PICKER_TITLE, bp.rows.len().max(1) + 3)
 }
 
-const BASE_PICKER_TITLE: &str = "Pick base";
+const BASE_PICKER_TITLE: &str = "Pick base branch";
 
 fn base_picker_scroll(bp: &crate::app::BasePicker, rows: usize) -> usize {
     menu_scroll(bp.cursor, bp.filtered().len(), rows)
@@ -2109,14 +2089,22 @@ fn render_base_picker(frame: &mut Frame, app: &App, area: Rect) {
         return;
     }
 
-    // The filter line: the typed query, or a dim invitation while it is empty. An
-    // overlong query keeps its tail, so what was just typed stays visible.
-    let filter = if bp.query.is_empty() {
-        Line::from(Span::styled(" type to filter…", Style::default().fg(p.overlay0)))
+    // The filter line: the query with the comment editor's block caret, or a dim invitation
+    // while it is empty. The single line cannot wrap, so it scrolls horizontally to keep the
+    // caret in view — what was just typed stays visible (`specs/input.md` Base picker).
+    let mut filter = if bp.query.is_empty() {
+        let mut line = row_with_caret("", 0, p);
+        line.spans.push(Span::styled(" type to filter…", Style::default().fg(p.overlay0)));
+        line
     } else {
-        let echo = truncate_left(&bp.query, (inner.width as usize).saturating_sub(1));
-        Line::from(Span::styled(format!(" {echo}"), text_style(p)))
+        let chars: Vec<char> = bp.query.chars().collect();
+        let caret_col = bp.caret.min(chars.len());
+        let avail = (inner.width as usize).saturating_sub(2);
+        let start = caret_col.saturating_sub(avail.saturating_sub(1));
+        let visible: String = chars[start.min(chars.len())..].iter().collect();
+        row_with_caret(&visible, caret_col - start, p)
     };
+    filter.spans.insert(0, Span::styled(" ", text_style(p)));
     frame.render_widget(Paragraph::new(filter), Rect { height: 1, ..inner });
 
     let list_area = Rect { y: inner.y + 1, height: inner.height.saturating_sub(1), ..inner };

--- a/src/world.rs
+++ b/src/world.rs
@@ -90,12 +90,12 @@ pub fn build_changed(input: &WorldInput) -> Result<(git::BaseStatus, Vec<Changed
         },
         Scope::Uncommitted => Ok((none(), git::changed_files(&input.repo, input.scope, None)?)),
         Scope::Branch => {
-            // A resolve failure degrades to the no-base empty state instead of failing the
-            // whole build — the header's `no base` is legible, a poll-time error loop is
-            // not (specs/review-model.md Base branch).
-            let Ok(resolution) = git::resolve_base(&input.repo, input.base.as_deref()) else {
-                return Ok((none(), Vec::new()));
-            };
+            // A resolve failure fails the build whole, so the landing keeps the stale
+            // frame and reports — degrading to an empty snapshot would blank a populated
+            // view over a transient error (specs/overview.md Continuity). A chain where
+            // nothing resolves is not a failure: it returns the legible no-base state.
+            let resolution = git::resolve_base(&input.repo, input.base.as_deref())
+                .map_err(|e| anyhow::anyhow!("{}", e.0))?;
             let base_oid = resolution.status.winner.as_ref().map(|w| w.oid.clone());
             let changed = git::changed_files(&input.repo, input.scope, base_oid.as_deref())?;
             Ok((resolution.status, changed))

--- a/src/world.rs
+++ b/src/world.rs
@@ -30,6 +30,10 @@ pub struct WorldInput {
     /// must land here as newer content, not be discarded as a mismatch
     /// (specs/review-model.md).
     pub base: Option<String>,
+    /// Bumped by this pane's own pick, so a build that read the previous pick fails the
+    /// landing's input-equality gate instead of reverting the picked base. Another pane's
+    /// pick leaves it alone — see `base` above.
+    pub base_epoch: u64,
     /// The `last-turn` baseline tree the changed set diffs against; `None` before a turn.
     pub turn_baseline: Option<String>,
     /// Expanded ignored directories whose children the `All files` tree loads.
@@ -85,8 +89,12 @@ pub fn build_changed(input: &WorldInput) -> Result<(Option<git::ResolvedBase>, V
         },
         Scope::Uncommitted => Ok((None, git::changed_files(&input.repo, input.scope, None)?)),
         Scope::Branch => {
-            let resolution = git::resolve_base(&input.repo, input.base.as_deref())
-                .map_err(|e| anyhow::anyhow!("{}", e.0))?;
+            // A resolve failure degrades to the no-base empty state instead of failing the
+            // whole build — the header's `no base` is legible, a poll-time error loop is
+            // not (specs/review-model.md Base branch).
+            let Ok(resolution) = git::resolve_base(&input.repo, input.base.as_deref()) else {
+                return Ok((None, Vec::new()));
+            };
             let base_oid = resolution.winner.as_ref().map(|w| w.oid.clone());
             let changed = git::changed_files(&input.repo, input.scope, base_oid.as_deref())?;
             Ok((resolution.winner, changed))

--- a/src/world.rs
+++ b/src/world.rs
@@ -47,7 +47,7 @@ pub struct WorldInput {
 pub struct WorldSnapshot {
     pub changed: HashMap<String, Annotation>,
     pub entries: Vec<Entry>,
-    pub branch_base: Option<git::ResolvedBase>,
+    pub branch_base: git::BaseStatus,
 }
 
 /// Build the snapshot for `input`. The changeset is computed regardless of tab so the
@@ -61,7 +61,7 @@ pub fn build(input: &WorldInput) -> Result<WorldSnapshot> {
         return Ok(WorldSnapshot {
             changed: HashMap::new(),
             entries: Vec::new(),
-            branch_base: None,
+            branch_base: git::BaseStatus::default(),
         });
     }
     let (branch_base, changed) = build_changed(input)?;
@@ -78,26 +78,27 @@ pub fn build(input: &WorldInput) -> Result<WorldSnapshot> {
 /// The active scope's changed files and, on the `branch` scope, the base they diff against —
 /// the piece a scope switch rebuilds before its frame, so the header count and list never
 /// wear another scope's label (specs/tui.md).
-pub fn build_changed(input: &WorldInput) -> Result<(Option<git::ResolvedBase>, Vec<ChangedFile>)> {
+pub fn build_changed(input: &WorldInput) -> Result<(git::BaseStatus, Vec<ChangedFile>)> {
+    let none = git::BaseStatus::default;
     if !git::is_repo(&input.repo) {
-        return Ok((None, Vec::new()));
+        return Ok((none(), Vec::new()));
     }
     match input.scope {
         Scope::LastTurn => match input.turn_baseline.as_deref() {
-            Some(t) => Ok((None, git::changed_against_tree(&input.repo, t)?)),
-            None => Ok((None, Vec::new())),
+            Some(t) => Ok((none(), git::changed_against_tree(&input.repo, t)?)),
+            None => Ok((none(), Vec::new())),
         },
-        Scope::Uncommitted => Ok((None, git::changed_files(&input.repo, input.scope, None)?)),
+        Scope::Uncommitted => Ok((none(), git::changed_files(&input.repo, input.scope, None)?)),
         Scope::Branch => {
             // A resolve failure degrades to the no-base empty state instead of failing the
             // whole build — the header's `no base` is legible, a poll-time error loop is
             // not (specs/review-model.md Base branch).
             let Ok(resolution) = git::resolve_base(&input.repo, input.base.as_deref()) else {
-                return Ok((None, Vec::new()));
+                return Ok((none(), Vec::new()));
             };
-            let base_oid = resolution.winner.as_ref().map(|w| w.oid.clone());
+            let base_oid = resolution.status.winner.as_ref().map(|w| w.oid.clone());
             let changed = git::changed_files(&input.repo, input.scope, base_oid.as_deref())?;
-            Ok((resolution.winner, changed))
+            Ok((resolution.status, changed))
         }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -25,19 +25,25 @@ pub struct WorldInput {
     pub repo: PathBuf,
     pub tab: Tab,
     pub scope: Scope,
+    /// The `--base` flag, resolved fresh per build. The pick is read from its ref at build
+    /// time, so it is derived output, never input identity — a pick made in another pane
+    /// must land here as newer content, not be discarded as a mismatch
+    /// (specs/review-model.md).
     pub base: Option<String>,
-    pub base_branches: Vec<String>,
     /// The `last-turn` baseline tree the changed set diffs against; `None` before a turn.
     pub turn_baseline: Option<String>,
     /// Expanded ignored directories whose children the `All files` tree loads.
     pub toggled_dirs: HashSet<String>,
 }
 
-/// The derived state one refresh produces: the scope changeset and the navigator entries.
+/// The derived state one refresh produces: the scope changeset, the navigator entries, and
+/// the `branch` scope's resolved base. The base rides the snapshot so the header name and
+/// the changeset it heads land whole, from one build (specs/tui.md).
 #[derive(Debug)]
 pub struct WorldSnapshot {
     pub changed: HashMap<String, Annotation>,
     pub entries: Vec<Entry>,
+    pub branch_base: Option<git::ResolvedBase>,
 }
 
 /// Build the snapshot for `input`. The changeset is computed regardless of tab so the
@@ -48,9 +54,13 @@ pub fn build(input: &WorldInput) -> Result<WorldSnapshot> {
     // Outside a git repo, an empty snapshot paints the quiet empty state rather than a
     // failing status line every poll (specs/herdr-host.md).
     if !git::is_repo(&input.repo) {
-        return Ok(WorldSnapshot { changed: HashMap::new(), entries: Vec::new() });
+        return Ok(WorldSnapshot {
+            changed: HashMap::new(),
+            entries: Vec::new(),
+            branch_base: None,
+        });
     }
-    let changed = build_changed(input)?;
+    let (branch_base, changed) = build_changed(input)?;
     let changed_map = annotate(&changed);
     let entries = match input.tab {
         // The whole worktree (ignored included), with expanded ignored dirs loaded lazily.
@@ -58,26 +68,29 @@ pub fn build(input: &WorldInput) -> Result<WorldSnapshot> {
         // `Changes` (the `PR` tab never builds a snapshot).
         _ => changed.iter().map(Entry::from_changed).collect(),
     };
-    Ok(WorldSnapshot { changed: changed_map, entries })
+    Ok(WorldSnapshot { changed: changed_map, entries, branch_base })
 }
 
-/// The active scope's changed files alone — the piece a scope switch rebuilds before its
-/// frame, so the header count and list never wear another scope's label (specs/tui.md).
-pub fn build_changed(input: &WorldInput) -> Result<Vec<ChangedFile>> {
+/// The active scope's changed files and, on the `branch` scope, the base they diff against —
+/// the piece a scope switch rebuilds before its frame, so the header count and list never
+/// wear another scope's label (specs/tui.md).
+pub fn build_changed(input: &WorldInput) -> Result<(Option<git::ResolvedBase>, Vec<ChangedFile>)> {
     if !git::is_repo(&input.repo) {
-        return Ok(Vec::new());
+        return Ok((None, Vec::new()));
     }
     match input.scope {
         Scope::LastTurn => match input.turn_baseline.as_deref() {
-            Some(t) => git::changed_against_tree(&input.repo, t),
-            None => Ok(Vec::new()),
+            Some(t) => Ok((None, git::changed_against_tree(&input.repo, t)?)),
+            None => Ok((None, Vec::new())),
         },
-        _ => git::changed_files(
-            &input.repo,
-            input.scope,
-            input.base.as_deref(),
-            &input.base_branches,
-        ),
+        Scope::Uncommitted => Ok((None, git::changed_files(&input.repo, input.scope, None)?)),
+        Scope::Branch => {
+            let resolution = git::resolve_base(&input.repo, input.base.as_deref())
+                .map_err(|e| anyhow::anyhow!("{}", e.0))?;
+            let base_oid = resolution.winner.as_ref().map(|w| w.oid.clone());
+            let changed = git::changed_files(&input.repo, input.scope, base_oid.as_deref())?;
+            Ok((resolution.winner, changed))
+        }
     }
 }
 

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -2709,6 +2709,8 @@ fn switching_scope_on_all_files_remarks_in_place() {
     r.write("a.rs", "one\n");
     r.write("b.rs", "two\n");
     r.commit_all("init");
+    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
+    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
     r.git(&["checkout", "-q", "-b", "feature"]);
     r.write("b.rs", "TWO\n");
     r.commit_all("committed change to b"); // committed on the branch
@@ -2952,6 +2954,8 @@ fn changing_scope_on_all_files_snaps_the_changes_diff_to_the_top() {
     }
     r.write("a.rs", &body);
     r.commit_all("base");
+    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
+    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
     r.git(&["checkout", "-b", "feature"]);
     r.write("a.rs", &body.replace("line 5", "LINE 5"));
     r.commit_all("feature edit"); // a.rs differs from base → changed in branch scope
@@ -4105,7 +4109,7 @@ fn outside_a_repo_the_build_yields_the_quiet_empty_snapshot() {
     let app = App::new(dir.path().to_path_buf(), Scope::Uncommitted, None);
     let snapshot = herdr_reviewr::world::build(&app.world_input()).unwrap();
     assert!(snapshot.entries.is_empty(), "no error, no entries — the empty state stays quiet");
-    assert!(herdr_reviewr::world::build_changed(&app.world_input()).unwrap().is_empty());
+    assert!(herdr_reviewr::world::build_changed(&app.world_input()).unwrap().1.is_empty());
 }
 
 #[test]

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -5202,8 +5202,8 @@ fn typing_filters_and_enter_picks_the_highlight() {
     app.set_scope(Scope::Branch).unwrap();
     assert_eq!(app.branch_base.winner.as_ref().map(|b| b.name.as_str()), Some("main"));
     app.open_base_picker();
-    app.base_picker_input('d');
-    app.base_picker_input('e');
+    app.input_push('d');
+    app.input_push('e');
     let bp = app.base_picker.as_ref().unwrap();
     assert_eq!(bp.filtered().len(), 1, "the filter matches anywhere in the name");
     app.base_picker_pick().unwrap();
@@ -5227,7 +5227,7 @@ fn a_pick_retags_the_world_input() {
     app.set_scope(Scope::Branch).unwrap();
     let stale = app.world_input();
     app.open_base_picker();
-    app.base_picker_input('d');
+    app.input_push('d');
     app.base_picker_pick().unwrap();
     assert_ne!(app.world_input(), stale, "an in-flight build's tag no longer matches");
 }
@@ -5259,15 +5259,57 @@ fn a_filter_with_no_match_leaves_enter_inert_and_backspace_recovers() {
     app.set_scope(Scope::Branch).unwrap();
     app.open_base_picker();
     for ch in "zzz".chars() {
-        app.base_picker_input(ch);
+        app.input_push(ch);
     }
     assert!(app.base_picker.as_ref().unwrap().filtered().is_empty());
     app.base_picker_pick().unwrap();
     assert_eq!(app.mode, Mode::BasePick, "enter does nothing with no matching branch");
-    app.base_picker_backspace();
-    app.base_picker_backspace();
-    app.base_picker_backspace();
+    app.input_backspace();
+    app.input_backspace();
+    app.input_backspace();
     assert_eq!(app.base_picker.as_ref().unwrap().filtered().len(), 2);
+}
+
+#[test]
+fn a_repo_with_no_pickable_branch_refuses_to_open_the_picker() {
+    let r = Repo::init();
+    r.write("a.rs", "one\n");
+    r.commit_all("init");
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+
+    // One branch, checked out, and no origin default: nothing to choose, so the picker
+    // refuses with the cause rather than opening empty (`specs/input.md` Base picker).
+    app.open_base_picker();
+    assert_eq!(app.mode, Mode::Normal);
+    assert!(app.base_picker.is_none());
+    assert_eq!(app.status, "no branches to pick");
+}
+
+#[test]
+fn the_filter_edits_with_the_comment_editors_controls() {
+    let r = based_repo();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    for ch in "release dev".chars() {
+        app.input_push(ch);
+    }
+
+    // The filter is a text field like every other one: `ctrl+w` drops a word, the caret
+    // moves, and an insert lands at the caret (`specs/input.md` Base picker).
+    app.input_delete_word();
+    assert_eq!(app.base_picker.as_ref().unwrap().query, "release ");
+    app.input_kill_to_start();
+    assert_eq!(app.base_picker.as_ref().unwrap().query, "");
+    for ch in "dv".chars() {
+        app.input_push(ch);
+    }
+    app.caret_left();
+    app.input_push('e');
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(bp.query, "dev");
+    assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name, "dev", "the narrowed view still picks");
 }
 
 #[test]
@@ -5279,7 +5321,7 @@ fn the_highlight_follows_its_row_through_a_narrowing_filter() {
     app.base_picker_move(1); // main -> dev
     let bp = app.base_picker.as_ref().unwrap();
     assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name, "dev");
-    app.base_picker_input('d');
+    app.input_push('d');
     let bp = app.base_picker.as_ref().unwrap();
     assert_eq!(
         bp.rows[bp.filtered()[bp.cursor]].name,
@@ -5318,7 +5360,7 @@ fn the_base_picker_owns_the_whole_footer_bar_and_survives_a_config_error() {
     );
 
     // The config error leaves the picker open for recovery to carry (`specs/tui.md`).
-    app.base_picker_input('d');
+    app.input_push('d');
     app.set_config_error("theme = \"not-a-theme\"".to_string());
     assert_eq!(app.mode, Mode::BasePick);
     assert_eq!(app.base_picker.as_ref().unwrap().query, "d");

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -5203,7 +5203,7 @@ fn typing_filters_and_enter_picks_the_highlight() {
     let r = based_repo();
     let mut app = app_on(&r);
     app.set_scope(Scope::Branch).unwrap();
-    assert_eq!(app.branch_base.as_ref().map(|b| b.name.as_str()), Some("main"));
+    assert_eq!(app.branch_base.winner.as_ref().map(|b| b.name.as_str()), Some("main"));
     app.open_base_picker();
     app.base_picker_input('d');
     app.base_picker_input('e');
@@ -5211,7 +5211,7 @@ fn typing_filters_and_enter_picks_the_highlight() {
     assert_eq!(bp.filtered().len(), 1, "the filter matches anywhere in the name");
     app.base_picker_pick().unwrap();
     assert_eq!(app.mode, Mode::Normal, "a pick closes the picker");
-    assert_eq!(app.branch_base.as_ref().map(|b| b.name.as_str()), Some("dev"));
+    assert_eq!(app.branch_base.winner.as_ref().map(|b| b.name.as_str()), Some("dev"));
     let picked = r.git(&["show", "refs/reviewr/base-pick"]);
     assert_eq!(picked.trim(), "dev", "the pick persists in the private ref");
     assert!(
@@ -5241,13 +5241,13 @@ fn picking_the_default_clears_the_pick() {
     herdr_reviewr::git::write_base_pick(r.path(), "dev").unwrap();
     let mut app = app_on(&r);
     app.set_scope(Scope::Branch).unwrap();
-    assert_eq!(app.branch_base.as_ref().map(|b| b.name.as_str()), Some("dev"));
+    assert_eq!(app.branch_base.winner.as_ref().map(|b| b.name.as_str()), Some("dev"));
     app.open_base_picker();
     let bp = app.base_picker.as_ref().unwrap();
     assert_eq!(bp.rows[bp.cursor].name, "dev", "the highlight opens on the current base");
     app.base_picker_goto(0);
     app.base_picker_pick().unwrap();
-    assert_eq!(app.branch_base.as_ref().map(|b| b.name.as_str()), Some("main"));
+    assert_eq!(app.branch_base.winner.as_ref().map(|b| b.name.as_str()), Some("main"));
     assert_eq!(
         herdr_reviewr::git::read_base_pick(r.path()).unwrap(),
         None,
@@ -5300,7 +5300,7 @@ fn the_branch_scope_with_no_base_leads_the_footer_with_the_picker() {
     r.git(&["checkout", "-q", "-b", "feature"]);
     let mut app = app_on(&r);
     app.set_scope(Scope::Branch).unwrap();
-    assert!(app.branch_base.is_none(), "no origin/HEAD, no pick: nothing resolves");
+    assert!(app.branch_base.winner.is_none(), "no origin/HEAD, no pick: nothing resolves");
     assert!(app.entries.is_empty(), "the empty state is legible, never a guessed base");
     let bands: Vec<(FooterAction, Band)> = app.footer_bands();
     assert_eq!(bands[0], (FooterAction::BasePick, Band::Primary));

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -5310,6 +5310,15 @@ fn the_filter_edits_with_the_comment_editors_controls() {
     let bp = app.base_picker.as_ref().unwrap();
     assert_eq!(bp.query, "dev");
     assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name, "dev", "the narrowed view still picks");
+
+    // A branch name pasted with the trailing newline it was copied with still filters:
+    // the single-line field takes a newline as a space (`specs/input.md`).
+    app.caret_end();
+    app.input_kill_to_start();
+    app.input_paste("dev\n");
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(bp.query, "dev", "the trailing newline never lands in the query");
+    assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name, "dev", "the pasted name filters");
 }
 
 #[test]

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -2709,8 +2709,7 @@ fn switching_scope_on_all_files_remarks_in_place() {
     r.write("a.rs", "one\n");
     r.write("b.rs", "two\n");
     r.commit_all("init");
-    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
-    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    r.set_origin_default("main", "main");
     r.git(&["checkout", "-q", "-b", "feature"]);
     r.write("b.rs", "TWO\n");
     r.commit_all("committed change to b"); // committed on the branch
@@ -2954,8 +2953,7 @@ fn changing_scope_on_all_files_snaps_the_changes_diff_to_the_top() {
     }
     r.write("a.rs", &body);
     r.commit_all("base");
-    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
-    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    r.set_origin_default("main", "main");
     r.git(&["checkout", "-b", "feature"]);
     r.write("a.rs", &body.replace("line 5", "LINE 5"));
     r.commit_all("feature edit"); // a.rs differs from base → changed in branch scope
@@ -5161,8 +5159,7 @@ fn based_repo() -> Repo {
     let r = Repo::init();
     r.write("a.rs", "one\n");
     r.commit_all("init");
-    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
-    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    r.set_origin_default("main", "main");
     r.git(&["branch", "dev"]);
     r.git(&["checkout", "-q", "-b", "feature"]);
     r.write("a.rs", "two\n");

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -5221,6 +5221,21 @@ fn typing_filters_and_enter_picks_the_highlight() {
 }
 
 #[test]
+fn a_pick_retags_the_world_input() {
+    // The pick is read from its ref at build time, so it is not input identity on its
+    // own: the pick must bump the tag, or a build launched before it lands afterwards
+    // and reverts the picked base (`specs/tui.md`).
+    let r = based_repo();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let stale = app.world_input();
+    app.open_base_picker();
+    app.base_picker_input('d');
+    app.base_picker_pick().unwrap();
+    assert_ne!(app.world_input(), stale, "an in-flight build's tag no longer matches");
+}
+
+#[test]
 fn picking_the_default_clears_the_pick() {
     let r = based_repo();
     herdr_reviewr::git::write_base_pick(r.path(), "dev").unwrap();

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -5152,3 +5152,162 @@ fn the_picker_owns_the_whole_footer_bar() {
         vec![FooterAction::PickAgent, FooterAction::ClosePicker, FooterAction::MovePickerRow]
     );
 }
+
+// --- Base picker (specs/input.md Base picker, specs/review-model.md) -----------------------
+
+/// A repo on branch `feature` with sibling branches `dev` and `main`, `origin/HEAD`
+/// naming `main` the default, and one committed edit to diff.
+fn based_repo() -> Repo {
+    let r = Repo::init();
+    r.write("a.rs", "one\n");
+    r.commit_all("init");
+    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
+    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    r.git(&["branch", "dev"]);
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("a.rs", "two\n");
+    r.commit_all("feature work");
+    r
+}
+
+#[test]
+fn the_base_picker_opens_only_on_the_branch_scope_without_a_flag() {
+    let r = based_repo();
+    let mut app = app_on(&r);
+    app.open_base_picker();
+    assert_eq!(app.mode, Mode::Normal, "the picker is inert off the branch scope");
+
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    assert_eq!(app.mode, Mode::BasePick);
+    let bp = app.base_picker.as_ref().expect("picker state");
+    let names: Vec<&str> = bp.rows.iter().map(|r| r.name.as_str()).collect();
+    assert!(!names.contains(&"feature"), "the checked-out branch is not listed");
+    assert_eq!(bp.rows[0].name, "main", "the default branch sorts ahead of recency");
+    assert!(bp.rows[0].is_default);
+    assert!(names.contains(&"dev"));
+    assert_eq!(bp.cursor, 0, "the highlight opens on the current base");
+    app.close_base_picker();
+    assert_eq!(app.mode, Mode::Normal);
+    assert!(app.base_picker.is_none());
+
+    // A `--base` flag pins the base for the session, so the picker never opens.
+    let mut flagged = App::new(r.path_buf(), Scope::Branch, Some("dev".to_string()));
+    flagged.reload().unwrap();
+    flagged.open_base_picker();
+    assert_eq!(flagged.mode, Mode::Normal, "the flag disables the picker");
+}
+
+#[test]
+fn typing_filters_and_enter_picks_the_highlight() {
+    let r = based_repo();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    assert_eq!(app.branch_base.as_ref().map(|b| b.name.as_str()), Some("main"));
+    app.open_base_picker();
+    app.base_picker_input('d');
+    app.base_picker_input('e');
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(bp.filtered().len(), 1, "the filter matches anywhere in the name");
+    app.base_picker_pick().unwrap();
+    assert_eq!(app.mode, Mode::Normal, "a pick closes the picker");
+    assert_eq!(app.branch_base.as_ref().map(|b| b.name.as_str()), Some("dev"));
+    let picked = r.git(&["show", "refs/reviewr/base-pick"]);
+    assert_eq!(picked.trim(), "dev", "the pick persists in the private ref");
+    assert!(
+        app.entries.iter().any(|e| e.path == "a.rs"),
+        "the changeset rebuilds against the picked base before the frame"
+    );
+}
+
+#[test]
+fn picking_the_default_clears_the_pick() {
+    let r = based_repo();
+    herdr_reviewr::git::write_base_pick(r.path(), "dev").unwrap();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    assert_eq!(app.branch_base.as_ref().map(|b| b.name.as_str()), Some("dev"));
+    app.open_base_picker();
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(bp.rows[bp.cursor].name, "dev", "the highlight opens on the current base");
+    app.base_picker_goto(0);
+    app.base_picker_pick().unwrap();
+    assert_eq!(app.branch_base.as_ref().map(|b| b.name.as_str()), Some("main"));
+    assert_eq!(
+        herdr_reviewr::git::read_base_pick(r.path()).unwrap(),
+        None,
+        "choosing the default clears the pick rather than recording it"
+    );
+}
+
+#[test]
+fn a_filter_with_no_match_leaves_enter_inert_and_backspace_recovers() {
+    let r = based_repo();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    for ch in "zzz".chars() {
+        app.base_picker_input(ch);
+    }
+    assert!(app.base_picker.as_ref().unwrap().filtered().is_empty());
+    app.base_picker_pick().unwrap();
+    assert_eq!(app.mode, Mode::BasePick, "enter does nothing with no matching branch");
+    app.base_picker_backspace();
+    app.base_picker_backspace();
+    app.base_picker_backspace();
+    assert_eq!(app.base_picker.as_ref().unwrap().filtered().len(), 2);
+}
+
+#[test]
+fn the_highlight_follows_its_row_through_a_narrowing_filter() {
+    let r = based_repo();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    app.base_picker_move(1); // main -> dev
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name, "dev");
+    app.base_picker_input('d');
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(
+        bp.rows[bp.filtered()[bp.cursor]].name,
+        "dev",
+        "the highlight keeps its row when the row survives the filter"
+    );
+}
+
+#[test]
+fn the_branch_scope_with_no_base_leads_the_footer_with_the_picker() {
+    let r = Repo::init();
+    r.write("a.rs", "one\n");
+    r.commit_all("init");
+    r.git(&["branch", "dev"]);
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    assert!(app.branch_base.is_none(), "no origin/HEAD, no pick: nothing resolves");
+    assert!(app.entries.is_empty(), "the empty state is legible, never a guessed base");
+    let bands: Vec<(FooterAction, Band)> = app.footer_bands();
+    assert_eq!(bands[0], (FooterAction::BasePick, Band::Primary));
+    assert_eq!(bands[1], (FooterAction::ScopeOther, Band::Do));
+    assert_eq!(bands[2], (FooterAction::Refresh, Band::Do));
+}
+
+#[test]
+fn the_base_picker_owns_the_whole_footer_bar_and_survives_a_config_error() {
+    let r = based_repo();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    let bands: Vec<FooterAction> = app.footer_bands().into_iter().map(|(a, _)| a).collect();
+    assert_eq!(
+        bands,
+        vec![FooterAction::PickBaseRow, FooterAction::ClosePicker, FooterAction::MoveBaseRow]
+    );
+
+    // The config error leaves the picker open for recovery to carry (`specs/tui.md`).
+    app.base_picker_input('d');
+    app.set_config_error("theme = \"not-a-theme\"".to_string());
+    assert_eq!(app.mode, Mode::BasePick);
+    assert_eq!(app.base_picker.as_ref().unwrap().query, "d");
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -71,6 +71,16 @@ impl Repo {
         ]);
     }
 
+    /// Record `content` as the base-pick blob verbatim, bypassing `write_base_pick` — for
+    /// the values only a foreign writer could put on that shared ref.
+    pub fn write_raw_base_pick(&self, content: &str) {
+        let path = self.path().join("raw-pick");
+        std::fs::write(&path, content).unwrap();
+        let blob = self.git(&["hash-object", "-w", path.to_str().unwrap()]).trim().to_string();
+        self.git(&["update-ref", "refs/reviewr/base-pick", &blob]);
+        std::fs::remove_file(&path).unwrap();
+    }
+
     pub fn write(&self, rel: &str, contents: &str) {
         let path = self.path().join(rel);
         if let Some(parent) = path.parent() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -32,6 +32,28 @@ impl Repo {
         self.dir.path().to_path_buf()
     }
 
+    /// Like [`Self::git`] with extra environment variables — a pinned committer date makes
+    /// commit-recency ordering deterministic without sleeping across a clock tick.
+    pub fn git_env(&self, args: &[&str], env: &[(&str, &str)]) -> String {
+        let out = Command::new("git")
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@herdr.test")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@herdr.test")
+            .envs(env.iter().copied())
+            .arg("-C")
+            .arg(self.path())
+            .args(args)
+            .output()
+            .expect("git");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
     /// Run `git -C <repo> <args>`, asserting success, returning stdout.
     pub fn git(&self, args: &[&str]) -> String {
         let out = Command::new("git")

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -56,22 +56,19 @@ impl Repo {
 
     /// Run `git -C <repo> <args>`, asserting success, returning stdout.
     pub fn git(&self, args: &[&str]) -> String {
-        let out = Command::new("git")
-            .env("GIT_AUTHOR_NAME", "Test")
-            .env("GIT_AUTHOR_EMAIL", "test@herdr.test")
-            .env("GIT_COMMITTER_NAME", "Test")
-            .env("GIT_COMMITTER_EMAIL", "test@herdr.test")
-            .arg("-C")
-            .arg(self.path())
-            .args(args)
-            .output()
-            .expect("git");
-        assert!(
-            out.status.success(),
-            "git {args:?} failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-        String::from_utf8_lossy(&out.stdout).into_owned()
+        self.git_env(args, &[])
+    }
+
+    /// Fabricate a remote-tracking default branch without a real remote: a
+    /// `refs/remotes/origin/<name>` ref at the given rev plus the `origin/HEAD` symref.
+    pub fn set_origin_default(&self, name: &str, rev: &str) {
+        let oid = self.git(&["rev-parse", rev]).trim().to_string();
+        self.git(&["update-ref", &format!("refs/remotes/origin/{name}"), &oid]);
+        self.git(&[
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            &format!("refs/remotes/origin/{name}"),
+        ]);
     }
 
     pub fn write(&self, rel: &str, contents: &str) {

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -7,9 +7,10 @@ use std::path::Path;
 
 use common::Repo;
 use herdr_reviewr::git::{
-    all_files, changed_against_tree, changed_files as changed_files_with_config, file_content,
-    merge_base as merge_base_with_config, read_baseline_ref, snapshot_worktree, worktree_key,
-    write_baseline_ref,
+    BaseSource, all_files, changed_against_tree, changed_files as changed_files_oid,
+    clear_base_pick, default_branch_name, file_content, list_branches,
+    merge_base as merge_base_oid, read_base_pick, read_baseline_ref, resolve_base,
+    snapshot_worktree, worktree_key, write_base_pick, write_baseline_ref,
 };
 use herdr_reviewr::model::{ChangeKind, ChangedFile, Scope};
 
@@ -17,23 +18,26 @@ fn by_path(files: &[ChangedFile]) -> HashMap<&str, &ChangedFile> {
     files.iter().map(|f| (f.path.as_str(), f)).collect()
 }
 
-fn bases() -> Vec<String> {
-    herdr_reviewr::config::DEFAULT_BASE_BRANCHES
-        .iter()
-        .map(|branch| (*branch).to_string())
-        .collect()
-}
-
 fn changed_files(
     repo: &Path,
     scope: Scope,
     base: Option<&str>,
 ) -> anyhow::Result<Vec<ChangedFile>> {
-    changed_files_with_config(repo, scope, base, &bases())
+    let winner = resolve_base(repo, base).map_err(|e| anyhow::anyhow!("{}", e.0))?.winner;
+    changed_files_oid(repo, scope, winner.as_ref().map(|w| w.oid.as_str()))
 }
 
 fn merge_base(repo: &Path, base: Option<&str>) -> Option<String> {
-    merge_base_with_config(repo, base, &bases())
+    let winner = resolve_base(repo, base).ok()?.winner?;
+    merge_base_oid(repo, &winner.oid)
+}
+
+/// Fabricate a remote-tracking default branch without a real remote: a
+/// `refs/remotes/origin/<name>` ref at the given rev plus the `origin/HEAD` symref.
+fn set_origin_default(r: &Repo, name: &str, rev: &str) {
+    let oid = r.git(&["rev-parse", rev]).trim().to_string();
+    r.git(&["update-ref", &format!("refs/remotes/origin/{name}"), &oid]);
+    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", &format!("refs/remotes/origin/{name}")]);
 }
 
 #[test]
@@ -99,7 +103,33 @@ fn merge_base_is_the_branch_point() {
 }
 
 #[test]
-fn base_resolves_via_the_default_list_without_a_flag() {
+fn the_chain_is_flag_then_pick_then_default() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    set_origin_default(&r, "main", "HEAD");
+    r.git(&["branch", "picked-base"]);
+    r.git(&["branch", "flagged-base"]);
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("base.rs", "2\n");
+    r.commit_all("diverge");
+
+    // Default branch alone: `origin/HEAD` names `main` (specs/review-model.md).
+    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    assert_eq!((winner.name.as_str(), winner.source), ("main", BaseSource::DefaultBranch));
+
+    // A pick outranks the default.
+    write_base_pick(r.path(), "picked-base").unwrap();
+    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    assert_eq!((winner.name.as_str(), winner.source), ("picked-base", BaseSource::Pick));
+
+    // The flag outranks the pick.
+    let winner = resolve_base(r.path(), Some("flagged-base")).unwrap().winner.unwrap();
+    assert_eq!((winner.name.as_str(), winner.source), ("flagged-base", BaseSource::Flag));
+}
+
+#[test]
+fn base_resolves_via_the_pick_without_a_flag() {
     let r = Repo::init();
     r.write("base.rs", "1\n");
     r.commit_all("base");
@@ -108,12 +138,14 @@ fn base_resolves_via_the_default_list_without_a_flag() {
     r.write("base.rs", "2\n");
     r.commit_all("diverge");
 
-    // No flag: the default `base_branches` list skips the absent `origin/*` and finds `main`.
+    // No flag, no origin: only a recorded pick names the base (specs/review-model.md).
+    assert_eq!(merge_base(r.path(), None), None);
+    write_base_pick(r.path(), "main").unwrap();
     assert_eq!(merge_base(r.path(), None), Some(branch_point));
 }
 
 #[test]
-fn a_nonexistent_flag_falls_through_to_the_list() {
+fn a_nonexistent_flag_falls_through_and_reads_as_skipped() {
     let r = Repo::init();
     r.write("base.rs", "1\n");
     r.commit_all("base");
@@ -121,9 +153,97 @@ fn a_nonexistent_flag_falls_through_to_the_list() {
     r.git(&["checkout", "-q", "-b", "feature"]);
     r.write("base.rs", "2\n");
     r.commit_all("diverge");
+    write_base_pick(r.path(), "main").unwrap();
 
-    // A `--base` naming no existing ref is skipped, not an error; resolution uses the list.
+    // A `--base` naming no existing ref is skipped, not an error; the pick resolves, and
+    // the header can name the dead flag (specs/review-model.md, specs/tui.md).
     assert_eq!(merge_base(r.path(), Some("no-such-ref")), Some(branch_point));
+    let winner = resolve_base(r.path(), Some("no-such-ref")).unwrap().winner.unwrap();
+    assert_eq!(winner.skipped.as_deref(), Some("no-such-ref"));
+}
+
+#[test]
+fn a_dormant_pick_is_skipped_and_reactivates() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    set_origin_default(&r, "main", "HEAD");
+    r.git(&["branch", "dev"]);
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("base.rs", "2\n");
+    r.commit_all("diverge");
+    write_base_pick(r.path(), "dev").unwrap();
+
+    // The pick wins while its branch resolves.
+    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    assert_eq!(winner.source, BaseSource::Pick);
+
+    // The branch disappears: the pick is kept and skipped, the default wins, and the
+    // header can say so (specs/review-model.md).
+    r.git(&["branch", "-D", "dev"]);
+    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    assert_eq!((winner.name.as_str(), winner.source), ("main", BaseSource::DefaultBranch));
+    assert_eq!(winner.skipped.as_deref(), Some("dev"));
+    assert_eq!(read_base_pick(r.path()).unwrap().as_deref(), Some("dev"));
+
+    // The branch returns: the pick reactivates without a new choice.
+    r.git(&["branch", "dev", "main"]);
+    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    assert_eq!((winner.name.as_str(), winner.source), ("dev", BaseSource::Pick));
+}
+
+#[test]
+fn the_pick_persists_in_a_private_ref_and_clears() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+
+    // Absent until written; a write survives re-reading (a fresh pane would reread the
+    // same ref); a clear removes it (specs/review-model.md).
+    assert_eq!(read_base_pick(r.path()).unwrap(), None);
+    write_base_pick(r.path(), "dev").unwrap();
+    assert_eq!(read_base_pick(r.path()).unwrap().as_deref(), Some("dev"));
+    write_base_pick(r.path(), "release/1.0").unwrap();
+    assert_eq!(read_base_pick(r.path()).unwrap().as_deref(), Some("release/1.0"));
+    clear_base_pick(r.path()).unwrap();
+    assert_eq!(read_base_pick(r.path()).unwrap(), None);
+
+    // The only ref the pick machinery touches lives under `refs/reviewr/` — the worktree,
+    // index, and branches stay untouched (specs/overview.md No writes).
+    write_base_pick(r.path(), "dev").unwrap();
+    let refs = r.git(&["for-each-ref", "--format=%(refname)"]);
+    let reviewr_refs: Vec<&str> = refs.lines().filter(|l| !l.starts_with("refs/heads/")).collect();
+    assert_eq!(reviewr_refs, ["refs/reviewr/base-pick"]);
+    assert_eq!(r.git(&["status", "--porcelain"]).trim(), "");
+}
+
+#[test]
+fn default_branch_name_reads_the_origin_head_symref() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    assert_eq!(default_branch_name(r.path()).unwrap(), None);
+    set_origin_default(&r, "trunk", "HEAD");
+    assert_eq!(default_branch_name(r.path()).unwrap().as_deref(), Some("trunk"));
+}
+
+#[test]
+fn list_branches_merges_names_newest_first_and_hides_the_checked_out() {
+    let r = Repo::init();
+    r.write("a.rs", "1\n");
+    r.git(&["add", "-A"]);
+    r.git_env(&["commit", "-q", "-m", "one"], &[("GIT_COMMITTER_DATE", "2026-01-01T00:00:00")]);
+    r.git(&["branch", "older"]);
+    set_origin_default(&r, "main", "HEAD");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("a.rs", "2\n");
+    r.commit_all("two");
+    r.git(&["branch", "newer"]);
+
+    // Local and origin names merge (main exists only as origin/main here), the newest
+    // commit sorts first, and the checked-out branch is not listed (specs/input.md).
+    let names = list_branches(r.path()).unwrap();
+    assert_eq!(names, ["newer", "main", "older"]);
 }
 
 #[test]
@@ -190,7 +310,7 @@ fn ignored_paths_never_enter_changes() {
 }
 
 #[test]
-fn branch_scope_falls_back_to_master_when_main_is_absent() {
+fn branch_scope_is_empty_without_a_recorded_base() {
     let r = Repo::init();
     r.write("base.rs", "1\n");
     r.commit_all("base");
@@ -199,9 +319,15 @@ fn branch_scope_falls_back_to_master_when_main_is_absent() {
     r.write("feature.rs", "x\n");
     r.commit_all("feature work");
 
-    // base = None → the fallback chain (origin/main, origin/master, main, master) finds master.
+    // base = None and nothing recorded → no base, and the scope lists nothing rather than
+    // guessing (specs/review-model.md).
     let files = changed_files(r.path(), Scope::Branch, None).unwrap();
-    assert!(files.iter().any(|f| f.path == "feature.rs"), "resolved master as the base ref");
+    assert!(files.is_empty(), "no source resolves, so the scope shows nothing");
+
+    // A pick of `master` brings the scope back.
+    write_base_pick(r.path(), "master").unwrap();
+    let files = changed_files(r.path(), Scope::Branch, None).unwrap();
+    assert!(files.iter().any(|f| f.path == "feature.rs"), "the pick names the base");
 }
 
 #[test]

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -23,12 +23,12 @@ fn changed_files(
     scope: Scope,
     base: Option<&str>,
 ) -> anyhow::Result<Vec<ChangedFile>> {
-    let winner = resolve_base(repo, base).map_err(|e| anyhow::anyhow!("{}", e.0))?.winner;
+    let winner = resolve_base(repo, base).map_err(|e| anyhow::anyhow!("{}", e.0))?.status.winner;
     changed_files_oid(repo, scope, winner.as_ref().map(|w| w.oid.as_str()))
 }
 
 fn merge_base(repo: &Path, base: Option<&str>) -> Option<String> {
-    let winner = resolve_base(repo, base).ok()?.winner?;
+    let winner = resolve_base(repo, base).ok()?.status.winner?;
     merge_base_oid(repo, &winner.oid)
 }
 
@@ -115,16 +115,16 @@ fn the_chain_is_flag_then_pick_then_default() {
     r.commit_all("diverge");
 
     // Default branch alone: `origin/HEAD` names `main` (specs/review-model.md).
-    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
     assert_eq!((winner.name.as_str(), winner.source), ("main", BaseSource::DefaultBranch));
 
     // A pick outranks the default.
     write_base_pick(r.path(), "picked-base").unwrap();
-    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
     assert_eq!((winner.name.as_str(), winner.source), ("picked-base", BaseSource::Pick));
 
     // The flag outranks the pick.
-    let winner = resolve_base(r.path(), Some("flagged-base")).unwrap().winner.unwrap();
+    let winner = resolve_base(r.path(), Some("flagged-base")).unwrap().status.winner.unwrap();
     assert_eq!((winner.name.as_str(), winner.source), ("flagged-base", BaseSource::Flag));
 }
 
@@ -158,8 +158,8 @@ fn a_nonexistent_flag_falls_through_and_reads_as_skipped() {
     // A `--base` naming no existing ref is skipped, not an error; the pick resolves, and
     // the header can name the dead flag (specs/review-model.md, specs/tui.md).
     assert_eq!(merge_base(r.path(), Some("no-such-ref")), Some(branch_point));
-    let winner = resolve_base(r.path(), Some("no-such-ref")).unwrap().winner.unwrap();
-    assert_eq!(winner.skipped.as_deref(), Some("no-such-ref"));
+    let status = resolve_base(r.path(), Some("no-such-ref")).unwrap().status;
+    assert_eq!(status.skipped.as_deref(), Some("no-such-ref"));
 }
 
 #[test]
@@ -174,7 +174,7 @@ fn a_prefixed_flag_spelling_resolves_to_the_bare_name() {
 
     // `--base origin/main` resolves as a verbatim rev, but the header and the PR name
     // shield carry the bare spelling (specs/tui.md, specs/forge-host.md).
-    let winner = resolve_base(r.path(), Some("origin/main")).unwrap().winner.unwrap();
+    let winner = resolve_base(r.path(), Some("origin/main")).unwrap().status.winner.unwrap();
     assert_eq!((winner.name.as_str(), winner.source), ("main", BaseSource::Flag));
 }
 
@@ -191,21 +191,36 @@ fn a_dormant_pick_is_skipped_and_reactivates() {
     write_base_pick(r.path(), "dev").unwrap();
 
     // The pick wins while its branch resolves.
-    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
     assert_eq!(winner.source, BaseSource::Pick);
 
     // The branch disappears: the pick is kept and skipped, the default wins, and the
     // header can say so (specs/review-model.md).
     r.git(&["branch", "-D", "dev"]);
-    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    let status = resolve_base(r.path(), None).unwrap().status;
+    let winner = status.winner.unwrap();
     assert_eq!((winner.name.as_str(), winner.source), ("main", BaseSource::DefaultBranch));
-    assert_eq!(winner.skipped.as_deref(), Some("dev"));
+    assert_eq!(status.skipped.as_deref(), Some("dev"));
     assert_eq!(read_base_pick(r.path()).unwrap().as_deref(), Some("dev"));
 
     // The branch returns: the pick reactivates without a new choice.
     r.git(&["branch", "dev", "main"]);
-    let winner = resolve_base(r.path(), None).unwrap().winner.unwrap();
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
     assert_eq!((winner.name.as_str(), winner.source), ("dev", BaseSource::Pick));
+}
+
+#[test]
+fn a_dormant_pick_survives_even_when_nothing_resolves() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    write_base_pick(r.path(), "gone").unwrap();
+
+    // No flag, no default, and the picked branch is missing: the skip still reports, so
+    // the header reads `no base · gone missing`, never a bare `no base` (specs/tui.md).
+    let status = resolve_base(r.path(), None).unwrap().status;
+    assert_eq!(status.winner, None);
+    assert_eq!(status.skipped.as_deref(), Some("gone"));
 }
 
 #[test]
@@ -241,6 +256,19 @@ fn default_branch_name_reads_the_origin_head_symref() {
     assert_eq!(default_branch_name(r.path()).unwrap(), None);
     set_origin_default(&r, "trunk", "HEAD");
     assert_eq!(default_branch_name(r.path()).unwrap().as_deref(), Some("trunk"));
+}
+
+#[test]
+fn a_dangling_origin_head_symref_names_no_default() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    set_origin_default(&r, "master", "HEAD");
+
+    // `fetch --prune` after a server-side rename deletes the target but leaves the
+    // symref: a name resolving to nothing is no default (specs/review-model.md).
+    r.git(&["update-ref", "-d", "refs/remotes/origin/master"]);
+    assert_eq!(default_branch_name(r.path()).unwrap(), None);
 }
 
 #[test]

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -163,6 +163,22 @@ fn a_nonexistent_flag_falls_through_and_reads_as_skipped() {
 }
 
 #[test]
+fn a_prefixed_flag_spelling_resolves_to_the_bare_name() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    set_origin_default(&r, "main", "HEAD");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("base.rs", "2\n");
+    r.commit_all("diverge");
+
+    // `--base origin/main` resolves as a verbatim rev, but the header and the PR name
+    // shield carry the bare spelling (specs/tui.md, specs/forge-host.md).
+    let winner = resolve_base(r.path(), Some("origin/main")).unwrap().winner.unwrap();
+    assert_eq!((winner.name.as_str(), winner.source), ("main", BaseSource::Flag));
+}
+
+#[test]
 fn a_dormant_pick_is_skipped_and_reactivates() {
     let r = Repo::init();
     r.write("base.rs", "1\n");
@@ -228,6 +244,20 @@ fn default_branch_name_reads_the_origin_head_symref() {
 }
 
 #[test]
+fn a_plain_ref_origin_head_names_the_matching_tip() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    let oid = r.git(&["rev-parse", "HEAD"]).trim().to_string();
+    r.git(&["update-ref", "refs/remotes/origin/trunk", &oid]);
+
+    // Some clones carry `origin/HEAD` as a plain ref, not a symref: the default is the
+    // origin tip at the same commit (specs/review-model.md).
+    r.git(&["update-ref", "refs/remotes/origin/HEAD", &oid]);
+    assert_eq!(default_branch_name(r.path()).unwrap().as_deref(), Some("trunk"));
+}
+
+#[test]
 fn list_branches_merges_names_newest_first_and_hides_the_checked_out() {
     let r = Repo::init();
     r.write("a.rs", "1\n");
@@ -244,6 +274,23 @@ fn list_branches_merges_names_newest_first_and_hides_the_checked_out() {
     // commit sorts first, and the checked-out branch is not listed (specs/input.md).
     let names = list_branches(r.path()).unwrap();
     assert_eq!(names, ["newer", "main", "older"]);
+}
+
+#[test]
+fn the_checked_out_default_branch_stays_listed() {
+    let r = Repo::init();
+    r.write("a.rs", "1\n");
+    r.git(&["add", "-A"]);
+    r.git_env(&["commit", "-q", "-m", "one"], &[("GIT_COMMITTER_DATE", "2026-01-01T00:00:00")]);
+    r.git(&["branch", "dev"]);
+    r.write("a.rs", "2\n");
+    r.commit_all("two");
+    set_origin_default(&r, "main", "HEAD");
+
+    // Checked out on the default branch itself: its row stays, or a recorded pick could
+    // never be cleared from the picker (specs/input.md).
+    let names = list_branches(r.path()).unwrap();
+    assert_eq!(names, ["main", "dev"]);
 }
 
 #[test]

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -190,6 +190,12 @@ fn a_pick_git_could_never_have_written_is_no_pick() {
     // can smuggle an escape sequence into the frame (specs/review-model.md).
     r.write_raw_base_pick("dev\u{1b}]0;pwned\u{7}");
     assert_eq!(read_base_pick(r.path()).unwrap(), None);
+
+    // Nor a rev expression: `main~5` resolves to a commit no branch names, and the header
+    // would paint it as though a branch were chosen.
+    r.write_raw_base_pick("main~5");
+    assert_eq!(read_base_pick(r.path()).unwrap(), None);
+
     let status = resolve_base(r.path(), None).unwrap().status;
     assert_eq!(status.skipped, None, "a malformed pick is not a recorded choice either");
     assert_eq!(status.winner.unwrap().name, "main");

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -168,6 +168,31 @@ fn a_prefixed_flag_spelling_resolves_to_the_bare_name() {
     // shield carry the bare spelling (specs/tui.md, specs/forge-host.md).
     let winner = resolve_base(r.path(), Some("origin/main")).unwrap().status.winner.unwrap();
     assert_eq!(winner.name, "main");
+
+    // A prefixed spelling that resolves to nothing is skipped under the same bare name,
+    // so the header reads `· gone missing`, never `· origin/gone missing`.
+    let status = resolve_base(r.path(), Some("origin/gone")).unwrap().status;
+    assert_eq!(status.skipped.as_deref(), Some("gone"));
+}
+
+#[test]
+fn a_pick_git_could_never_have_written_is_no_pick() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    r.set_origin_default("main", "HEAD");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("base.rs", "2\n");
+    r.commit_all("diverge");
+
+    // The pick ref is shared repository state any tool can write, and a skipped pick paints
+    // its name in the header: a blob carrying control bytes is no pick at all, so nothing
+    // can smuggle an escape sequence into the frame (specs/review-model.md).
+    r.write_raw_base_pick("dev\u{1b}]0;pwned\u{7}");
+    assert_eq!(read_base_pick(r.path()).unwrap(), None);
+    let status = resolve_base(r.path(), None).unwrap().status;
+    assert_eq!(status.skipped, None, "a malformed pick is not a recorded choice either");
+    assert_eq!(status.winner.unwrap().name, "main");
 }
 
 #[test]
@@ -284,6 +309,11 @@ fn list_branches_merges_names_newest_first_and_hides_the_checked_out() {
     r.git(&["add", "-A"]);
     r.git_env(&["commit", "-q", "-m", "one"], &[("GIT_COMMITTER_DATE", "2026-01-01T00:00:00")]);
     r.git(&["branch", "older"]);
+    // Every branch gets its own commit date, so the asserted order follows the contract
+    // rather than git's tie-break between two branches sharing a timestamp.
+    r.write("a.rs", "1b\n");
+    r.git(&["add", "-A"]);
+    r.git_env(&["commit", "-q", "-m", "middle"], &[("GIT_COMMITTER_DATE", "2026-02-01T00:00:00")]);
     r.set_origin_default("main", "HEAD");
     r.git(&["checkout", "-q", "-b", "feature"]);
     r.write("a.rs", "2\n");

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -7,10 +7,10 @@ use std::path::Path;
 
 use common::Repo;
 use herdr_reviewr::git::{
-    BaseSource, all_files, changed_against_tree, changed_files as changed_files_oid,
-    clear_base_pick, default_branch_name, file_content, list_branches,
-    merge_base as merge_base_oid, read_base_pick, read_baseline_ref, resolve_base,
-    snapshot_worktree, worktree_key, write_base_pick, write_baseline_ref,
+    all_files, changed_against_tree, changed_files as changed_files_oid, clear_base_pick,
+    default_branch_name, file_content, list_branches, merge_base as merge_base_oid, read_base_pick,
+    read_baseline_ref, resolve_base, snapshot_worktree, worktree_key, write_base_pick,
+    write_baseline_ref,
 };
 use herdr_reviewr::model::{ChangeKind, ChangedFile, Scope};
 
@@ -30,14 +30,6 @@ fn changed_files(
 fn merge_base(repo: &Path, base: Option<&str>) -> Option<String> {
     let winner = resolve_base(repo, base).ok()?.status.winner?;
     merge_base_oid(repo, &winner.oid)
-}
-
-/// Fabricate a remote-tracking default branch without a real remote: a
-/// `refs/remotes/origin/<name>` ref at the given rev plus the `origin/HEAD` symref.
-fn set_origin_default(r: &Repo, name: &str, rev: &str) {
-    let oid = r.git(&["rev-parse", rev]).trim().to_string();
-    r.git(&["update-ref", &format!("refs/remotes/origin/{name}"), &oid]);
-    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", &format!("refs/remotes/origin/{name}")]);
 }
 
 #[test]
@@ -107,7 +99,7 @@ fn the_chain_is_flag_then_pick_then_default() {
     let r = Repo::init();
     r.write("base.rs", "1\n");
     r.commit_all("base");
-    set_origin_default(&r, "main", "HEAD");
+    r.set_origin_default("main", "HEAD");
     r.git(&["branch", "picked-base"]);
     r.git(&["branch", "flagged-base"]);
     r.git(&["checkout", "-q", "-b", "feature"]);
@@ -116,16 +108,16 @@ fn the_chain_is_flag_then_pick_then_default() {
 
     // Default branch alone: `origin/HEAD` names `main` (specs/review-model.md).
     let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
-    assert_eq!((winner.name.as_str(), winner.source), ("main", BaseSource::DefaultBranch));
+    assert_eq!(winner.name, "main");
 
     // A pick outranks the default.
     write_base_pick(r.path(), "picked-base").unwrap();
     let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
-    assert_eq!((winner.name.as_str(), winner.source), ("picked-base", BaseSource::Pick));
+    assert_eq!(winner.name, "picked-base");
 
     // The flag outranks the pick.
     let winner = resolve_base(r.path(), Some("flagged-base")).unwrap().status.winner.unwrap();
-    assert_eq!((winner.name.as_str(), winner.source), ("flagged-base", BaseSource::Flag));
+    assert_eq!(winner.name, "flagged-base");
 }
 
 #[test]
@@ -167,7 +159,7 @@ fn a_prefixed_flag_spelling_resolves_to_the_bare_name() {
     let r = Repo::init();
     r.write("base.rs", "1\n");
     r.commit_all("base");
-    set_origin_default(&r, "main", "HEAD");
+    r.set_origin_default("main", "HEAD");
     r.git(&["checkout", "-q", "-b", "feature"]);
     r.write("base.rs", "2\n");
     r.commit_all("diverge");
@@ -175,7 +167,7 @@ fn a_prefixed_flag_spelling_resolves_to_the_bare_name() {
     // `--base origin/main` resolves as a verbatim rev, but the header and the PR name
     // shield carry the bare spelling (specs/tui.md, specs/forge-host.md).
     let winner = resolve_base(r.path(), Some("origin/main")).unwrap().status.winner.unwrap();
-    assert_eq!((winner.name.as_str(), winner.source), ("main", BaseSource::Flag));
+    assert_eq!(winner.name, "main");
 }
 
 #[test]
@@ -183,7 +175,7 @@ fn a_dormant_pick_is_skipped_and_reactivates() {
     let r = Repo::init();
     r.write("base.rs", "1\n");
     r.commit_all("base");
-    set_origin_default(&r, "main", "HEAD");
+    r.set_origin_default("main", "HEAD");
     r.git(&["branch", "dev"]);
     r.git(&["checkout", "-q", "-b", "feature"]);
     r.write("base.rs", "2\n");
@@ -192,21 +184,21 @@ fn a_dormant_pick_is_skipped_and_reactivates() {
 
     // The pick wins while its branch resolves.
     let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
-    assert_eq!(winner.source, BaseSource::Pick);
+    assert_eq!(winner.name, "dev");
 
     // The branch disappears: the pick is kept and skipped, the default wins, and the
     // header can say so (specs/review-model.md).
     r.git(&["branch", "-D", "dev"]);
     let status = resolve_base(r.path(), None).unwrap().status;
     let winner = status.winner.unwrap();
-    assert_eq!((winner.name.as_str(), winner.source), ("main", BaseSource::DefaultBranch));
+    assert_eq!(winner.name, "main");
     assert_eq!(status.skipped.as_deref(), Some("dev"));
     assert_eq!(read_base_pick(r.path()).unwrap().as_deref(), Some("dev"));
 
     // The branch returns: the pick reactivates without a new choice.
     r.git(&["branch", "dev", "main"]);
     let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
-    assert_eq!((winner.name.as_str(), winner.source), ("dev", BaseSource::Pick));
+    assert_eq!(winner.name, "dev");
 }
 
 #[test]
@@ -254,7 +246,7 @@ fn default_branch_name_reads_the_origin_head_symref() {
     r.write("base.rs", "1\n");
     r.commit_all("base");
     assert_eq!(default_branch_name(r.path()).unwrap(), None);
-    set_origin_default(&r, "trunk", "HEAD");
+    r.set_origin_default("trunk", "HEAD");
     assert_eq!(default_branch_name(r.path()).unwrap().as_deref(), Some("trunk"));
 }
 
@@ -263,7 +255,7 @@ fn a_dangling_origin_head_symref_names_no_default() {
     let r = Repo::init();
     r.write("base.rs", "1\n");
     r.commit_all("base");
-    set_origin_default(&r, "master", "HEAD");
+    r.set_origin_default("master", "HEAD");
 
     // `fetch --prune` after a server-side rename deletes the target but leaves the
     // symref: a name resolving to nothing is no default (specs/review-model.md).
@@ -292,7 +284,7 @@ fn list_branches_merges_names_newest_first_and_hides_the_checked_out() {
     r.git(&["add", "-A"]);
     r.git_env(&["commit", "-q", "-m", "one"], &[("GIT_COMMITTER_DATE", "2026-01-01T00:00:00")]);
     r.git(&["branch", "older"]);
-    set_origin_default(&r, "main", "HEAD");
+    r.set_origin_default("main", "HEAD");
     r.git(&["checkout", "-q", "-b", "feature"]);
     r.write("a.rs", "2\n");
     r.commit_all("two");
@@ -300,7 +292,7 @@ fn list_branches_merges_names_newest_first_and_hides_the_checked_out() {
 
     // Local and origin names merge (main exists only as origin/main here), the newest
     // commit sorts first, and the checked-out branch is not listed (specs/input.md).
-    let names = list_branches(r.path()).unwrap();
+    let names = list_branches(r.path(), default_branch_name(r.path()).unwrap().as_deref()).unwrap();
     assert_eq!(names, ["newer", "main", "older"]);
 }
 
@@ -313,11 +305,11 @@ fn the_checked_out_default_branch_stays_listed() {
     r.git(&["branch", "dev"]);
     r.write("a.rs", "2\n");
     r.commit_all("two");
-    set_origin_default(&r, "main", "HEAD");
+    r.set_origin_default("main", "HEAD");
 
     // Checked out on the default branch itself: its row stays, or a recorded pick could
     // never be cleared from the picker (specs/input.md).
-    let names = list_branches(r.path()).unwrap();
+    let names = list_branches(r.path(), default_branch_name(r.path()).unwrap().as_deref()).unwrap();
     assert_eq!(names, ["main", "dev"]);
 }
 

--- a/tests/pr_candidates.rs
+++ b/tests/pr_candidates.rs
@@ -23,8 +23,7 @@ fn worktree() -> Repo {
     repo.write("a.txt", "one\n");
     repo.commit_all("base");
     repo.git(&["remote", "add", "origin", "https://github.com/owner/repo.git"]);
-    repo.git(&["update-ref", "refs/remotes/origin/main", "main"]);
-    repo.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    repo.set_origin_default("main", "main");
     repo.git(&["switch", "-qc", "work"]);
     repo.write("b.txt", "two\n");
     repo.commit_all("feature");
@@ -226,8 +225,7 @@ fn an_upstream_on_a_base_resolved_without_its_name_is_excluded_by_tip() {
     repo.git(&["branch", "-qm", "develop"]);
     repo.write("d.txt", "dev\n");
     repo.commit_all("develop work");
-    repo.git(&["update-ref", "refs/remotes/origin/develop", "develop"]);
-    repo.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop"]);
+    repo.set_origin_default("develop", "develop");
     let develop_tip = repo.git(&["rev-parse", "develop"]).trim().to_string();
     repo.git(&["switch", "-qc", "work"]);
     repo.write("b.txt", "two\n");

--- a/tests/pr_candidates.rs
+++ b/tests/pr_candidates.rs
@@ -199,7 +199,7 @@ fn every_resolved_base_source_excludes_names() {
 
 #[test]
 fn a_dormant_pick_still_shields_its_name() {
-    // The picked `develop` no longer resolves (its refs are gone), but the record stands:
+    // The picked `develop` was never created, so it resolves to nothing, but the record stands:
     // an upstream naming it is still tracking a base, not publishing to it
     // (`specs/forge-host.md` Resolution — "resolved or recorded").
     let repo = worktree();

--- a/tests/pr_candidates.rs
+++ b/tests/pr_candidates.rs
@@ -11,19 +11,20 @@ use herdr_reviewr::config::{PluginConfig, plugin_config_in};
 use herdr_reviewr::forge::{Association, PrInputError, assoc_history, fetch_input, resolve_pick};
 use herdr_reviewr::git::{
     GitFail, PrLocalState, RepositoryIdentity, ahead_behind_oids, contains_commit,
-    pr_local as pr_local_with_config,
 };
 use std::io::Write;
 use std::path::Path;
 
-/// A repo on branch `work` (one commit past `main`), with a GitHub `origin` remote and
-/// `origin/main` tracking-ref at `main`'s tip — the baseline every test builds on.
+/// A repo on branch `work` (one commit past `main`), with a GitHub `origin` remote,
+/// `origin/main` tracking-ref at `main`'s tip, and `origin/HEAD` naming `main` the
+/// default branch — the baseline every test builds on.
 fn worktree() -> Repo {
     let repo = Repo::init();
     repo.write("a.txt", "one\n");
     repo.commit_all("base");
     repo.git(&["remote", "add", "origin", "https://github.com/owner/repo.git"]);
     repo.git(&["update-ref", "refs/remotes/origin/main", "main"]);
+    repo.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
     repo.git(&["switch", "-qc", "work"]);
     repo.write("b.txt", "two\n");
     repo.commit_all("feature");
@@ -39,8 +40,7 @@ fn defaults() -> PluginConfig {
 }
 
 fn pr_local(repo: &Path, base: Option<&str>) -> Result<PrLocalState, GitFail> {
-    let config = defaults();
-    pr_local_with_config(repo, base, config.base_branches())
+    herdr_reviewr::git::pr_local(repo, base)
 }
 
 fn assert_target(identity: &RepositoryIdentity, host: &str, owner: &str, name: &str) {
@@ -174,9 +174,9 @@ fn a_recorded_upstream_joins_the_names_unless_it_names_a_base() {
 }
 
 #[test]
-fn secondary_configured_bases_also_exclude_names() {
-    // Gitflow: `develop` wins the pin, but a tip on `main` history must still
-    // contribute no name — every configured base excludes.
+fn every_resolved_base_source_excludes_names() {
+    // Gitflow: the picked `develop` wins the pin, but a tip on the default `main`'s
+    // history must still contribute no name — every source that resolved excludes.
     let repo = worktree();
     repo.git(&["switch", "-qc", "develop", "main"]);
     repo.write("d.txt", "dev\n");
@@ -191,14 +191,8 @@ fn secondary_configured_bases_also_exclude_names() {
     // The worktree parks at main's tip with zero work of its own.
     repo.git(&["switch", "-qC", "work", "main"]);
 
-    let config_dir = tempfile::tempdir().unwrap();
-    std::fs::write(
-        config_dir.path().join("config.toml"),
-        "base_branches = [\"develop\", \"main\"]\n",
-    )
-    .unwrap();
-    let config = plugin_config_in(config_dir.path()).unwrap();
-    let local = pr_local_with_config(repo.path(), None, config.base_branches()).expect("pr_local");
+    herdr_reviewr::git::write_base_pick(repo.path(), "develop").unwrap();
+    let local = pr_local(repo.path(), None).expect("pr_local");
     let develop_tip = repo.git(&["rev-parse", "origin/develop"]).trim().to_string();
     assert_eq!(local.base_oid.as_deref(), Some(develop_tip.as_str()), "develop wins the pin");
     assert_eq!(local.names, ["work"], "a tip on main history contributes no name");
@@ -460,12 +454,12 @@ fn fetch_input_changes_only_with_derived_query_state() {
     let head_changed = fetch_input(repo.path(), None, &defaults()).unwrap();
     assert_ne!(head_changed, names_changed);
 
-    // A different base pin changes the input.
-    let config_dir = tempfile::tempdir().unwrap();
-    std::fs::write(config_dir.path().join("config.toml"), "base_branches = [\"work\"]\n").unwrap();
-    let custom = plugin_config_in(config_dir.path()).unwrap();
-    let base_changed = fetch_input(repo.path(), None, &custom).unwrap();
+    // A base pick written by any pane changes the input; clearing it restores the default.
+    herdr_reviewr::git::write_base_pick(repo.path(), "work").unwrap();
+    let base_changed = fetch_input(repo.path(), None, &defaults()).unwrap();
     assert_ne!(base_changed, head_changed);
+    herdr_reviewr::git::clear_base_pick(repo.path()).unwrap();
+    assert_eq!(fetch_input(repo.path(), None, &defaults()).unwrap(), head_changed);
 }
 
 #[test]

--- a/tests/pr_candidates.rs
+++ b/tests/pr_candidates.rs
@@ -199,6 +199,20 @@ fn every_resolved_base_source_excludes_names() {
 }
 
 #[test]
+fn a_dormant_pick_still_shields_its_name() {
+    // The picked `develop` no longer resolves (its refs are gone), but the record stands:
+    // an upstream naming it is still tracking a base, not publishing to it
+    // (`specs/forge-host.md` Resolution — "resolved or recorded").
+    let repo = worktree();
+    herdr_reviewr::git::write_base_pick(repo.path(), "develop").unwrap();
+    repo.git(&["config", "branch.work.remote", "origin"]);
+    repo.git(&["config", "branch.work.merge", "refs/heads/develop"]);
+
+    let local = pr_local(repo.path(), None).expect("pr_local");
+    assert_eq!(local.names, ["work"], "the dormant pick's name never joins");
+}
+
+#[test]
 fn an_upstream_on_a_base_resolved_without_its_name_is_excluded_by_tip() {
     // The `develop`-default repo under the stock `main`/`master` config: the base
     // resolves only through `origin/HEAD`, so no configured entry carries its name.

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2860,6 +2860,50 @@ fn an_overlong_base_name_truncates_with_an_ellipsis() {
 }
 
 #[test]
+fn a_narrow_header_never_maps_a_click_outside_the_painted_base() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    let long = format!("feature/{}", "x".repeat(60));
+    r.git(&["branch", &long]);
+    herdr_reviewr::git::write_base_pick(r.path(), &long).unwrap();
+    r.git(&["checkout", "-q", "-b", "work"]);
+    r.write("hello.rs", "alpha\nBETA\n");
+    r.commit_all("edit");
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+
+    // The base label truncates to its budget at a narrow width, and the hit test walks the
+    // same arithmetic the paint does: every column it claims carries painted label, and the
+    // claim is one unbroken run (specs/tui.md).
+    for width in [40u16, 56, 72] {
+        let area = Rect { x: 0, y: 0, width, height: 12 };
+        let line0 = dump(&render_size(&app, width, 12)).lines().next().unwrap().to_string();
+        let cells: Vec<char> = line0.chars().collect();
+        let hits: Vec<u16> = (0..width)
+            .filter(|&c| ui::hit_header(area, &app, app.keymap(), c, 0) == Some(HeaderHit::Base))
+            .collect();
+        let Some((&first, &last)) = hits.first().zip(hits.last()) else { continue };
+        assert_eq!(
+            hits.len() as u16,
+            last - first + 1,
+            "width {width}: the base claims one unbroken run"
+        );
+        let claimed: String = hits.iter().map(|&c| cells[c as usize]).collect();
+        assert_ne!(claimed.trim(), "vs", "width {width}: a nameless `vs` is claimed: {line0}");
+        assert!(
+            !claimed.ends_with(' '),
+            "width {width}: the claim runs past the painted label: {line0}"
+        );
+        assert_eq!(
+            cells.get(last as usize + 1).copied(),
+            Some(' '),
+            "width {width}: the claim stops short of the painted label: {line0}"
+        );
+    }
+}
+
+#[test]
 fn an_overlong_skipped_tail_never_evicts_the_base_name() {
     let r = Repo::init();
     r.write("hello.rs", "alpha\n");

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2883,7 +2883,13 @@ fn a_narrow_header_never_maps_a_click_outside_the_painted_base() {
         let hits: Vec<u16> = (0..width)
             .filter(|&c| ui::hit_header(area, &app, app.keymap(), c, 0) == Some(HeaderHit::Base))
             .collect();
-        let Some((&first, &last)) = hits.first().zip(hits.last()) else { continue };
+        let Some((&first, &last)) = hits.first().zip(hits.last()) else {
+            // Too narrow for even one column of the name: the base left the header whole,
+            // so nothing paints a nameless `vs` and nothing claims it (specs/tui.md).
+            assert!(!line0.contains("vs"), "width {width}: a nameless `vs` paints: {line0}");
+            assert!(line0.contains("[branch]"), "width {width}: the scope survives: {line0}");
+            continue;
+        };
         assert_eq!(
             hits.len() as u16,
             last - first + 1,

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1301,8 +1301,7 @@ fn header_tab_hits_align_with_wide_hint_keys() {
     let row0 = out.lines().next().unwrap().to_string();
     let col_of = |needle: &str| row0[..row0.find(needle).unwrap()].chars().count() as u16;
     let area = Rect::new(0, 0, 140, 40);
-    for (needle, tab) in
-        [("Changes", Tab::Changes), ("2 Files", Tab::AllFiles), ("3 PR", Tab::Pr)]
+    for (needle, tab) in [("Changes", Tab::Changes), ("2 Files", Tab::AllFiles), ("3 PR", Tab::Pr)]
     {
         assert_eq!(
             ui::hit_header(area, &app, app.keymap(), col_of(needle), 0),

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -867,27 +867,21 @@ fn the_box_is_inserted_under_the_selected_line() {
 const AREA: Rect = Rect { x: 0, y: 0, width: 140, height: 40 };
 
 #[test]
-fn header_clicks_map_to_scope_and_send() {
+fn header_clicks_map_to_the_scope_chip() {
     let app = edited_app(); // scope uncommitted, no comments
     // Scan the header row instead of hardcoding columns, so the test survives changes
-    // to the label/button text.
+    // to the label text.
     let scope: Vec<u16> = (0..AREA.width)
         .filter(|&c| ui::hit_header(AREA, &app, app.keymap(), c, 0) == Some(HeaderHit::Scope))
         .collect();
-    let send: Vec<u16> = (0..AREA.width)
-        .filter(|&c| ui::hit_header(AREA, &app, app.keymap(), c, 0) == Some(HeaderHit::Send))
-        .collect();
 
     assert!(!scope.is_empty(), "scope chip is clickable");
-    assert!(!send.is_empty(), "send button is clickable");
-    assert!(scope.iter().max() < send.iter().min(), "scope is left of the button, no overlap");
-    assert!(*send.iter().max().unwrap() < AREA.width);
 
     let gap = scope.iter().max().unwrap() + 1;
     assert_eq!(
         ui::hit_header(AREA, &app, app.keymap(), gap, 0),
         None,
-        "the space between controls is inert"
+        "the space right of the chip is inert"
     );
     assert_eq!(
         ui::hit_header(AREA, &app, app.keymap(), scope[0], 5),
@@ -1200,7 +1194,7 @@ fn all_files_tab_bar_footer_and_count_read_for_the_tab() {
 
     let out = render(&app);
     assert!(out.contains("1 Changes"), "tab labels carry their switch digit:\n{out}");
-    assert!(out.contains("2 All files"));
+    assert!(out.contains("2 Files"));
     assert!(
         out.contains("1 changed"),
         "the changed count stays in the header on All files:\n{out}"
@@ -1219,30 +1213,6 @@ fn all_files_tab_bar_footer_and_count_read_for_the_tab() {
     let expanded = render(&app);
     assert!(expanded.contains("scope"), "the `?` expansion lists the scope keys:\n{expanded}");
     assert!(expanded.contains("move"), "and labels the movement band:\n{expanded}");
-}
-
-#[test]
-fn a_narrow_overflowing_header_does_not_mis_map_a_click_to_send() {
-    let r = Repo::init();
-    r.write("a.rs", "x\n");
-    r.commit_all("init");
-    r.write("a.rs", "y\n");
-    let app = app_on(&r);
-
-    // At a narrow pane width the two-tab header overflows and the Send button is off-screen.
-    // No on-screen column may map to Send — the old right-aligned hit-zone landed a phantom Send
-    // over the chip/tab region, swallowing those clicks as a Send.
-    let width: u16 = 34;
-    let area = Rect::new(0, 0, width, 40);
-    let phantom =
-        (0..width).any(|c| ui::hit_header(area, &app, app.keymap(), c, 0) == Some(HeaderHit::Send));
-    assert!(!phantom, "no on-screen column mis-maps to Send when the narrow header overflows");
-
-    // At a wide width the Send button is right-aligned and clickable.
-    let wide = Rect::new(0, 0, 140, 40);
-    let send =
-        (0..140).any(|c| ui::hit_header(wide, &app, app.keymap(), c, 0) == Some(HeaderHit::Send));
-    assert!(send, "Send is clickable when the header fits");
 }
 
 #[test]
@@ -1332,7 +1302,7 @@ fn header_tab_hits_align_with_wide_hint_keys() {
     let col_of = |needle: &str| row0[..row0.find(needle).unwrap()].chars().count() as u16;
     let area = Rect::new(0, 0, 140, 40);
     for (needle, tab) in
-        [("Changes", Tab::Changes), ("2 All files", Tab::AllFiles), ("3 PR", Tab::Pr)]
+        [("Changes", Tab::Changes), ("2 Files", Tab::AllFiles), ("3 PR", Tab::Pr)]
     {
         assert_eq!(
             ui::hit_header(area, &app, app.keymap(), col_of(needle), 0),

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2762,8 +2762,7 @@ fn based_app() -> (Repo, App) {
     let r = Repo::init();
     r.write("hello.rs", "alpha\n");
     r.commit_all("init");
-    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
-    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    r.set_origin_default("main", "main");
     r.git(&["branch", "dev"]);
     r.git(&["checkout", "-q", "-b", "feature"]);
     r.write("hello.rs", "alpha\nBETA\n");
@@ -2802,8 +2801,7 @@ fn a_skipped_pick_warns_beside_the_resolved_base() {
     let r = Repo::init();
     r.write("hello.rs", "alpha\n");
     r.commit_all("init");
-    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
-    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    r.set_origin_default("main", "main");
     herdr_reviewr::git::write_base_pick(r.path(), "gone").unwrap();
     r.git(&["checkout", "-q", "-b", "feature"]);
     let mut app = app_on(&r);
@@ -2866,8 +2864,7 @@ fn an_overlong_skipped_tail_never_evicts_the_base_name() {
     let r = Repo::init();
     r.write("hello.rs", "alpha\n");
     r.commit_all("init");
-    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
-    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    r.set_origin_default("main", "main");
     let long = format!("feature/{}", "x".repeat(80));
     herdr_reviewr::git::write_base_pick(r.path(), &long).unwrap();
     r.git(&["checkout", "-q", "-b", "work"]);

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2753,3 +2753,94 @@ fn a_click_on_a_picker_row_moves_the_highlight_and_misses_stay_inert() {
     .unwrap();
     assert_eq!(app.picker_cursor, 2, "a click moves the highlight to the clicked row");
 }
+
+// --- Header base label (specs/tui.md) ------------------------------------------------------
+
+/// A repo on branch `feature` past `main`, with `origin/HEAD` naming `main` the default.
+/// The repo rides along: opening the picker shells out to git at click time.
+fn based_app() -> (Repo, App) {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
+    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    r.git(&["branch", "dev"]);
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("hello.rs", "alpha\nBETA\n");
+    r.commit_all("edit");
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    (r, app)
+}
+
+#[test]
+fn the_branch_header_names_the_base_and_its_click_opens_the_picker() {
+    let (_repo, mut app) = based_app();
+    let line0 = render(&app).lines().next().unwrap().to_string();
+    assert!(line0.contains("[branch] vs main"), "the bare base name follows the scope: {line0}");
+
+    let base: Vec<u16> = (0..AREA.width)
+        .filter(|&c| ui::hit_header(AREA, &app, app.keymap(), c, 0) == Some(HeaderHit::Base))
+        .collect();
+    assert!(!base.is_empty(), "the base label is clickable");
+    let click = MouseEvent {
+        kind: MouseEventKind::Down(ratatui::crossterm::event::MouseButton::Left),
+        column: base[0],
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    };
+    let keymap = app.keymap().clone();
+    handle_mouse(&mut app, click, AREA, &[], &keymap).unwrap();
+    let frame = render(&app);
+    assert!(frame.contains("Pick base"), "the click opens the picker popup");
+    assert!(frame.contains("dev"), "the sibling branch is a row");
+    assert!(frame.contains("default"), "the default branch is marked");
+}
+
+#[test]
+fn a_skipped_pick_warns_beside_the_resolved_base() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
+    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    herdr_reviewr::git::write_base_pick(r.path(), "gone").unwrap();
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let line0 = render(&app).lines().next().unwrap().to_string();
+    assert!(line0.contains("vs main · gone missing"), "the dormant pick reads as skipped: {line0}");
+}
+
+#[test]
+fn without_a_resolving_base_the_header_reads_no_base() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let frame = render(&app);
+    let line0 = frame.lines().next().unwrap().to_string();
+    assert!(line0.contains("[branch] no base"), "the empty state is named: {line0}");
+    assert!(frame.contains("pick base"), "the footer advertises the picker");
+}
+
+#[test]
+fn an_overlong_base_name_truncates_with_an_ellipsis() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    let long = format!("feature/{}", "x".repeat(80));
+    r.git(&["branch", &long]);
+    herdr_reviewr::git::write_base_pick(r.path(), &long).unwrap();
+    r.git(&["checkout", "-q", "-b", "work"]);
+    r.write("hello.rs", "alpha\nBETA\n");
+    r.commit_all("edit");
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let line0 = dump(&render_size(&app, 80, 20)).lines().next().unwrap().to_string();
+    assert!(line0.contains("vs feature/x"), "the name paints up to the fit: {line0}");
+    assert!(line0.contains('…'), "the overflow truncates with a trailing ellipsis: {line0}");
+    assert!(line0.contains("1 changed"), "the right-aligned stats survive the long name: {line0}");
+}

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2844,3 +2844,24 @@ fn an_overlong_base_name_truncates_with_an_ellipsis() {
     assert!(line0.contains('…'), "the overflow truncates with a trailing ellipsis: {line0}");
     assert!(line0.contains("1 changed"), "the right-aligned stats survive the long name: {line0}");
 }
+
+#[test]
+fn an_overlong_skipped_tail_never_evicts_the_base_name() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.git(&["update-ref", "refs/remotes/origin/main", "main"]);
+    r.git(&["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    let long = format!("feature/{}", "x".repeat(80));
+    herdr_reviewr::git::write_base_pick(r.path(), &long).unwrap();
+    r.git(&["checkout", "-q", "-b", "work"]);
+    r.write("hello.rs", "alpha\nBETA\n");
+    r.commit_all("edit");
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let line0 = dump(&render_size(&app, 80, 20)).lines().next().unwrap().to_string();
+    assert!(line0.contains("vs main"), "the resolved name keeps first claim: {line0}");
+    assert!(line0.contains("· feature/x"), "the skipped tail paints in what remains: {line0}");
+    assert!(line0.contains('…'), "the tail truncates with a trailing ellipsis: {line0}");
+    assert!(line0.contains("1 changed"), "the right-aligned stats survive the long tail: {line0}");
+}

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -2827,6 +2827,22 @@ fn without_a_resolving_base_the_header_reads_no_base() {
 }
 
 #[test]
+fn a_dormant_pick_shows_beside_the_empty_state() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    herdr_reviewr::git::write_base_pick(r.path(), "gone").unwrap();
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let line0 = render(&app).lines().next().unwrap().to_string();
+    assert!(
+        line0.contains("no base · gone missing"),
+        "a dormant choice never reads as never-chosen: {line0}"
+    );
+}
+
+#[test]
 fn an_overlong_base_name_truncates_with_an_ellipsis() {
     let r = Repo::init();
     r.write("hello.rs", "alpha\n");


### PR DESCRIPTION
Closes #42.

## Problem

The `branch` scope diffs against a fixed lookup: the `base_branches` config (default `main`, `master`), then `origin/HEAD`. In a repo whose trunk is `dev`, the scope silently diffs against `main`, and the chosen base is never displayed, so the wrong diff reads as broken autodetection (reported by @danielo515). The same fixed list blocks stacked branches, where the base is another feature branch. A global config list cannot fix it, because one repo's convention poisons another.

## What changes

The base is always a visible, recorded choice. It resolves through one chain: the `--base` flag, then a per-repo pick, then `origin/HEAD`, then a legible empty state.

- **The header names the base.** The `branch` scope reads `vs dev`. A recorded choice whose branch is gone reads `vs main · dev missing`, and a repo where nothing resolves reads `no base`. Clicking the name opens the picker.
- **`B` opens a base picker.** Rows are every local and origin branch merged by name, sorted by recent commit, with the open PR's target starred first and the default branch marked `default`. Type to filter, `enter` picks. Choosing the default clears the pick.
- **The pick is a private ref.** It lives as a blob under `refs/reviewr/base-pick`, so it survives restarts and is shared by every worktree of the repo. It is skipped rather than dropped when its branch disappears, and it reactivates when the branch comes back.
- **`base_branches` is retired strictly.** A config still carrying the key fails to load like any other unknown key, and the standard recovery flow applies.

The header tidy-up ships in the same branch: the `All files` tab is labelled `Files`, the `Send` button is gone, and the changed-file count with its line totals is right-aligned.

## Why this shape

Three alternatives were weighed and rejected. A **global config list** was the existing design and is what fails: one repo's convention poisons another. **Reflog or topology inference** is rejected industry-wide as unreliable, and is now an explicit non-goal in `specs/review-model.md` — no amount of evidence should make reviewr guess a base. **Following the forge's PR target automatically** is deferred rather than rejected: the picker stars it today, and auto-following it is a recorded open decision pending a QA trial.

A provenance tag in the header (`vs origin/main · default`) was designed and then dropped after a width analysis. The bare name is what the reviewer needs, and the tag cost the room a long branch name needs.

## Verification

`just ci` green. The full suite runs 645 tests, including the base chain's order and skip behavior, pick persistence across worktrees, picker rows and filtering, and the header's states and click hit-test at narrow widths. The PTY latency benchmark was run A/B against `main` and is flat.

Every touched spec is promoted to `Current`: `review-model.md`, `input.md`, `tui.md`, `config.md`, `overview.md`, `pr-tab.md`, `search.md`.

## Known open question

For a picked branch that exists both locally and on origin, resolution prefers `origin/<name>`. A stacked branch whose local base is ahead of its pushed tip therefore diffs against the stale remote. Flipping the order has the symmetric failure with a stale local `main`. This is pre-existing and spec-pinned, and is left for a deliberate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
