### PR TITLE
Open on the focused pane's live foreground cwd

### DIFF
--- a/docs/herdr-api-notes.md
+++ b/docs/herdr-api-notes.md
@@ -101,8 +101,9 @@ herdr runs plugin commands with a minimal `PATH`; prepend common bin dirs for `j
 - **`focused_pane_cwd` is the pane's *launch* cwd, not its live one** (observed, 0.7.5: a pane
   running `claude -w <worktree>` reported the main checkout it was launched from, while the
   agent process had chdir'd into the worktree). `herdr pane get <id>` carries both: `.result.pane.cwd`
-  (launch) and `.result.pane.foreground_cwd` (live foreground process). `pane.sh` prefers
-  `foreground_cwd` and falls back to the context cwd.
+  (launch) and `.result.pane.foreground_cwd` (live foreground process). A `pane list` entry carries
+  `foreground_cwd` too (see above), so `pane.sh` reads it from the pane-list snapshot it already
+  holds and falls back to the context cwd.
 - **`plugin action invoke` resolves context from the focused workspace**, wherever it is run — the
   calling pane's `HERDR_*` env is ignored, and `invoke <action_id> [--plugin ID]` has no workspace
   selector (verified live, 0.7.1: invoked from pane `w1X:p1`, context arrived for focused `w1B`).

--- a/docs/herdr-api-notes.md
+++ b/docs/herdr-api-notes.md
@@ -96,8 +96,13 @@ herdr plugin pane close <pane_id>
 herdr runs plugin commands with a minimal `PATH`; prepend common bin dirs for `jq`/`git`.
 
 - **Action context** (`HERDR_PLUGIN_CONTEXT_JSON`): `workspace_id`, `tab_id`, `focused_pane_id`,
-  `focused_pane_cwd`, `worktree:{repo_root, checkout_path, ...}`. `pane.sh` reads
-  `focused_pane_cwd` to place a manual open; the binary reads none of it.
+  `focused_pane_cwd`, `worktree:{repo_root, checkout_path, ...}`. `pane.sh` places a manual
+  open from the focused pane's cwd; the binary reads none of it.
+- **`focused_pane_cwd` is the pane's *launch* cwd, not its live one** (observed, 0.7.5: a pane
+  running `claude -w <worktree>` reported the main checkout it was launched from, while the
+  agent process had chdir'd into the worktree). `herdr pane get <id>` carries both: `.result.pane.cwd`
+  (launch) and `.result.pane.foreground_cwd` (live foreground process). `pane.sh` prefers
+  `foreground_cwd` and falls back to the context cwd.
 - **`plugin action invoke` resolves context from the focused workspace**, wherever it is run — the
   calling pane's `HERDR_*` env is ignored, and `invoke <action_id> [--plugin ID]` has no workspace
   selector (verified live, 0.7.1: invoked from pane `w1X:p1`, context arrived for focused `w1B`).

--- a/docs/plans/2026-08-12-open-cwd-live-foreground/plan.md
+++ b/docs/plans/2026-08-12-open-cwd-live-foreground/plan.md
@@ -1,0 +1,53 @@
+# Open on the live foreground cwd: Plan
+
+Delivers `specs/herdr-host.md#repo-discovery` by finishing PR #59 (external contribution, branch `fix/open-cwd-live-foreground`).
+
+## Problem
+
+Opening reviewr beside a pane running `claude -w <worktree>` reviews the main checkout's branch, not the worktree's. herdr's action context carries the pane's launch cwd, and `claude -w` chdirs into the worktree only inside its own process. PR #59 fixes the case but diverges from the locked design in two ways: a live cwd outside any git repo refuses an open the launch cwd could place, and the live read runs on every mode including close.
+
+## Goal
+
+PR #59 merged, matching the Repo discovery contract exactly: live foreground cwd when it lies in a git repo, launch cwd otherwise, refusal only when neither qualifies, and no live read off the open path.
+
+## Definition of Done
+
+- [ ] An open beside a `claude -w <worktree>` pane reviews the worktree (PR's existing test `open_prefers_the_focused_panes_live_foreground_cwd`).
+- [ ] A live cwd outside any git repo falls back to the launch cwd instead of refusing (new test).
+- [ ] A failed or empty live read falls back to the launch cwd (PR's existing test `open_keeps_the_context_cwd_without_a_live_foreground_cwd`).
+- [ ] `close`, a closing `toggle`, and `auto-open` issue no `pane get` (new assertions on the fake-herdr call log).
+- [ ] PR #59 merges with the contributor's commits intact.
+
+## Out of Scope
+
+- Refusal message wording. Builder's mechanism, spec owns only the refusal itself.
+- The `docs/herdr-api-notes.md` addition. Already correct in the PR, lands as-is.
+
+## Execution Plan
+
+1. [ ] `gh pr checkout 59`, then rebase onto `main` if behind.
+2. [ ] In `herdr/pane.sh`: move the live-read block from before the mode dispatch to after it, just above the "Opening from here on" repo check, gated `[ "$mode" != auto-open ]`.
+3. [ ] In the same block: accept `$live` only when `git -C "$live" rev-parse --show-toplevel` succeeds, else keep the context cwd.
+4. [ ] In `tests/pane_actions.rs`: add `open_falls_back_when_the_live_cwd_is_not_a_repo` (paneget fixture whose `foreground_cwd` is a non-repo tempdir, context cwd a repo, assert `--cwd <repo>` in the call log).
+5. [ ] In `tests/pane_actions.rs`: assert `pane get` absent from the call log in a close-path test and an auto-open test.
+6. [ ] Commit on top of the contributor's commits and push to their branch (`maintainerCanModify` is true).
+
+## Likely Files
+
+| file                     | change                                                        |
+| ------------------------ | ------------------------------------------------------------- |
+| `herdr/pane.sh`          | relocate the live read to the open path, add the repo guard   |
+| `tests/pane_actions.rs`  | one fallback test, two no-live-read assertions                |
+| `specs/herdr-host.md`    | promote Repo discovery Draft to Current at the merge gate     |
+
+## Verification
+
+- `cargo test --test pane_actions` → all pass, including the PR's two existing tests unchanged.
+- `just ci` → clean.
+- Tight: everything the diff adds is exercised by a DoD line. Delete or defer the rest.
+- Gate: high-effort `/code-review` loop on the branch until clean, then `/garfield` end to end, then promote `specs/herdr-host.md` to Current.
+
+## Replan
+
+- If pushing to the fork branch fails despite `maintainerCanModify`, then recreate the branch in this repo from their head with commits intact and retarget the merge.
+- 2026-08-12: initial plan.

--- a/docs/plans/2026-08-12-open-cwd-live-foreground/plan.md
+++ b/docs/plans/2026-08-12-open-cwd-live-foreground/plan.md
@@ -45,7 +45,7 @@ PR #59 merged, matching the Repo discovery contract exactly: live foreground cwd
 - `cargo test --test pane_actions` → all pass, including the PR's two existing tests unchanged.
 - `just ci` → clean.
 - Tight: everything the diff adds is exercised by a DoD line. Delete or defer the rest.
-- Gate: high-effort `/code-review` loop on the branch until clean, then `/garfield` end to end, then promote `specs/herdr-host.md` to Current.
+- Gate: high-effort `/code-review` loop on the branch until clean (4 rounds), then `/garfield` end to end (pass), then promote `specs/herdr-host.md` to Current. Done.
 
 ## Replan
 

--- a/docs/plans/2026-08-12-open-cwd-live-foreground/plan.md
+++ b/docs/plans/2026-08-12-open-cwd-live-foreground/plan.md
@@ -12,10 +12,11 @@ PR #59 merged, matching the Repo discovery contract exactly: live foreground cwd
 
 ## Definition of Done
 
-- [ ] An open beside a `claude -w <worktree>` pane reviews the worktree (PR's existing test `open_prefers_the_focused_panes_live_foreground_cwd`).
-- [ ] A live cwd outside any git repo falls back to the launch cwd instead of refusing (new test).
-- [ ] A failed or empty live read falls back to the launch cwd (PR's existing test `open_keeps_the_context_cwd_without_a_live_foreground_cwd`).
-- [ ] `close`, a closing `toggle`, and `auto-open` issue no `pane get` (new assertions on the fake-herdr call log).
+- [x] An open beside a `claude -w <worktree>` pane reviews the worktree (PR's existing test `open_prefers_the_focused_panes_live_foreground_cwd`).
+- [x] A live cwd outside any git repo falls back to the launch cwd instead of refusing (`a_toggle_open_falls_back_when_the_live_cwd_is_not_a_repo`, run as a toggle).
+- [x] A missing live cwd falls back to the launch cwd (PR's existing test `open_keeps_the_context_cwd_without_a_live_foreground_cwd`).
+- [x] No action pays an extra herdr call: the live cwd comes from the pane-list snapshot the run already holds.
+- [x] The event open takes the payload cwd even when the live cwd is a repo (`auto_open_takes_the_event_payload_cwd_over_the_live_one`).
 - [ ] PR #59 merges with the contributor's commits intact.
 
 ## Out of Scope
@@ -25,12 +26,11 @@ PR #59 merged, matching the Repo discovery contract exactly: live foreground cwd
 
 ## Execution Plan
 
-1. [ ] `gh pr checkout 59`, then rebase onto `main` if behind.
-2. [ ] In `herdr/pane.sh`: move the live-read block from before the mode dispatch to after it, just above the "Opening from here on" repo check, gated `[ "$mode" != auto-open ]`.
-3. [ ] In the same block: accept `$live` only when `git -C "$live" rev-parse --show-toplevel` succeeds, else keep the context cwd.
-4. [ ] In `tests/pane_actions.rs`: add `open_falls_back_when_the_live_cwd_is_not_a_repo` (paneget fixture whose `foreground_cwd` is a non-repo tempdir, context cwd a repo, assert `--cwd <repo>` in the call log).
-5. [ ] In `tests/pane_actions.rs`: assert `pane get` absent from the call log in a close-path test and an auto-open test.
-6. [ ] Commit on top of the contributor's commits and push to their branch (`maintainerCanModify` is true).
+1. [x] `gh pr checkout 59`, then rebase onto `main` if behind.
+2. [x] In `herdr/pane.sh`: move the live-cwd block onto the open path, just above the repo check, gated `[ "$mode" != auto-open ]`.
+3. [x] In the same block: read `foreground_cwd` from the held `panes_json` snapshot and accept it only when `is_git_repo` passes, else keep the context cwd.
+4. [x] In `tests/pane_actions.rs`: serve `foreground_cwd` through `pane_with_cwd` pane-list fixtures, drop the fake's `pane get` verb, add the non-repo-fallback toggle test and the event-payload-wins auto-open test.
+5. [x] Commit on top of the contributor's commits and push to their branch (`maintainerCanModify` is true).
 
 ## Likely Files
 
@@ -50,4 +50,5 @@ PR #59 merged, matching the Repo discovery contract exactly: live foreground cwd
 ## Replan
 
 - If pushing to the fork branch fails despite `maintainerCanModify`, then recreate the branch in this repo from their head with commits intact and retarget the merge.
+- 2026-08-12: review found `pane list` entries already carry `foreground_cwd` (docs/herdr-api-notes.md, verified live 0.7.5) → the live read reuses the run's held snapshot and `pane get` drops entirely → pane.sh, tests, DoD.
 - 2026-08-12: initial plan.

--- a/herdr/pane.sh
+++ b/herdr/pane.sh
@@ -246,7 +246,9 @@ fi
 if is_git_repo "$live"; then
   cwd="$live"
 elif ! is_git_repo "$cwd"; then
-  refuse "not a git repo: '${cwd:-<no cwd>}'"
+  # Name every candidate the check rejected, or a refusal over an inspected-but-unusable
+  # live cwd would read as if no directory was ever tried.
+  refuse "not a git repo: '${cwd:-<no cwd>}'${live:+ (live cwd '$live')}"
 fi
 
 # Focus follows the placement on a manual open; the event never takes it (spec A3, P5, P6).

--- a/herdr/pane.sh
+++ b/herdr/pane.sh
@@ -85,6 +85,19 @@ cwd=""
 [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ] &&
   cwd=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | jq -r '.focused_pane_cwd // .workspace_cwd // empty' 2>/dev/null)
 
+# The context's `focused_pane_cwd` is the pane's launch cwd. An agent that changes
+# directory only inside its own process (`claude -w <worktree>` starts in the main
+# checkout and chdirs into the worktree after launch) leaves the launch cwd naming the
+# wrong repo, and the review would open on the wrong branch. Prefer the focused pane's
+# live `foreground_cwd`; an unreadable read keeps the context cwd, never refuses.
+if [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
+  fp=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | jq -r '.focused_pane_id // empty' 2>/dev/null)
+  if [ -n "$fp" ]; then
+    live=$("$H" pane get "$fp" 2>/dev/null | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null)
+    [ -n "$live" ] && cwd="$live"
+  fi
+fi
+
 # The event fires without a focused pane; target the fresh workspace from its payload
 # (worktree.created shape: .data.workspace.workspace_id, .data.workspace.worktree.checkout_path).
 if [ "$mode" = auto-open ] && [ -n "${HERDR_PLUGIN_EVENT_JSON:-}" ]; then

--- a/herdr/pane.sh
+++ b/herdr/pane.sh
@@ -241,7 +241,7 @@ live=""
 if [ "$mode" != auto-open ] && [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
   fp=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | jq -r '.focused_pane_id // empty' 2>/dev/null)
   [ -z "$fp" ] || live=$(printf '%s' "$panes_json" |
-    jq -r --arg p "$fp" '.result.panes[] | select(.pane_id == $p) | .foreground_cwd // empty' 2>/dev/null)
+    jq -r --arg p "$fp" 'first(.result.panes[] | select(.pane_id == $p) | .foreground_cwd // empty)' 2>/dev/null)
 fi
 if is_git_repo "$live"; then
   cwd="$live"

--- a/herdr/pane.sh
+++ b/herdr/pane.sh
@@ -85,19 +85,6 @@ cwd=""
 [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ] &&
   cwd=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | jq -r '.focused_pane_cwd // .workspace_cwd // empty' 2>/dev/null)
 
-# The context's `focused_pane_cwd` is the pane's launch cwd. An agent that changes
-# directory only inside its own process (`claude -w <worktree>` starts in the main
-# checkout and chdirs into the worktree after launch) leaves the launch cwd naming the
-# wrong repo, and the review would open on the wrong branch. Prefer the focused pane's
-# live `foreground_cwd`; an unreadable read keeps the context cwd, never refuses.
-if [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
-  fp=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | jq -r '.focused_pane_id // empty' 2>/dev/null)
-  if [ -n "$fp" ]; then
-    live=$("$H" pane get "$fp" 2>/dev/null | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null)
-    [ -n "$live" ] && cwd="$live"
-  fi
-fi
-
 # The event fires without a focused pane; target the fresh workspace from its payload
 # (worktree.created shape: .data.workspace.workspace_id, .data.workspace.worktree.checkout_path).
 if [ "$mode" = auto-open ] && [ -n "${HERDR_PLUGIN_EVENT_JSON:-}" ]; then
@@ -239,7 +226,24 @@ open | auto-open)
   ;;
 esac
 
-# Opening from here on. Only inside a git repo.
+# Opening from here on. The context's `focused_pane_cwd` is the pane's launch cwd. An
+# agent that changes directory only inside its own process (`claude -w <worktree>` starts
+# in the main checkout and chdirs into the worktree after launch) leaves the launch cwd
+# naming the wrong repo, and the review would open on the wrong branch. Prefer the focused
+# pane's live `foreground_cwd` when it lies in a git repo (specs/herdr-host.md, Repo
+# discovery); a failed read, or a live cwd outside any repo, keeps the context cwd — the
+# live read never refuses an open the context alone could place. The event never reads a
+# pane: its payload names the checkout above, and the guard on mode keeps close and a
+# closing toggle from paying the round-trip.
+if [ "$mode" != auto-open ] && [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
+  fp=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | jq -r '.focused_pane_id // empty' 2>/dev/null)
+  if [ -n "$fp" ]; then
+    live=$("$H" pane get "$fp" 2>/dev/null | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null)
+    [ -n "$live" ] && git -C "$live" rev-parse --show-toplevel >/dev/null 2>&1 && cwd="$live"
+  fi
+fi
+
+# Only inside a git repo.
 if [ -z "$cwd" ] || ! git -C "$cwd" rev-parse --show-toplevel >/dev/null 2>&1; then
   refuse "not a git repo: '${cwd:-<no cwd>}'"
 fi

--- a/herdr/pane.sh
+++ b/herdr/pane.sh
@@ -231,20 +231,21 @@ esac
 # in the main checkout and chdirs into the worktree after launch) leaves the launch cwd
 # naming the wrong repo, and the review would open on the wrong branch. Prefer the focused
 # pane's live `foreground_cwd` when it lies in a git repo (specs/herdr-host.md, Repo
-# discovery); a failed read, or a live cwd outside any repo, keeps the context cwd — the
-# live read never refuses an open the context alone could place. The event never reads a
-# pane: its payload names the checkout above, and the guard on mode keeps close and a
-# closing toggle from paying the round-trip.
+# discovery), read from the pane-list snapshot already in hand — the focused pane sits in
+# the focused workspace, so the list carries it and the keypress path pays no extra herdr
+# round-trip (docs/herdr-api-notes.md). A live cwd outside any repo, or a pane the list is
+# missing, keeps the context cwd — the live read never refuses an open the context alone
+# could place. The mode guard keeps the event payload's cwd above in charge on auto-open.
+is_git_repo() { [ -n "$1" ] && git -C "$1" rev-parse --show-toplevel >/dev/null 2>&1; }
+live=""
 if [ "$mode" != auto-open ] && [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
   fp=$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" | jq -r '.focused_pane_id // empty' 2>/dev/null)
-  if [ -n "$fp" ]; then
-    live=$("$H" pane get "$fp" 2>/dev/null | jq -r '.result.pane.foreground_cwd // empty' 2>/dev/null)
-    [ -n "$live" ] && git -C "$live" rev-parse --show-toplevel >/dev/null 2>&1 && cwd="$live"
-  fi
+  [ -z "$fp" ] || live=$(printf '%s' "$panes_json" |
+    jq -r --arg p "$fp" '.result.panes[] | select(.pane_id == $p) | .foreground_cwd // empty' 2>/dev/null)
 fi
-
-# Only inside a git repo.
-if [ -z "$cwd" ] || ! git -C "$cwd" rev-parse --show-toplevel >/dev/null 2>&1; then
+if is_git_repo "$live"; then
+  cwd="$live"
+elif ! is_git_repo "$cwd"; then
   refuse "not a git repo: '${cwd:-<no cwd>}'"
 fi
 

--- a/herdr/pane.sh
+++ b/herdr/pane.sh
@@ -226,16 +226,10 @@ open | auto-open)
   ;;
 esac
 
-# Opening from here on. The context's `focused_pane_cwd` is the pane's launch cwd. An
-# agent that changes directory only inside its own process (`claude -w <worktree>` starts
-# in the main checkout and chdirs into the worktree after launch) leaves the launch cwd
-# naming the wrong repo, and the review would open on the wrong branch. Prefer the focused
-# pane's live `foreground_cwd` when it lies in a git repo (specs/herdr-host.md, Repo
-# discovery), read from the pane-list snapshot already in hand — the focused pane sits in
-# the focused workspace, so the list carries it and the keypress path pays no extra herdr
-# round-trip (docs/herdr-api-notes.md). A live cwd outside any repo, or a pane the list is
-# missing, keeps the context cwd — the live read never refuses an open the context alone
-# could place. The mode guard keeps the event payload's cwd above in charge on auto-open.
+# Opening from here on. Prefer the focused pane's live `foreground_cwd`, read from the
+# pane-list snapshot already in hand, over the context's launch cwd (specs/herdr-host.md,
+# Repo discovery; the launch-vs-live split is docs/herdr-api-notes.md). The mode guard
+# keeps auto-open on the event payload's cwd set above.
 is_git_repo() { [ -n "$1" ] && git -C "$1" rev-parse --show-toplevel >/dev/null 2>&1; }
 live=""
 if [ "$mode" != auto-open ] && [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -89,7 +89,7 @@ A `tab` open names the fresh tab `reviewr`, using the `tab_id` the pane-open res
 
 The binary reviews its own pane's working directory, normalized to its git top level. A directory outside any repository shows an empty state.
 
-A manual open places the pane in the focused pane's live foreground directory, never its recorded launch directory. Launch a `claude -w <worktree>` pane from the main checkout, and the open reviews the worktree. A live directory outside any git repository falls back to the launch directory, and a failed or empty live read falls back the same way. The open refuses only when no candidate directory is inside a git repository. The event open takes its directory from the event payload and reads no pane.
+A manual open prefers the focused pane's live foreground directory over its recorded launch directory. Launch a `claude -w <worktree>` pane from the main checkout, and the open reviews the worktree. A live directory outside any git repository falls back to the launch directory, and a failed or empty live read falls back the same way. The open refuses only when no candidate directory is inside a git repository. The event open takes its directory from the event payload and reads no pane.
 
 ## Sending to the agent
 

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -1,5 +1,5 @@
 ---
-Status: Draft
+Status: Current
 Created: 2026-06-23
 Last edited: 2026-08-12
 ---
@@ -89,7 +89,7 @@ A `tab` open names the fresh tab `reviewr`, using the `tab_id` the pane-open res
 
 The binary reviews its own pane's working directory, normalized to its git top level. A directory outside any repository shows an empty state.
 
-A manual open prefers the focused pane's live foreground directory over its recorded launch directory. Launch a `claude -w <worktree>` pane from the main checkout, and the open reviews the worktree. A live directory outside any git repository falls back to the launch directory, and a failed or empty live read falls back the same way. The open refuses only when no candidate directory is inside a git repository. The event open takes its directory from the event payload and reads no pane.
+A manual open prefers the focused pane's live foreground directory over its recorded launch directory. Launch a `claude -w <worktree>` pane from the main checkout, and the open reviews the worktree. A live directory outside any git repository falls back to the launch directory. A failed or empty live read falls back the same way. The open refuses only when no candidate directory is inside a git repository. The refusal names every directory it rejected. The event open takes its directory from the event payload. It reads no pane.
 
 ## Sending to the agent
 

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -1,7 +1,7 @@
 ---
-Status: Current
+Status: Draft
 Created: 2026-06-23
-Last edited: 2026-07-31
+Last edited: 2026-08-12
 ---
 
 # herdr host
@@ -88,6 +88,8 @@ A `tab` open names the fresh tab `reviewr`, using the `tab_id` the pane-open res
 ## Repo discovery
 
 The binary reviews its own pane's working directory, normalized to its git top level. A directory outside any repository shows an empty state.
+
+A manual open places the pane in the focused pane's live foreground directory, never its recorded launch directory. Launch a `claude -w <worktree>` pane from the main checkout, and the open reviews the worktree. A live directory outside any git repository falls back to the launch directory, and a failed or empty live read falls back the same way. The open refuses only when no candidate directory is inside a git repository. The event open takes its directory from the event payload and reads no pane.
 
 ## Sending to the agent
 

--- a/tests/pane_actions.rs
+++ b/tests/pane_actions.rs
@@ -671,6 +671,43 @@ fn a_toggle_open_falls_back_when_the_live_cwd_is_not_a_repo() {
 }
 
 #[test]
+fn open_takes_the_focused_panes_cwd_not_another_panes() {
+    let dir = tempfile::tempdir().unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+    // Two panes, both in repos: a decoy listed first and the focused pane after it. The
+    // lookup must key on the focused pane's id — a first-entry read would review the
+    // decoy's repo.
+    let decoy_repo = init_repo(dir.path(), "decoy-repo");
+    fs::write(
+        dir.path().join("panes.json"),
+        format!(
+            r#"{{"result":{{"panes":[{{"pane_id":"w1:p0","foreground_cwd":"{decoy}"}},{{"pane_id":"w1:p1","foreground_cwd":"{focused}"}}]}}}}"#,
+            decoy = decoy_repo.display(),
+            focused = env!("CARGO_MANIFEST_DIR"),
+        ),
+    )
+    .unwrap();
+    let context = serde_json::json!({
+        "focused_pane_id": "w1:p1",
+        "focused_pane_cwd": dir.path().to_str().unwrap(),
+    })
+    .to_string();
+
+    let output = run_with_context("open", dir.path(), &herdr, &context);
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(
+        calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
+        "the open must use the focused pane's cwd, not the decoy's: {calls}"
+    );
+    assert!(
+        !calls.contains(&format!("--cwd {}", decoy_repo.display())),
+        "the decoy pane's cwd must not be reviewed: {calls}"
+    );
+}
+
+#[test]
 fn a_refusal_names_the_rejected_live_cwd_too() {
     let dir = tempfile::tempdir().unwrap();
     let (herdr, _log) = fake_herdr(dir.path());

--- a/tests/pane_actions.rs
+++ b/tests/pane_actions.rs
@@ -12,7 +12,8 @@ fn reviewr_bin() -> &'static str {
 /// A fake herdr, answering in the live 0.7.5 envelope shapes (docs/herdr-api-notes.md).
 /// `pane list` serves `panes.json` (else one plain pane), `pane process-info` serves the
 /// per-pane `procinfo-<id>.json` (else a plain shell, which is not a reviewr pane) or fails
-/// with `procfail-<id>.json` on stderr, `pane close` succeeds unless `closefail-<id>`
+/// with `procfail-<id>.json` on stderr, `pane get` serves `paneget-<id>.json` (else a bare
+/// pane without a foreground cwd), `pane close` succeeds unless `closefail-<id>`
 /// exists (whose content becomes the failure's stderr), `plugin config-dir` names the
 /// fixture dir itself (after a 5s hang when `configdir-hang` exists), and everything else
 /// answers as a successful `plugin pane open`.
@@ -34,6 +35,9 @@ fn fake_herdr(dir: &Path) -> (PathBuf, PathBuf) {
                 "    if [ -f \"$dir/procfail-$4.json\" ]; then cat \"$dir/procfail-$4.json\" >&2; exit 1; fi\n",
                 "    if [ -f \"$dir/procinfo-$4.json\" ]; then cat \"$dir/procinfo-$4.json\";\n",
                 "    else printf '%s\\n' '{{\"result\":{{\"process_info\":{{\"foreground_process_group_id\":7,\"foreground_processes\":[{{\"pid\":7,\"name\":\"zsh\",\"argv0\":\"zsh\",\"argv\":[\"-zsh\"],\"cwd\":\"/\"}}],\"pane_id\":\"'\"$4\"'\",\"shell_pid\":1}}}}}}'; fi ;;\n",
+                "  'pane get '*)\n",
+                "    if [ -f \"$dir/paneget-$3.json\" ]; then cat \"$dir/paneget-$3.json\";\n",
+                "    else printf '%s\\n' '{{\"result\":{{\"pane\":{{\"pane_id\":\"'\"$3\"'\"}}}}}}'; fi ;;\n",
                 "  'pane close '*)\n",
                 "    if [ -f \"$dir/closefail-$3\" ]; then cat \"$dir/closefail-$3\" >&2; exit 1; fi\n",
                 "    printf '%s\\n' '{{\"result\":{{}}}}' ;;\n",
@@ -82,6 +86,11 @@ fn run(mode: &str, config_dir: &Path, herdr: &Path) -> Output {
 /// placement and `plugin pane open` stages.
 fn run_open(config_dir: &Path, herdr: &Path) -> Output {
     let context = serde_json::json!({"focused_pane_cwd": env!("CARGO_MANIFEST_DIR")}).to_string();
+    run_open_with_context(config_dir, herdr, &context)
+}
+
+/// An `open` with a caller-shaped action context.
+fn run_open_with_context(config_dir: &Path, herdr: &Path, context: &str) -> Output {
     Command::new("bash")
         .arg("herdr/pane.sh")
         .arg("open")
@@ -539,6 +548,63 @@ fn tab_placement_open_names_its_fresh_tab() {
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
     let calls = fs::read_to_string(&log).unwrap();
     assert!(calls.contains("tab rename w1:t9 reviewr"), "{calls}");
+}
+
+// --- Open cwd: the focused pane's live foreground cwd, then the context's launch cwd.
+
+#[test]
+fn open_prefers_the_focused_panes_live_foreground_cwd() {
+    let dir = tempfile::tempdir().unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+    // The launch cwd is not a git repo: an open that trusted it would refuse. The pane's
+    // live foreground cwd is the reviewed repo — the `claude -w <worktree>` shape, where
+    // the agent chdirs into the worktree only inside its own process after launching
+    // from the main checkout.
+    let context = serde_json::json!({
+        "focused_pane_id": "w1:p1",
+        "focused_pane_cwd": dir.path().to_str().unwrap(),
+    })
+    .to_string();
+    fs::write(
+        dir.path().join("paneget-w1:p1.json"),
+        format!(
+            r#"{{"result":{{"pane":{{"pane_id":"w1:p1","cwd":"{launch}","foreground_cwd":"{live}"}}}}}}"#,
+            launch = dir.path().display(),
+            live = env!("CARGO_MANIFEST_DIR"),
+        ),
+    )
+    .unwrap();
+
+    let output = run_open_with_context(dir.path(), &herdr, &context);
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(
+        calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
+        "the open must use the live foreground cwd: {calls}"
+    );
+}
+
+#[test]
+fn open_keeps_the_context_cwd_without_a_live_foreground_cwd() {
+    let dir = tempfile::tempdir().unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+    // The fake's default `pane get` answer carries no foreground cwd — a pane whose live
+    // read has nothing to add keeps the context cwd instead of losing it.
+    let context = serde_json::json!({
+        "focused_pane_id": "w1:p1",
+        "focused_pane_cwd": env!("CARGO_MANIFEST_DIR"),
+    })
+    .to_string();
+
+    let output = run_open_with_context(dir.path(), &herdr, &context);
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(
+        calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
+        "the open must fall back to the context cwd: {calls}"
+    );
 }
 
 #[test]

--- a/tests/pane_actions.rs
+++ b/tests/pane_actions.rs
@@ -12,8 +12,7 @@ fn reviewr_bin() -> &'static str {
 /// A fake herdr, answering in the live 0.7.5 envelope shapes (docs/herdr-api-notes.md).
 /// `pane list` serves `panes.json` (else one plain pane), `pane process-info` serves the
 /// per-pane `procinfo-<id>.json` (else a plain shell, which is not a reviewr pane) or fails
-/// with `procfail-<id>.json` on stderr, `pane get` serves `paneget-<id>.json` (else a bare
-/// pane without a foreground cwd), `pane close` succeeds unless `closefail-<id>`
+/// with `procfail-<id>.json` on stderr, `pane close` succeeds unless `closefail-<id>`
 /// exists (whose content becomes the failure's stderr), `plugin config-dir` names the
 /// fixture dir itself (after a 5s hang when `configdir-hang` exists), and everything else
 /// answers as a successful `plugin pane open`.
@@ -35,9 +34,6 @@ fn fake_herdr(dir: &Path) -> (PathBuf, PathBuf) {
                 "    if [ -f \"$dir/procfail-$4.json\" ]; then cat \"$dir/procfail-$4.json\" >&2; exit 1; fi\n",
                 "    if [ -f \"$dir/procinfo-$4.json\" ]; then cat \"$dir/procinfo-$4.json\";\n",
                 "    else printf '%s\\n' '{{\"result\":{{\"process_info\":{{\"foreground_process_group_id\":7,\"foreground_processes\":[{{\"pid\":7,\"name\":\"zsh\",\"argv0\":\"zsh\",\"argv\":[\"-zsh\"],\"cwd\":\"/\"}}],\"pane_id\":\"'\"$4\"'\",\"shell_pid\":1}}}}}}'; fi ;;\n",
-                "  'pane get '*)\n",
-                "    if [ -f \"$dir/paneget-$3.json\" ]; then cat \"$dir/paneget-$3.json\";\n",
-                "    else printf '%s\\n' '{{\"result\":{{\"pane\":{{\"pane_id\":\"'\"$3\"'\"}}}}}}'; fi ;;\n",
                 "  'pane close '*)\n",
                 "    if [ -f \"$dir/closefail-$3\" ]; then cat \"$dir/closefail-$3\" >&2; exit 1; fi\n",
                 "    printf '%s\\n' '{{\"result\":{{}}}}' ;;\n",
@@ -70,6 +66,19 @@ fn procinfo(dir: &Path, pane: &str, entries: &str) {
     .unwrap();
 }
 
+/// One `pane list` answer: a single pane whose entry carries a live `foreground_cwd`,
+/// in the live envelope shape (docs/herdr-api-notes.md).
+fn pane_with_cwd(dir: &Path, pane: &str, foreground_cwd: &Path) {
+    fs::write(
+        dir.join("panes.json"),
+        format!(
+            r#"{{"result":{{"panes":[{{"pane_id":"{pane}","foreground_cwd":"{cwd}"}}]}}}}"#,
+            cwd = foreground_cwd.display(),
+        ),
+    )
+    .unwrap();
+}
+
 fn run(mode: &str, config_dir: &Path, herdr: &Path) -> Output {
     Command::new("bash")
         .arg("herdr/pane.sh")
@@ -86,14 +95,14 @@ fn run(mode: &str, config_dir: &Path, herdr: &Path) -> Output {
 /// placement and `plugin pane open` stages.
 fn run_open(config_dir: &Path, herdr: &Path) -> Output {
     let context = serde_json::json!({"focused_pane_cwd": env!("CARGO_MANIFEST_DIR")}).to_string();
-    run_open_with_context(config_dir, herdr, &context)
+    run_with_context("open", config_dir, herdr, &context)
 }
 
-/// An `open` with a caller-shaped action context.
-fn run_open_with_context(config_dir: &Path, herdr: &Path, context: &str) -> Output {
+/// Any mode with a caller-shaped action context.
+fn run_with_context(mode: &str, config_dir: &Path, herdr: &Path, context: &str) -> Output {
     Command::new("bash")
         .arg("herdr/pane.sh")
-        .arg("open")
+        .arg(mode)
         .env("HERDR_REVIEWR_BIN", reviewr_bin())
         .env("HERDR_PLUGIN_CONFIG_DIR", config_dir)
         .env("HERDR_BIN_PATH", herdr)
@@ -559,23 +568,16 @@ fn open_prefers_the_focused_panes_live_foreground_cwd() {
     // The launch cwd is not a git repo: an open that trusted it would refuse. The pane's
     // live foreground cwd is the reviewed repo — the `claude -w <worktree>` shape, where
     // the agent chdirs into the worktree only inside its own process after launching
-    // from the main checkout.
+    // from the main checkout. The live cwd comes from the pane-list snapshot, so the
+    // open pays no extra herdr call.
     let context = serde_json::json!({
         "focused_pane_id": "w1:p1",
         "focused_pane_cwd": dir.path().to_str().unwrap(),
     })
     .to_string();
-    fs::write(
-        dir.path().join("paneget-w1:p1.json"),
-        format!(
-            r#"{{"result":{{"pane":{{"pane_id":"w1:p1","cwd":"{launch}","foreground_cwd":"{live}"}}}}}}"#,
-            launch = dir.path().display(),
-            live = env!("CARGO_MANIFEST_DIR"),
-        ),
-    )
-    .unwrap();
+    pane_with_cwd(dir.path(), "w1:p1", Path::new(env!("CARGO_MANIFEST_DIR")));
 
-    let output = run_open_with_context(dir.path(), &herdr, &context);
+    let output = run_with_context("open", dir.path(), &herdr, &context);
 
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
     let calls = fs::read_to_string(&log).unwrap();
@@ -589,7 +591,7 @@ fn open_prefers_the_focused_panes_live_foreground_cwd() {
 fn open_keeps_the_context_cwd_without_a_live_foreground_cwd() {
     let dir = tempfile::tempdir().unwrap();
     let (herdr, log) = fake_herdr(dir.path());
-    // The fake's default `pane get` answer carries no foreground cwd — a pane whose live
+    // The fake's default pane-list entry carries no foreground cwd — a pane whose live
     // read has nothing to add keeps the context cwd instead of losing it.
     let context = serde_json::json!({
         "focused_pane_id": "w1:p1",
@@ -597,7 +599,7 @@ fn open_keeps_the_context_cwd_without_a_live_foreground_cwd() {
     })
     .to_string();
 
-    let output = run_open_with_context(dir.path(), &herdr, &context);
+    let output = run_with_context("open", dir.path(), &herdr, &context);
 
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
     let calls = fs::read_to_string(&log).unwrap();
@@ -608,28 +610,21 @@ fn open_keeps_the_context_cwd_without_a_live_foreground_cwd() {
 }
 
 #[test]
-fn open_falls_back_when_the_live_cwd_is_not_a_repo() {
+fn a_toggle_open_falls_back_when_the_live_cwd_is_not_a_repo() {
     let dir = tempfile::tempdir().unwrap();
     let (herdr, log) = fake_herdr(dir.path());
     // The live foreground cwd sits outside any git repo — a shell that wandered off. The
-    // live read wins only inside a repo; here it yields to the context cwd rather than
-    // refusing an open the context alone could place (specs/herdr-host.md, Repo discovery).
+    // live cwd wins only inside a repo; here it yields to the context cwd rather than
+    // refusing an open the context alone could place (specs/herdr-host.md, Repo
+    // discovery). Run as a toggle, so the opening toggle exercises the same block.
     let context = serde_json::json!({
         "focused_pane_id": "w1:p1",
         "focused_pane_cwd": env!("CARGO_MANIFEST_DIR"),
     })
     .to_string();
-    fs::write(
-        dir.path().join("paneget-w1:p1.json"),
-        format!(
-            r#"{{"result":{{"pane":{{"pane_id":"w1:p1","cwd":"{launch}","foreground_cwd":"{live}"}}}}}}"#,
-            launch = env!("CARGO_MANIFEST_DIR"),
-            live = dir.path().display(),
-        ),
-    )
-    .unwrap();
+    pane_with_cwd(dir.path(), "w1:p1", dir.path());
 
-    let output = run_open_with_context(dir.path(), &herdr, &context);
+    let output = run_with_context("toggle", dir.path(), &herdr, &context);
 
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
     let calls = fs::read_to_string(&log).unwrap();
@@ -640,42 +635,25 @@ fn open_falls_back_when_the_live_cwd_is_not_a_repo() {
 }
 
 #[test]
-fn close_reads_no_pane() {
+fn auto_open_takes_the_event_payload_cwd_over_the_live_one() {
     let dir = tempfile::tempdir().unwrap();
     let (herdr, log) = fake_herdr(dir.path());
-    let ui = r#"{"pid":8,"name":"herdr-reviewr","argv0":"herdr-reviewr","argv":["/plugin/bin/herdr-reviewr"],"cwd":"/w"}"#;
-    procinfo(dir.path(), "w1:p1", ui);
-    let context = serde_json::json!({
-        "focused_pane_id": "w1:p1",
-        "focused_pane_cwd": env!("CARGO_MANIFEST_DIR"),
-    })
-    .to_string();
-
-    let output = Command::new("bash")
-        .arg("herdr/pane.sh")
-        .arg("close")
-        .env("HERDR_REVIEWR_BIN", reviewr_bin())
-        .env("HERDR_PLUGIN_CONFIG_DIR", dir.path())
-        .env("HERDR_BIN_PATH", &herdr)
-        .env("HERDR_WORKSPACE_ID", "workspace-1")
-        .env("HERDR_PANE_ID", "w1:p1")
-        .env("HERDR_PLUGIN_CONTEXT_JSON", &context)
-        .output()
-        .unwrap();
-
-    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
-    let calls = fs::read_to_string(&log).unwrap();
-    // The live cwd read serves only an open; a close never uses a cwd and pays no
-    // round-trip for one.
-    assert!(!calls.contains("pane get"), "a close must not read a pane's live cwd: {calls}");
-}
-
-#[test]
-fn auto_open_takes_the_event_payload_cwd_and_reads_no_pane() {
-    let dir = tempfile::tempdir().unwrap();
-    let (herdr, log) = fake_herdr(dir.path());
-    // The event open takes its directory from the payload and never reads a pane
-    // (specs/herdr-host.md, Repo discovery) — even with a focused-pane context present.
+    // The focused pane's live cwd is a real git repo, so only the mode guard keeps it
+    // from winning: the event open takes its directory from the payload alone
+    // (specs/herdr-host.md, Repo discovery).
+    let live_repo = dir.path().join("live-repo");
+    fs::create_dir(&live_repo).unwrap();
+    assert!(
+        Command::new("git")
+            .arg("-C")
+            .arg(&live_repo)
+            .arg("init")
+            .arg("-q")
+            .status()
+            .unwrap()
+            .success()
+    );
+    pane_with_cwd(dir.path(), "w1:p1", &live_repo);
     let context = serde_json::json!({
         "focused_pane_id": "w1:p1",
         "focused_pane_cwd": dir.path().to_str().unwrap(),
@@ -706,7 +684,6 @@ fn auto_open_takes_the_event_payload_cwd_and_reads_no_pane() {
         calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
         "the event open must use the payload cwd: {calls}"
     );
-    assert!(!calls.contains("pane get"), "the event must not read a pane's live cwd: {calls}");
 }
 
 #[test]

--- a/tests/pane_actions.rs
+++ b/tests/pane_actions.rs
@@ -99,7 +99,7 @@ fn run_open_with_context(config_dir: &Path, herdr: &Path, context: &str) -> Outp
         .env("HERDR_BIN_PATH", herdr)
         .env("HERDR_WORKSPACE_ID", "workspace-1")
         .env("HERDR_PANE_ID", "w1:p1")
-        .env("HERDR_PLUGIN_CONTEXT_JSON", &context)
+        .env("HERDR_PLUGIN_CONTEXT_JSON", context)
         .output()
         .unwrap()
 }
@@ -605,6 +605,108 @@ fn open_keeps_the_context_cwd_without_a_live_foreground_cwd() {
         calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
         "the open must fall back to the context cwd: {calls}"
     );
+}
+
+#[test]
+fn open_falls_back_when_the_live_cwd_is_not_a_repo() {
+    let dir = tempfile::tempdir().unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+    // The live foreground cwd sits outside any git repo — a shell that wandered off. The
+    // live read wins only inside a repo; here it yields to the context cwd rather than
+    // refusing an open the context alone could place (specs/herdr-host.md, Repo discovery).
+    let context = serde_json::json!({
+        "focused_pane_id": "w1:p1",
+        "focused_pane_cwd": env!("CARGO_MANIFEST_DIR"),
+    })
+    .to_string();
+    fs::write(
+        dir.path().join("paneget-w1:p1.json"),
+        format!(
+            r#"{{"result":{{"pane":{{"pane_id":"w1:p1","cwd":"{launch}","foreground_cwd":"{live}"}}}}}}"#,
+            launch = env!("CARGO_MANIFEST_DIR"),
+            live = dir.path().display(),
+        ),
+    )
+    .unwrap();
+
+    let output = run_open_with_context(dir.path(), &herdr, &context);
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(
+        calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
+        "a non-repo live cwd must fall back to the context cwd: {calls}"
+    );
+}
+
+#[test]
+fn close_reads_no_pane() {
+    let dir = tempfile::tempdir().unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+    let ui = r#"{"pid":8,"name":"herdr-reviewr","argv0":"herdr-reviewr","argv":["/plugin/bin/herdr-reviewr"],"cwd":"/w"}"#;
+    procinfo(dir.path(), "w1:p1", ui);
+    let context = serde_json::json!({
+        "focused_pane_id": "w1:p1",
+        "focused_pane_cwd": env!("CARGO_MANIFEST_DIR"),
+    })
+    .to_string();
+
+    let output = Command::new("bash")
+        .arg("herdr/pane.sh")
+        .arg("close")
+        .env("HERDR_REVIEWR_BIN", reviewr_bin())
+        .env("HERDR_PLUGIN_CONFIG_DIR", dir.path())
+        .env("HERDR_BIN_PATH", &herdr)
+        .env("HERDR_WORKSPACE_ID", "workspace-1")
+        .env("HERDR_PANE_ID", "w1:p1")
+        .env("HERDR_PLUGIN_CONTEXT_JSON", &context)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    // The live cwd read serves only an open; a close never uses a cwd and pays no
+    // round-trip for one.
+    assert!(!calls.contains("pane get"), "a close must not read a pane's live cwd: {calls}");
+}
+
+#[test]
+fn auto_open_takes_the_event_payload_cwd_and_reads_no_pane() {
+    let dir = tempfile::tempdir().unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+    // The event open takes its directory from the payload and never reads a pane
+    // (specs/herdr-host.md, Repo discovery) — even with a focused-pane context present.
+    let context = serde_json::json!({
+        "focused_pane_id": "w1:p1",
+        "focused_pane_cwd": dir.path().to_str().unwrap(),
+    })
+    .to_string();
+    let event = serde_json::json!({
+        "data": {"workspace": {
+            "workspace_id": "workspace-9",
+            "worktree": {"checkout_path": env!("CARGO_MANIFEST_DIR")},
+        }},
+    })
+    .to_string();
+
+    let output = Command::new("bash")
+        .arg("herdr/pane.sh")
+        .arg("auto-open")
+        .env("HERDR_REVIEWR_BIN", reviewr_bin())
+        .env("HERDR_PLUGIN_CONFIG_DIR", dir.path())
+        .env("HERDR_BIN_PATH", &herdr)
+        .env("HERDR_PLUGIN_CONTEXT_JSON", &context)
+        .env("HERDR_PLUGIN_EVENT_JSON", &event)
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(
+        calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
+        "the event open must use the payload cwd: {calls}"
+    );
+    assert!(!calls.contains("pane get"), "the event must not read a pane's live cwd: {calls}");
 }
 
 #[test]

--- a/tests/pane_actions.rs
+++ b/tests/pane_actions.rs
@@ -588,6 +588,42 @@ fn open_prefers_the_focused_panes_live_foreground_cwd() {
 }
 
 #[test]
+fn open_prefers_the_live_cwd_when_the_launch_cwd_is_also_a_repo() {
+    let dir = tempfile::tempdir().unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+    // The motivating shape exactly: the launch cwd is itself a valid repo (the main
+    // checkout `claude -w <worktree>` was launched from), so a fallback-only read would
+    // pass every other test and still review the wrong repo. The live cwd must win.
+    let launch_repo = dir.path().join("main-checkout");
+    fs::create_dir(&launch_repo).unwrap();
+    assert!(
+        Command::new("git")
+            .arg("-C")
+            .arg(&launch_repo)
+            .arg("init")
+            .arg("-q")
+            .status()
+            .unwrap()
+            .success()
+    );
+    let context = serde_json::json!({
+        "focused_pane_id": "w1:p1",
+        "focused_pane_cwd": launch_repo.to_str().unwrap(),
+    })
+    .to_string();
+    pane_with_cwd(dir.path(), "w1:p1", Path::new(env!("CARGO_MANIFEST_DIR")));
+
+    let output = run_with_context("open", dir.path(), &herdr, &context);
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(
+        calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
+        "the live cwd must win over a launch cwd that is also a repo: {calls}"
+    );
+}
+
+#[test]
 fn open_keeps_the_context_cwd_without_a_live_foreground_cwd() {
     let dir = tempfile::tempdir().unwrap();
     let (herdr, log) = fake_herdr(dir.path());

--- a/tests/pane_actions.rs
+++ b/tests/pane_actions.rs
@@ -66,6 +66,17 @@ fn procinfo(dir: &Path, pane: &str, entries: &str) {
     .unwrap();
 }
 
+/// A fresh git repo at `dir/name`, for tests that need a real second repo beside the
+/// crate's own.
+fn init_repo(dir: &Path, name: &str) -> PathBuf {
+    let repo = dir.join(name);
+    fs::create_dir(&repo).unwrap();
+    assert!(
+        Command::new("git").arg("-C").arg(&repo).arg("init").arg("-q").status().unwrap().success()
+    );
+    repo
+}
+
 /// One `pane list` answer: a single pane whose entry carries a live `foreground_cwd`,
 /// in the live envelope shape (docs/herdr-api-notes.md).
 fn pane_with_cwd(dir: &Path, pane: &str, foreground_cwd: &Path) {
@@ -594,18 +605,7 @@ fn open_prefers_the_live_cwd_when_the_launch_cwd_is_also_a_repo() {
     // The motivating shape exactly: the launch cwd is itself a valid repo (the main
     // checkout `claude -w <worktree>` was launched from), so a fallback-only read would
     // pass every other test and still review the wrong repo. The live cwd must win.
-    let launch_repo = dir.path().join("main-checkout");
-    fs::create_dir(&launch_repo).unwrap();
-    assert!(
-        Command::new("git")
-            .arg("-C")
-            .arg(&launch_repo)
-            .arg("init")
-            .arg("-q")
-            .status()
-            .unwrap()
-            .success()
-    );
+    let launch_repo = init_repo(dir.path(), "main-checkout");
     let context = serde_json::json!({
         "focused_pane_id": "w1:p1",
         "focused_pane_cwd": launch_repo.to_str().unwrap(),
@@ -671,24 +671,34 @@ fn a_toggle_open_falls_back_when_the_live_cwd_is_not_a_repo() {
 }
 
 #[test]
+fn a_refusal_names_the_rejected_live_cwd_too() {
+    let dir = tempfile::tempdir().unwrap();
+    let (herdr, _log) = fake_herdr(dir.path());
+    // No context cwd and a non-repo live cwd: the open refuses, and the one stderr line
+    // names the live directory it inspected and rejected — a refusal that hid it would
+    // read as if no directory was ever tried.
+    let context = serde_json::json!({"focused_pane_id": "w1:p1"}).to_string();
+    pane_with_cwd(dir.path(), "w1:p1", dir.path());
+
+    let output = run_with_context("open", dir.path(), &herdr, &context);
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not a git repo"), "{stderr}");
+    assert!(
+        stderr.contains(dir.path().to_str().unwrap()),
+        "the refusal must name the rejected live cwd: {stderr}"
+    );
+}
+
+#[test]
 fn auto_open_takes_the_event_payload_cwd_over_the_live_one() {
     let dir = tempfile::tempdir().unwrap();
     let (herdr, log) = fake_herdr(dir.path());
     // The focused pane's live cwd is a real git repo, so only the mode guard keeps it
     // from winning: the event open takes its directory from the payload alone
     // (specs/herdr-host.md, Repo discovery).
-    let live_repo = dir.path().join("live-repo");
-    fs::create_dir(&live_repo).unwrap();
-    assert!(
-        Command::new("git")
-            .arg("-C")
-            .arg(&live_repo)
-            .arg("init")
-            .arg("-q")
-            .status()
-            .unwrap()
-            .success()
-    );
+    let live_repo = init_repo(dir.path(), "live-repo");
     pane_with_cwd(dir.path(), "w1:p1", &live_repo);
     let context = serde_json::json!({
         "focused_pane_id": "w1:p1",

--- a/tests/pane_actions.rs
+++ b/tests/pane_actions.rs
@@ -72,7 +72,16 @@ fn init_repo(dir: &Path, name: &str) -> PathBuf {
     let repo = dir.join(name);
     fs::create_dir(&repo).unwrap();
     assert!(
-        Command::new("git").arg("-C").arg(&repo).arg("init").arg("-q").status().unwrap().success()
+        Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .arg("init")
+            .arg("-q")
+            .arg("-b")
+            .arg("main")
+            .status()
+            .unwrap()
+            .success()
     );
     repo
 }
@@ -596,6 +605,13 @@ fn open_prefers_the_focused_panes_live_foreground_cwd() {
         calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
         "the open must use the live foreground cwd: {calls}"
     );
+    // The live cwd comes from the run's one snapshot; a second listing would put a herdr
+    // round-trip back on the keypress path.
+    assert_eq!(
+        calls.matches("pane list --workspace").count(),
+        1,
+        "the open must reuse the held pane-list snapshot: {calls}"
+    );
 }
 
 #[test]
@@ -700,10 +716,6 @@ fn open_takes_the_focused_panes_cwd_not_another_panes() {
     assert!(
         calls.contains(&format!("--cwd {}", env!("CARGO_MANIFEST_DIR"))),
         "the open must use the focused pane's cwd, not the decoy's: {calls}"
-    );
-    assert!(
-        !calls.contains(&format!("--cwd {}", decoy_repo.display())),
-        "the decoy pane's cwd must not be reviewed: {calls}"
     );
 }
 


### PR DESCRIPTION
## Problem

Opening a reviewr pane from a pane running `claude -w <worktree>` always reviews the **main checkout's branch** instead of the worktree's.

The action context's `focused_pane_cwd` is the pane's *launch* cwd. `claude -w` starts in the main checkout and chdirs into the worktree only inside its own process, so the launch cwd keeps naming the main repo and every toggle/open lands the review on the wrong branch.

Observed on herdr 0.7.5:

- `herdr pane get <id>` for the pane → `cwd` = main checkout (launch), `foreground_cwd` = the worktree (live foreground process)
- the keybinding/action context delivered the launch cwd, and the opened pane reviewed `main`

## Fix

`pane.sh` now resolves the open cwd from the focused pane's live `foreground_cwd` (`herdr pane get`), falling back to the context cwd when the read fails or carries nothing — a failed live read never refuses an open that the context alone could place.

## Tests

- `open_prefers_the_focused_panes_live_foreground_cwd` — launch cwd is not a git repo (would have refused), live cwd is the reviewed repo; the open uses the live cwd.
- `open_keeps_the_context_cwd_without_a_live_foreground_cwd` — a `pane get` answer without `foreground_cwd` keeps the context cwd.
- fake herdr grows a `pane get` verb (`paneget-<id>.json`, else a bare pane).

`cargo test --all-features`: 648 passed, 0 failed. Also verified live in herdr 0.7.5 against a `claude -w` pane — the review now opens on the worktree's branch.