### PR TITLE
feat: respect `.editorconfig` tab widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **EditorConfig tab widths.** Hard tabs now use each file's local `.editorconfig`
+  `tab_width`, or its numeric `indent_size` fallback, in diffs, file views, and search.
+
 ## [0.30.1] — 2026-08-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ec4rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b31a881d38439026e3d5dd938ab20328d36e23caca8fd5981c42e4b677f5842"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +914,7 @@ version = "0.30.1"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
+ "ec4rs",
  "fff-search",
  "pulldown-cmark",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities", "development-tools"]
 [dependencies]
 anyhow = "1"
 dirs = "6"
+ec4rs = "1.2"
 fff-search = "0.10.0"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 ratatui = "0.30"

--- a/specs/diff-view.md
+++ b/specs/diff-view.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-24
-Last edited: 2026-07-20
+Last edited: 2026-08-09
 ---
 
 # Diff view
@@ -39,6 +39,7 @@ What the reviewer sees (unified view, a renamed TypeScript file):
 | `previous_path` | string? | the old path when renamed, absent otherwise                     |
 | `state`         | enum    | `normal` shows rows, `binary` and `too_large` show a notice     |
 | `view`          | enum    | `diff` shows change rows and folds, `file` shows all `context`  |
+| `tab_width`     | integer | display columns between hard-tab stops for this file            |
 | `rows`          | Row[]   | the render-and-cursor units, in display order                   |
 
 ### Row
@@ -129,7 +130,12 @@ Returning to source differs per view:
 - Long lines wrap by default, at word boundaries. A word wider than the column hard-breaks. A toggle switches to horizontal scroll (`←`/`→`), with the gutter pinned.
 - A wrapped continuation row has a blank gutter and drops the break's leading space.
 - A commented line shows its line number in the comment color. The change bar keeps its own color.
-- Tabs render as spaces, 4 by default.
+- Tabs render as spaces to the next tab stop. The width resolves for the displayed file from
+  `.editorconfig`: files are searched from the file's directory upward until `root = true` or
+  the filesystem root, matching sections in source order with closer files winning. A valid
+  `tab_width` applies; without one, a numeric `indent_size` applies; otherwise the width is 4.
+  `unset` removes an inherited value. Unreadable or malformed EditorConfig input falls back to
+  width 4. A refresh rereads the setting, including for an unchanged open file.
 
 ### Comment anchoring
 

--- a/specs/search.md
+++ b/specs/search.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-07-18
-Last edited: 2026-08-08
+Last edited: 2026-08-09
 ---
 
 # Search
@@ -98,6 +98,7 @@ is useful before the first keystroke.
 - A file's first match emits a header row in the file-list row look, then its match rows.
 - A match row is `line:` dimmed, then the matched line, its leading indentation dropped so
   the match text aligns at the left.
+- Hard tabs use the matched file's EditorConfig tab width (`diff-view.md`).
 - A match row longer than the pane clips around its first matched span, keeping the
   emphasis visible.
 - The pick lands only on match rows in `Code` mode, only on file rows in `Files` mode.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1155,6 +1155,10 @@ impl App {
         self.diff_path = Some(path.clone());
         let (old, new) = self.content_sides(&path, previous_path.as_deref());
         self.diff = self.cache.get(path, previous_path, &old, &new, &self.highlighter);
+        // Tab stops are display metadata, not highlighted content. Resolve them on every
+        // rebuild so editing a local `.editorconfig` repaints an unchanged open file on the
+        // next refresh without invalidating the expensive diff cache (`specs/diff-view.md`).
+        self.diff.tab_width = crate::editorconfig::tab_width(&self.repo, &self.diff.path);
         // Hold the new side as the preview's render input, the same current content the File
         // view previews. A non-markdown file, a notice, or a deleted file (empty new side)
         // holds nothing, so its toggle stays inert (specs/diff-view.md).
@@ -1204,10 +1208,13 @@ impl App {
         let oversize = std::fs::metadata(self.repo.join(path))
             .is_ok_and(|m| crate::diff::over_byte_budget(m.len() as usize));
         if oversize {
-            (FileDiff::too_large_notice(path.to_string()), String::new())
+            let mut diff = FileDiff::too_large_notice(path.to_string());
+            diff.tab_width = crate::editorconfig::tab_width(&self.repo, path);
+            (diff, String::new())
         } else {
             let content = worktree_content(&self.repo, path);
-            let diff = self.cache.get_file(path.to_string(), &content, &self.highlighter);
+            let mut diff = self.cache.get_file(path.to_string(), &content, &self.highlighter);
+            diff.tab_width = crate::editorconfig::tab_width(&self.repo, path);
             (diff, content)
         }
     }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -135,6 +135,8 @@ pub struct FileDiff {
     pub previous_path: Option<String>,
     pub state: FileState,
     pub view: View,
+    /// Display columns between hard-tab stops, resolved for `path` from `EditorConfig`.
+    pub tab_width: usize,
     pub rows: Vec<Row>,
 }
 
@@ -165,6 +167,7 @@ impl FileDiff {
             previous_path: None,
             state: FileState::Normal,
             view: View::Diff,
+            tab_width: crate::editorconfig::DEFAULT_TAB_WIDTH,
             rows: Vec::new(),
         }
     }
@@ -184,6 +187,7 @@ impl FileDiff {
             previous_path: previous_path.clone(),
             state,
             view: View::Diff,
+            tab_width: crate::editorconfig::DEFAULT_TAB_WIDTH,
             rows: Vec::new(),
         };
         if old.contains('\0') || new.contains('\0') {
@@ -235,6 +239,7 @@ impl FileDiff {
             previous_path,
             state: FileState::Normal,
             view: View::Diff,
+            tab_width: crate::editorconfig::DEFAULT_TAB_WIDTH,
             rows: collapse_context(&rows),
         }
     }
@@ -248,6 +253,7 @@ impl FileDiff {
             previous_path: None,
             state,
             view: View::File,
+            tab_width: crate::editorconfig::DEFAULT_TAB_WIDTH,
             rows: Vec::new(),
         };
         if content.contains('\0') {
@@ -269,7 +275,14 @@ impl FileDiff {
                 }
             })
             .collect();
-        Self { path, previous_path: None, state: FileState::Normal, view: View::File, rows }
+        Self {
+            path,
+            previous_path: None,
+            state: FileState::Normal,
+            view: View::File,
+            tab_width: crate::editorconfig::DEFAULT_TAB_WIDTH,
+            rows,
+        }
     }
 
     /// The File-view `too_large` notice, for an over-budget file the caller declines to read.
@@ -280,6 +293,7 @@ impl FileDiff {
             previous_path: None,
             state: FileState::TooLarge,
             view: View::File,
+            tab_width: crate::editorconfig::DEFAULT_TAB_WIDTH,
             rows: Vec::new(),
         }
     }

--- a/src/editorconfig.rs
+++ b/src/editorconfig.rs
@@ -1,0 +1,93 @@
+//! The `EditorConfig` properties that affect source display.
+//!
+//! See `specs/diff-view.md`. Resolution happens when a file model is built, never while a
+//! frame paints, so walking parent directories cannot turn rendering into filesystem work.
+
+use std::path::Path;
+
+use ec4rs::property::TabWidth;
+
+/// The historical tab stop when no usable `EditorConfig` property applies.
+pub const DEFAULT_TAB_WIDTH: usize = 4;
+
+/// Resolve the tab stop for `path`, including `EditorConfig`'s `indent_size` fallback.
+/// An unreadable, malformed, missing, or zero-width setting degrades to the historical default.
+#[must_use]
+pub fn tab_width(repo: &Path, path: &str) -> usize {
+    let mut properties = ec4rs::properties_of(repo.join(path)).unwrap_or_default();
+    properties.use_fallbacks();
+    match properties.get::<TabWidth>() {
+        Ok(TabWidth::Value(width)) if width > 0 => width,
+        _ => DEFAULT_TAB_WIDTH,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::{DEFAULT_TAB_WIDTH, tab_width};
+
+    #[test]
+    fn defaults_to_four_without_a_matching_setting() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(".editorconfig"), "root = true\n[*.md]\ntab_width = 2\n")
+            .unwrap();
+        assert_eq!(tab_width(dir.path(), "src/main.rs"), DEFAULT_TAB_WIDTH);
+    }
+
+    #[test]
+    fn closer_files_and_later_sections_win() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join(".editorconfig"),
+            "root = true\n[*]\ntab_width = 8\n[*.rs]\ntab_width = 6\n",
+        )
+        .unwrap();
+        fs::create_dir(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/.editorconfig"), "[*.rs]\ntab_width = 2\n").unwrap();
+        assert_eq!(tab_width(dir.path(), "src/main.rs"), 2);
+        assert_eq!(tab_width(dir.path(), "README.md"), 8);
+    }
+
+    #[test]
+    fn numeric_indent_size_is_the_standard_fallback() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(".editorconfig"), "root = true\n[*]\nindent_size = 3\n").unwrap();
+        assert_eq!(tab_width(dir.path(), "src/main.rs"), 3);
+    }
+
+    #[test]
+    fn explicit_tab_width_wins_over_indent_size() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join(".editorconfig"),
+            "root = true\n[*.{rs,py}]\nindent_size = 2\ntab_width = 7\n",
+        )
+        .unwrap();
+        assert_eq!(tab_width(dir.path(), "nested/main.rs"), 7);
+    }
+
+    #[test]
+    fn unset_removes_an_inherited_width() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join(".editorconfig"),
+            "root = true\n[*]\ntab_width = 8\n[generated/**]\ntab_width = unset\n",
+        )
+        .unwrap();
+        assert_eq!(tab_width(dir.path(), "generated/main.rs"), DEFAULT_TAB_WIDTH);
+    }
+
+    #[test]
+    fn invalid_or_malformed_settings_keep_the_default() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(".editorconfig"), "root = true\n[*]\ntab_width = 0\n").unwrap();
+        assert_eq!(tab_width(dir.path(), "main.rs"), DEFAULT_TAB_WIDTH);
+
+        fs::write(dir.path().join(".editorconfig"), "root = true\n[broken\n").unwrap();
+        assert_eq!(tab_width(dir.path(), "main.rs"), DEFAULT_TAB_WIDTH);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod azure_devops;
 pub mod browser;
 pub mod config;
 pub mod diff;
+pub mod editorconfig;
 pub mod export;
 pub mod file_list;
 pub mod forge;

--- a/src/search.rs
+++ b/src/search.rs
@@ -5,6 +5,7 @@
 //! its background scan, so a query never runs on the frame loop. Completions are
 //! generation-tagged and land latest-wins, like the world worker's (specs/tui.md Refresh).
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
 use std::time::Duration;
@@ -53,6 +54,8 @@ pub struct FileHit {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CodeHit {
     pub path: String,
+    /// Display columns between tab stops, resolved for `path` when the query runs.
+    pub tab_width: usize,
     /// 1-based line number.
     pub line: u64,
     pub text: String,
@@ -177,14 +180,22 @@ impl Engine {
         for m in &mut grep.matches {
             m.trim_leading_whitespace();
         }
+        let mut tab_widths = HashMap::new();
         let code: Vec<CodeHit> = grep
             .matches
             .iter()
-            .map(|m| CodeHit {
-                path: grep.files[m.file_index].relative_path(picker),
-                line: m.line_number,
-                text: m.line_content.clone(),
-                spans: m.match_byte_offsets.iter().copied().collect(),
+            .map(|m| {
+                let path = grep.files[m.file_index].relative_path(picker);
+                let tab_width = *tab_widths
+                    .entry(path.clone())
+                    .or_insert_with(|| crate::editorconfig::tab_width(&self.repo, &path));
+                CodeHit {
+                    path,
+                    tab_width,
+                    line: m.line_number,
+                    text: m.line_content.clone(),
+                    spans: m.match_byte_offsets.iter().copied().collect(),
+                }
             })
             .collect();
         let code_more = grep.next_file_offset != 0;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -297,7 +297,7 @@ pub fn diff_row_heights(app: &App, area: Rect) -> Vec<usize> {
         .iter()
         .enumerate()
         .map(|(i, r)| {
-            let base = row_height(r, gutter_w, width, app.wrap);
+            let base = row_height(r, gutter_w, width, app.wrap, app.diff.tab_width);
             let card: usize = cards[i]
                 .iter()
                 .filter(|&&ci| Some(ci) != editing)
@@ -993,6 +993,7 @@ fn render_diff_view(frame: &mut Frame, app: &App, area: Rect) {
         width,
         h_scroll: app.h_scroll,
         wrap: app.wrap,
+        tab_width: app.diff.tab_width,
         focused: app.focus == Focus::Diff,
         pal: p,
         find: app
@@ -1100,13 +1101,14 @@ fn gutter_prefix_width(gutter_w: usize) -> usize {
 /// How many display rows a row needs: 1 for a fold or with wrap off, else the number of
 /// word-wrapped segments its (tab-expanded) content fills. Shares [`wrap_segments`] with
 /// the renderer so per-row geometry stays aligned with what gets painted.
-fn row_height(row: &Row, gutter_w: usize, width: usize, wrap: bool) -> usize {
+fn row_height(row: &Row, gutter_w: usize, width: usize, wrap: bool, tab_width: usize) -> usize {
     if !wrap || matches!(row, Row::Fold { .. }) {
         return 1;
     }
     let code_width = width.saturating_sub(gutter_prefix_width(gutter_w)).max(1);
     // The find highlight never changes wrapping, so height ignores it.
-    wrap_segments(&code_cells(row, false, &[]), code_width, ContinuationSpaces::Trim).len()
+    wrap_segments(&code_cells(row, false, &[], tab_width), code_width, ContinuationSpaces::Trim)
+        .len()
 }
 
 /// The diff-pane layout: constant for a frame.
@@ -1116,6 +1118,8 @@ struct RowLayout<'a> {
     width: usize,
     h_scroll: usize,
     wrap: bool,
+    /// Display columns between tab stops for this file (`specs/diff-view.md`).
+    tab_width: usize,
     /// Whether the diff pane is focused — dims the cursor row when it is not.
     focused: bool,
     /// The active palette for the change bars, row tints, and fills.
@@ -1138,7 +1142,7 @@ struct RowState {
 /// into `code_width`-wide rows; a continuation row carries a blank gutter so numbers
 /// stay aligned. With wrap off, the line is one row scrolled by `h_scroll`.
 fn render_row(row: &Row, layout: RowLayout<'_>, state: RowState) -> Vec<Line<'static>> {
-    let RowLayout { gutter_w, width, h_scroll, wrap, focused, pal, find } = layout;
+    let RowLayout { gutter_w, width, h_scroll, wrap, tab_width, focused, pal, find } = layout;
     let RowState { commented, cursor, selected } = state;
     if let Row::Fold { .. } = row {
         let label = if cursor {
@@ -1186,7 +1190,7 @@ fn render_row(row: &Row, layout: RowLayout<'_>, state: RowState) -> Vec<Line<'st
     // like word emphasis (specs/find-in-file.md).
     let hl_ranges =
         find.map(|(q, cs)| crate::app::find_match_ranges(&row.text(), q, cs)).unwrap_or_default();
-    let cells = code_cells(row, emph_on, &hl_ranges);
+    let cells = code_cells(row, emph_on, &hl_ranges, tab_width);
 
     let prefix_w = gutter_prefix_width(gutter_w);
     let code_width = width.saturating_sub(prefix_w).max(1);
@@ -1238,9 +1242,6 @@ fn render_row(row: &Row, layout: RowLayout<'_>, state: RowState) -> Vec<Line<'st
 pub(crate) fn rgb(c: crate::diff::Rgb) -> Color {
     Color::Rgb(c.0, c.1, c.2)
 }
-
-/// Tabs expand to this many columns.
-const TAB: usize = 4;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ContinuationSpaces {
@@ -1334,20 +1335,21 @@ struct Cell {
 /// char carries its column width, color, its word-emphasis flag (when `emph_on`), and whether it
 /// falls in an in-file find match (`hl_ranges`, char indices). Width comes from `unicode-width`
 /// so wide glyphs measure as the two columns they paint.
-fn code_cells(row: &Row, emph_on: bool, hl_ranges: &[(u32, u32)]) -> Vec<Cell> {
+fn code_cells(row: &Row, emph_on: bool, hl_ranges: &[(u32, u32)], tab_width: usize) -> Vec<Cell> {
     let emphasis = if emph_on { row.emphasis() } else { &[] };
     let in_emph = |i: u32| emphasis.iter().any(|&(a, b)| i >= a && i < b);
     let in_hl = |i: u32| hl_ranges.iter().any(|&(a, b)| i >= a && i < b);
     let mut cells = Vec::new();
     let mut idx = 0u32;
     let mut col = 0usize; // display column, so tab stops land right after wide glyphs too
+    let tab_width = tab_width.max(1);
     for s in row.spans() {
         let fg = rgb(s.color);
         for ch in s.text.chars() {
             let emph = in_emph(idx);
             let hl = in_hl(idx);
             if ch == '\t' {
-                for _ in 0..(TAB - col % TAB) {
+                for _ in 0..(tab_width - col % tab_width) {
                     cells.push(Cell { ch: ' ', w: 1, fg, emph, hl });
                     col += 1;
                 }
@@ -2501,7 +2503,7 @@ fn render_search_preview(
                 .as_ref()
                 .filter(|(l, _)| row.new_no() == Some(*l as u32))
                 .map(|(_, spans)| spans.as_slice());
-            search_preview_line(row, gw, width, hit, p)
+            search_preview_line(row, gw, width, hit, pv.diff.tab_width, p)
         })
         .collect();
     frame.render_widget(Paragraph::new(lines), region);
@@ -2514,18 +2516,18 @@ fn search_preview_line(
     gw: usize,
     width: usize,
     hit: Option<&[(u32, u32)]>,
+    tab_width: usize,
     p: &Palette,
 ) -> Line<'static> {
     let num = row.new_no().map_or(String::new(), |n| n.to_string());
     let mut spans = vec![Span::styled(format!("{num:>gw$} "), Style::default().fg(p.overlay1))];
     match hit {
         None => {
+            let mut code = Vec::new();
             for sp in row.spans() {
-                spans.push(Span::styled(
-                    sp.text.replace('\t', "    "),
-                    Style::default().fg(rgb(sp.color)),
-                ));
+                code.push(Span::styled(sp.text.clone(), Style::default().fg(rgb(sp.color))));
             }
+            spans.extend(expand_span_tabs(code, tab_width));
             Line::from(spans)
         }
         Some(ranges) => {
@@ -2554,11 +2556,7 @@ fn search_preview_line(
                 Style::default().fg(colors.get(ci).map_or(p.text, |&(_, c)| c))
             };
             let emphasized = emphasized_spans(&text, &ranges, p.match_hl, base);
-            spans.extend(
-                emphasized
-                    .into_iter()
-                    .map(|sp| Span::styled(sp.content.replace('\t', "    "), sp.style)),
-            );
+            spans.extend(expand_span_tabs(emphasized, tab_width));
             let mut line = Line::from(spans);
             let pad = width.saturating_sub(line.width());
             if pad > 0 {
@@ -2567,6 +2565,30 @@ fn search_preview_line(
             line.style(Style::default().bg(p.cursor_bg(true)))
         }
     }
+}
+
+/// Expand hard tabs across styled spans without resetting the column at a syntax or match
+/// boundary. Search previews use spans directly rather than the diff renderer's [`Cell`]s.
+fn expand_span_tabs(spans: Vec<Span<'static>>, tab_width: usize) -> Vec<Span<'static>> {
+    let mut col = 0usize;
+    let tab_width = tab_width.max(1);
+    spans
+        .into_iter()
+        .map(|span| {
+            let mut text = String::new();
+            for ch in span.content.chars() {
+                if ch == '\t' {
+                    let spaces = tab_width - col % tab_width;
+                    text.push_str(&" ".repeat(spaces));
+                    col += spaces;
+                } else {
+                    text.push(ch);
+                    col += UnicodeWidthChar::width(ch).unwrap_or(0);
+                }
+            }
+            Span::styled(text, span.style)
+        })
+        .collect()
 }
 
 /// A code match row: `line:` dimmed, then the matched line. A too-wide row clips the line
@@ -2580,7 +2602,7 @@ fn search_code_row(
     let locator = format!("{:>5}: ", hit.line);
     let avail = width.saturating_sub(locator.width());
     // Expand tabs before the width and clip math run on the line (see `expand_tabs`).
-    let (text, match_spans) = expand_tabs(hit.text.trim_end(), &hit.spans);
+    let (text, match_spans) = expand_tabs(hit.text.trim_end(), &hit.spans, hit.tab_width);
     let text = text.as_str();
     // When the first matched span sits past the visible window, skip the line's head so
     // the match shows, marking the cut with a leading `…`. The engine's byte offset is
@@ -2624,26 +2646,37 @@ fn search_code_row(
     selectable_row(p, spans, width, fill)
 }
 
-/// Expand tabs to four spaces, shifting the match byte spans to keep them over the same
+/// Expand tabs to the file's tab stops, shifting match byte spans to keep them over the same
 /// characters. The engine reports match offsets into the raw line; a tab is zero display
 /// columns to the width math but real width on screen, so an un-expanded tab-indented row
-/// would skip the clip and overflow.
-fn expand_tabs(text: &str, spans: &[(u32, u32)]) -> (String, Vec<(u32, u32)>) {
+/// would skip the clip and overflow (`specs/search.md`, `specs/diff-view.md`).
+fn expand_tabs(text: &str, spans: &[(u32, u32)], tab_width: usize) -> (String, Vec<(u32, u32)>) {
     if !text.contains('\t') {
         return (text.to_string(), spans.to_vec());
     }
     let mut out = String::with_capacity(text.len());
-    let mut tabs = Vec::new();
+    let mut adjustments = Vec::new();
+    let mut added = 0usize;
+    let mut col = 0usize;
+    let tab_width = tab_width.max(1);
     for (i, c) in text.char_indices() {
         if c == '\t' {
-            out.push_str("    ");
-            tabs.push(i);
+            let spaces = tab_width - col % tab_width;
+            out.push_str(&" ".repeat(spaces));
+            col += spaces;
+            added += spaces - 1;
+            adjustments.push((i, added));
         } else {
             out.push(c);
+            col += UnicodeWidthChar::width(c).unwrap_or(0);
         }
     }
-    // Each tab strictly before an offset added three bytes; the tab positions are sorted.
-    let shift = |at: usize| -> u32 { (tabs.partition_point(|&t| t < at) * 3) as u32 };
+    // Entries are sorted by raw byte position and hold cumulative bytes added through that
+    // tab. A span at the tab itself stays before its expansion; later spans move past it.
+    let shift = |at: usize| -> u32 {
+        let n = adjustments.partition_point(|&(pos, _)| pos < at);
+        n.checked_sub(1).map_or(0, |i| adjustments[i].1 as u32)
+    };
     let spans =
         spans.iter().map(|&(s, e)| (s + shift(s as usize), e + shift(e as usize))).collect();
     (out, spans)

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -4240,7 +4240,7 @@ mod search_overlay {
     }
 
     fn code_hit(path: &str, line: u64, text: &str) -> CodeHit {
-        CodeHit { path: path.into(), line, text: text.into(), spans: vec![] }
+        CodeHit { path: path.into(), tab_width: 4, line, text: text.into(), spans: vec![] }
     }
 
     fn open(app: &mut App, keymap: &Keymap) {

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -231,6 +231,28 @@ fn tabs_expand_to_spaces_in_the_diff() {
 }
 
 #[test]
+fn local_editorconfig_sets_the_diff_tab_width() {
+    let r = Repo::init();
+    r.write(".editorconfig", "root = true\n[*.rs]\ntab_width = 2\n");
+    r.write("t.rs", "x\n");
+    r.commit_all("init");
+    r.write("t.rs", "x\n\tindented\n");
+
+    let mut app = app_on(&r);
+    let two = render(&app);
+    let two_col = two.lines().find(|l| l.contains("indented")).unwrap().find("indented").unwrap();
+    assert_eq!(app.diff.tab_width, 2);
+
+    // An EditorConfig-only edit is enough for refresh to repaint an unchanged open file.
+    r.write(".editorconfig", "root = true\n[*.rs]\ntab_width = 6\n");
+    app.reload().unwrap();
+    let six = render(&app);
+    let six_col = six.lines().find(|l| l.contains("indented")).unwrap().find("indented").unwrap();
+    assert_eq!(app.diff.tab_width, 6);
+    assert_eq!(six_col - two_col, 4, "the painted indentation follows the new tab stop");
+}
+
+#[test]
 fn a_long_line_wraps_across_display_rows() {
     let long: String = std::iter::repeat_n("abcd", 60).collect(); // 240 cols, wider than the pane
     let r = Repo::init();
@@ -2000,12 +2022,14 @@ mod search_screen_render {
                 code: vec![
                     CodeHit {
                         path: "src/registry.rs".into(),
+                        tab_width: 4,
                         line: 1,
                         text: "fn resolve() {}".into(),
                         spans: vec![(3, 6)],
                     },
                     CodeHit {
                         path: "src/registry.rs".into(),
+                        tab_width: 4,
                         line: 2,
                         text: "registry.resolve()".into(),
                         spans: vec![(0, 3)],
@@ -2146,6 +2170,7 @@ mod search_screen_render {
                 files: Vec::new(),
                 code: vec![CodeHit {
                     path: "a.rs".into(),
+                    tab_width: 4,
                     line: 30,
                     text: "line_30".into(),
                     spans: vec![(0, 7)],
@@ -2199,6 +2224,7 @@ mod search_screen_render {
                 // As the worker emits it: the trimmed line, offsets into the trimmed text.
                 code: vec![CodeHit {
                     path: "a.rs".into(),
+                    tab_width: 4,
                     line: 30,
                     text: "fn resolve() {}".into(),
                     spans: vec![(3, 10)], // "resolve" within the trimmed line
@@ -2374,6 +2400,7 @@ mod search_screen_render {
                 files: Vec::new(),
                 code: vec![CodeHit {
                     path: "a.rs".into(),
+                    tab_width: 4,
                     line: 1,
                     text: "alpha".into(),
                     spans: vec![(0, 5)],
@@ -2428,7 +2455,13 @@ mod search_row_emphasis {
         // first matched span (`needle_marker`, 13 bytes) rather than the un-shown head.
         let text = format!("{}needle_marker tail", "x".repeat(200));
         let start = 200u32;
-        let hit = CodeHit { path: "a.rs".into(), line: 1, text, spans: vec![(start, start + 13)] };
+        let hit = CodeHit {
+            path: "a.rs".into(),
+            tab_width: 4,
+            line: 1,
+            text,
+            spans: vec![(start, start + 13)],
+        };
         land_search_completion(&mut app, code_only(hit), 1);
         handle_key(&mut app, KeyEvent::from(KeyCode::Tab), AREA, default_keymap()).unwrap();
 
@@ -2476,6 +2509,7 @@ mod search_row_emphasis {
         // Two leading tabs, then `needle` — the match is at bytes 2..8 of the raw line.
         let hit = CodeHit {
             path: "a.rs".into(),
+            tab_width: 2,
             line: 1,
             text: "\t\tneedle here".into(),
             spans: vec![(2, 8)],
@@ -2487,8 +2521,8 @@ mod search_row_emphasis {
         let out = dump(&buf);
         let y = out.lines().position(|l| l.contains("needle")).unwrap();
         let row = out.lines().nth(y).unwrap();
-        // Eight spaces of expanded indent sit between the locator and `needle`.
-        assert!(row.contains("1:         needle"), "tabs expand to spaces: {row:?}");
+        // Two tabs at two-column stops put four spaces between the locator and `needle`.
+        assert!(row.contains("1:     needle"), "tabs expand to spaces: {row:?}");
         let x = row.find("needle").unwrap() as u16;
         let style = buf.cell((x, y as u16)).expect("cell").style();
         assert_eq!(
@@ -2515,6 +2549,7 @@ mod search_row_emphasis {
         let start = head.len() as u32; // 600 bytes in
         let hit = CodeHit {
             path: "a.rs".into(),
+            tab_width: 4,
             line: 1,
             text: format!("{head}needle tail"),
             spans: vec![(start, start + 6)],


### PR DESCRIPTION
## What

Implement `.editorconfig` support for tab width across diffs, file views, previews, and search results. It uses `tab_width`, falls back to numeric `indent_size`, and updates on refresh.

## Checklist

- [x] `just ci` is green
- [x] The governing specs under `specs/` say the new behavior
- [x] `CHANGELOG.md` has a bullet under `## [Unreleased]`
- [x] Perf-relevant paths: before/after painted-frame medians from the pinned
fixture:

| Action | Before | After |
|---|---:|---:|
| Enter All Files | 32.1 ms | 31.7 ms |
| Enter Changes | 17.9 ms | 18.0 ms |
| Enter All Files, then file | 32.4 ms | 32.0 ms |
| Next file in Changes | 8.0 ms | 8.3 ms |
| Next file in All Files | 0.7 ms | 0.9 ms |

No material latency regression observed.