### PR TITLE
Add CLI navigation: a one-shot command file steers the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **CLI navigation.** `herdr-reviewr nav [--tab changes|all|pr] [--scope uncommitted|branch|last-turn] [--file <path> | <path>]` steers the sidebar running on the repo from outside the pane — a script or a coding agent can put a specific diff on screen without synthesizing keypresses. The command lands within ~300 ms, shows its outcome in the status line, and is dropped whole while a comment, search, or overlay is open. `--repo <path>` targets a sidebar other than the current directory's.
+
 ## [0.30.4] — 2026-08-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ wins for the rest of the session.
 Every scope respects `.gitignore`, so build output never clutters **Changes**. To review a file,
 track it. **All files** still browses any ignored path.
 
+## CLI navigation
+
+`herdr-reviewr nav` steers the running sidebar from outside — a script or a coding agent puts a
+specific diff on screen without touching the pane:
+
+```bash
+herdr-reviewr nav --tab changes --scope branch --file src/lib.rs
+herdr-reviewr nav lib.rs              # bare path, resolved from the cwd — works in any subdir
+```
+
+`--tab` takes `changes`/`all`/`pr`, `--scope` takes `uncommitted`/`branch`/`last-turn`. All
+parts are optional and apply in tab → scope → file order. `--repo <path>` targets a sidebar
+other than the cwd's. The command lands within ~300 ms and reports in the sidebar's status
+line; while a comment, search, or overlay is open it is dropped and says so. A command sent
+with no sidebar running waits and applies when the next one opens on that repo.
+
 ## Configuration
 
 CLI flags on the pane command:

--- a/herdr/pane.sh
+++ b/herdr/pane.sh
@@ -103,11 +103,13 @@ panes_json=$("$H" pane list --workspace "$ws" 2>/dev/null) && [ -n "$panes_json"
   refuse "herdr pane list failed for $ws"
 
 # A reviewr pane runs the review UI in its foreground process group (specs/herdr-host.md,
-# Pane identity). A wrapped launch (`cargo run`) counts through its child; a flag run
-# (`--resolve-plugin-config`) never counts. The executable name in `argv0`/`argv[0]`
-# decides, never `name`: that field is a rewritable process title (docs/herdr-api-notes.md).
-# The flag exclusion mirrors the dispatch in `src/main.rs`, which recognizes the flag
-# anywhere in argv — a future non-UI flag must land in both halves.
+# Pane identity). A wrapped launch (`cargo run`) counts through its child; a non-UI run
+# (`--resolve-plugin-config` anywhere in argv, or the `nav` subcommand as the first
+# argument) never counts. The executable name in `argv0`/`argv[0]` decides, never `name`:
+# that field is a rewritable process title (docs/herdr-api-notes.md).
+# Each exclusion mirrors its dispatch in `src/main.rs` — the flag is recognized anywhere
+# in argv, the subcommand only in first position — and a future non-UI invocation must
+# land in both halves.
 # Takes the pane id and a scratch file for the call's stderr, which stays out of the JSON
 # handed to jq — a successful call with an advisory on stderr must not read as unreadable.
 # Returns 1 for a pane that is not the review UI — a pane the read reports gone exited
@@ -128,7 +130,8 @@ is_reviewr_pane() {
     [.result.process_info.foreground_processes[]
       | select((((.argv0 // "") | base) == "herdr-reviewr")
           or ((((.argv // [])[0] // "") | base) == "herdr-reviewr"))
-      | select(((.argv // []) | index("--resolve-plugin-config")) == null)]
+      | select(((.argv // []) | index("--resolve-plugin-config")) == null)
+      | select((((.argv // [])[1] // "")) != "nav")]
     | length' 2>/dev/null) || return 2
   # An empty count is a read that failed some new way, so the `[` error's status 2 refuses
   # it — a default here would pick the one outcome the failure semantics forbid.

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -24,7 +24,7 @@ The binary paints its empty frame before the first git scan, so the pane never s
 
 ## Pane identity
 
-A reviewr pane is any pane running the review UI in its foreground process group, read live from herdr at each action and event. A wrapped launch like `cargo run` counts through its child. A flag run like `--resolve-plugin-config` is not the review UI and never counts.
+A reviewr pane is any pane running the review UI in its foreground process group, read live from herdr at each action and event. A wrapped launch like `cargo run` counts through its child. A non-UI run — `--resolve-plugin-config` anywhere in argv, or the `nav` subcommand in first position (`nav.md`) — is not the review UI and never counts.
 
 The review run labels its pane `reviewr` when the pane has no label, and a normal exit clears only a `reviewr` label, so a name the user gave the pane survives both ends. The label is display only: a failed write or a stale label changes nothing an action or the event reads.
 

--- a/specs/nav.md
+++ b/specs/nav.md
@@ -1,0 +1,85 @@
+---
+Status: Draft
+Created: 2026-08-13
+Last edited: 2026-08-13
+---
+
+# CLI navigation
+
+`herdr-reviewr nav` steers the running sidebar from outside — a script or a coding agent puts a
+specific diff on screen without synthesizing keypresses into the pane.
+
+## Overview
+
+The channel is a one-shot command file, not a socket or stdin: the TUI owns its terminal, and a
+listener would add a lifecycle to manage for a feature whose whole job is "apply this once". The
+CLI writes the file; the sidebar's event loop takes it (read + delete) on its next wakeup and
+applies it. The file lives in the system temp dir, keyed by a hash of the canonical repo path —
+inside the repo it would dirty the very worktree under review.
+
+```json
+{ "tab": "changes", "scope": "branch", "file": "src/lib.rs" }
+```
+
+| field   | type   | meaning                                                              |
+| ------- | ------ | -------------------------------------------------------------------- |
+| `tab`   | string | `changes`, `all`, or `pr`; also the key spellings `1` `2` `3`         |
+| `scope` | string | `uncommitted`, `branch`, or `last-turn`; also the keys `u` `b` `t`    |
+| `file`  | string | path to open, stored repo-relative; see the re-rooting rule below     |
+
+Every field is optional; present ones apply in tab → scope → file order, so one command lands on
+"this file, in this scope, on this tab". Fields hold the CLI spellings and parse on apply — a
+stale file from a newer CLI degrades to a status-line error, never a crash.
+
+The CLI re-roots the `file` argument to repo-relative: an absolute path lexically, a relative
+one against the cwd when that resolves to a real file inside the repo — so `nav foo.rs` works
+from any subdirectory. A path that resolves nowhere passes through as repo-relative, so a
+deleted file, which exists only in the diff, stays nameable. The alternative — cwd-relative
+always — lost because it breaks the deleted-file case and every script that already speaks
+repo-relative paths.
+
+## Invariants
+
+| code              | Always true                                                                     |
+| ----------------- | ------------------------------------------------------------------------------- |
+| `NAV-AT-MOST-ONCE`| A command applies at most once: the take deletes the file before applying.       |
+| `NAV-NORMAL-ONLY` | A command applies only in `Normal` mode — it never destroys a composed comment, a search, or an open overlay. |
+| `NAV-NON-UI`      | A `nav` invocation never counts as the review UI: excluded in `main.rs` dispatch and `is_reviewr_pane`, the two halves of Pane identity (`herdr-host.md`). |
+| `NAV-REPO-KEYED`  | Sidebars on different repos never cross: the command path is derived from the canonical repo root. |
+| `NAV-LATENCY`     | The idle event wait is capped at 300 ms, so a command lands within that bound rather than the refresh interval's seconds. |
+
+## Behavior
+
+| command                                  | outcome                                                            |
+| ---------------------------------------- | ------------------------------------------------------------------ |
+| valid tab / scope / file                 | applied in order; the status line names the opened file            |
+| `file` not in the active tab's entries   | nothing moves; the status line names the file and the scope        |
+| `file` with `tab = pr`                   | tab switches; the file part reports "needs a file tab"             |
+| unknown spelling in any field            | that part reports in the status line; the others still apply       |
+| any command while not in `Normal` mode   | dropped whole, reported in the status line (`NAV-NORMAL-ONLY`)     |
+| CLI run with no field at all             | refused at the CLI with a usage error; nothing is written          |
+
+The CLI validates the spellings it can check locally and exits after writing — it never waits
+for the apply. The outcome surfaces only in the sidebar's status line: a round-trip
+acknowledgement would need the socket this design rejected.
+
+## Failure semantics
+
+A command written while no sidebar runs waits in the temp dir and applies when the next sidebar
+on that repo starts. The alternative — expiring stale commands — lost because a scripted
+open-then-navigate must survive the sidebar's startup time; the surprise is bounded to one
+command, since the take deletes the file. An unreadable or unparsable file is deleted the same
+way and dropped.
+
+## Non-goals
+
+- No cursor or line targeting. The unit of navigation is the file; finer targets belong to a
+  future command only if a real workflow needs them.
+- No state readback. The CLI writes; it never queries what the sidebar shows.
+- No multi-command queue. A second write before the take replaces the first — last writer wins.
+
+## Related specs
+
+- [herdr-host](./herdr-host.md) — Pane identity, which `NAV-NON-UI` extends.
+- [input](./input.md) — the in-pane keys these commands mirror.
+- [tui](./tui.md) — tabs, scopes, and the status line.

--- a/specs/overview.md
+++ b/specs/overview.md
@@ -50,6 +50,7 @@ to move the work forward.
 - Keyboard and mouse input (`input.md`).
 - Full-screen search over the worktree: fuzzy file names and literal code with a live preview, ranking owned by the engine (`search.md`).
 - In-file find in the read pane: literal match highlighting and match-to-match stepping (`find-in-file.md`).
+- CLI navigation: a one-shot command file steers tab, scope, and open file from outside the pane (`nav.md`).
 
 ## Roadmap
 
@@ -102,6 +103,7 @@ Newer content paints over the old in place, reconciling the reviewer's place as 
 - [input](./input.md)
 - [search](./search.md)
 - [find-in-file](./find-in-file.md)
+- [nav](./nav.md)
 - [tui](./tui.md)
 - [pr-tab](./pr-tab.md)
 - [herdr-host](./herdr-host.md)

--- a/src/app.rs
+++ b/src/app.rs
@@ -2397,6 +2397,38 @@ impl App {
         Ok(())
     }
 
+    /// `nav`: put the cursor on the file at repo-relative `path` and open its diff,
+    /// expanding collapsed ancestors so the row exists (specs/nav.md). Focus lands on the
+    /// navigator, or stays on the read pane while the navigator is hidden (specs/tui.md).
+    /// `false` when the path is not in the active tab's entries (e.g. unchanged under the
+    /// current scope).
+    pub fn goto_file(&mut self, path: &str) -> bool {
+        if self.ensure_config_ready().is_err()
+            || !self.entries.iter().any(|e| e.path == path && !e.is_dir)
+        {
+            return false;
+        }
+        let mut expanded = false;
+        let mut prefix = path;
+        while let Some((dir, _)) = prefix.rsplit_once('/') {
+            expanded |= self.set_dir_expanded(dir, true);
+            prefix = dir;
+        }
+        if expanded {
+            self.apply_dir_change();
+        }
+        let row = self.file_rows.iter().position(|r| match &r.kind {
+            RowKind::File { index, .. } => self.entries[*index].path == path,
+            RowKind::Dir { .. } => false,
+        });
+        let Some(row) = row else { return false };
+        self.focus = if self.navigator_hidden_here() { Focus::Diff } else { Focus::Files };
+        self.file_cursor = row;
+        self.open_cursor_file();
+        self.reveal_files = true;
+        true
+    }
+
     /// Collapse or expand the directory under the cursor, then rebuild the tree. The cursor
     /// stays on the directory row (still present, now toggled).
     fn toggle_dir(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod keymap;
 pub mod log;
 pub mod markdown;
 pub mod model;
+pub mod nav;
 pub mod proc;
 pub mod search;
 pub mod theme;
@@ -213,6 +214,10 @@ const FETCH_HANG: Duration = Duration::from_mins(1);
 const INDICATOR_DELAY: Duration = Duration::from_millis(200);
 /// Once lit, the glyph holds at least this long, so a fast landing still reads.
 const INDICATOR_MIN_SHOW: Duration = Duration::from_millis(300);
+
+/// Ceiling on the idle event wait, so a `herdr-reviewr nav` command file is noticed within
+/// this long even when the refresh poll would otherwise sleep for seconds (specs/nav.md).
+const NAV_POLL: Duration = Duration::from_millis(300);
 const PR_SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
 
 #[derive(Debug)]
@@ -1063,6 +1068,9 @@ fn event_loop(
             if let Some(started) = pr.wait_started {
                 timeout = timeout.min(INDICATOR_DELAY.saturating_sub(started.elapsed()));
             }
+            // A `nav` command file only lands between wakeups, so bound the idle wait to
+            // keep its worst-case latency at NAV_POLL rather than the refresh interval.
+            timeout = timeout.min(NAV_POLL);
             if event::poll(timeout)? {
                 if !painted_frame.still_current(app) {
                     continue;
@@ -1127,6 +1135,9 @@ fn event_loop(
             }
             if app.should_quit {
                 break;
+            }
+            if let Some(cmd) = nav::take(&app.repo) {
+                apply_nav(app, &cmd);
             }
             if last_poll.elapsed() >= poll {
                 let config_gate = reconcile_plugin_config(
@@ -1348,6 +1359,111 @@ fn apply_plugin_config_observation(
             false
         }
     }
+}
+
+/// Apply a one-shot `nav` command: tab, then scope, then file (specs/nav.md). Applied only
+/// from `Normal` mode, so an external command never destroys a comment in progress or a
+/// half-typed search. Failures land in the status line — the CLI has already exited by the
+/// time the command applies. Public for the dispatch tests; the event loop is the runtime
+/// caller.
+pub fn apply_nav(app: &mut App, cmd: &nav::NavCommand) {
+    if app.mode != Mode::Normal {
+        app.status = "nav: ignored while an overlay or composer is open".into();
+        return;
+    }
+    let mut errors: Vec<String> = Vec::new();
+    if let Some(tab) = &cmd.tab {
+        match nav::parse_tab(tab) {
+            Some(tab) => {
+                if let Err(e) = app.set_tab(tab) {
+                    errors.push(e.to_string());
+                }
+            }
+            None => errors.push(format!("unknown tab {tab:?}")),
+        }
+    }
+    if let Some(scope) = &cmd.scope {
+        match nav::parse_scope(scope) {
+            Some(scope) => {
+                if let Err(e) = app.set_scope(scope) {
+                    errors.push(e.to_string());
+                }
+            }
+            None => errors.push(format!("unknown scope {scope:?}")),
+        }
+    }
+    if let Some(file) = &cmd.file {
+        if app.tab == crate::app::Tab::Pr {
+            errors.push("a file needs the Changes or All files tab".into());
+        } else if !app.goto_file(file) {
+            errors.push(format!("{file:?} is not in the {} scope", app.scope.label()));
+        }
+    }
+    app.status = if errors.is_empty() {
+        format!("nav: {}", cmd.file.as_deref().unwrap_or("ok"))
+    } else {
+        format!("nav: {}", errors.join("; "))
+    };
+    logln!("nav {:?} -> tab={:?} scope={:?} status={}", cmd, app.tab, app.scope, app.status);
+}
+
+/// `herdr-reviewr nav [--repo <path>] [--tab changes|all|pr] [--scope uncommitted|branch|last-turn]
+/// [--file <path> | <path>]` — write a command file for the running sidebar on the repo
+/// (specs/nav.md).
+pub fn nav_main(args: &[String]) -> Result<()> {
+    use anyhow::{Context, bail, ensure};
+    let mut repo: Option<std::path::PathBuf> = None;
+    let mut cmd = nav::NavCommand::default();
+    let mut it = args.iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--repo" => {
+                repo = Some(it.next().context("--repo needs a path")?.into());
+            }
+            "--tab" => cmd.tab = Some(it.next().context("--tab needs a value")?.clone()),
+            "--scope" => cmd.scope = Some(it.next().context("--scope needs a value")?.clone()),
+            "--file" => cmd.file = Some(it.next().context("--file needs a path")?.clone()),
+            other if !other.starts_with('-') && cmd.file.is_none() => {
+                cmd.file = Some(other.to_string());
+            }
+            other => bail!("unknown argument {other:?}"),
+        }
+    }
+    if let Some(tab) = &cmd.tab {
+        ensure!(nav::parse_tab(tab).is_some(), "unknown tab {tab:?} (changes|all|pr)");
+    }
+    if let Some(scope) = &cmd.scope {
+        ensure!(
+            nav::parse_scope(scope).is_some(),
+            "unknown scope {scope:?} (uncommitted|branch|last-turn)"
+        );
+    }
+    ensure!(
+        cmd.tab.is_some() || cmd.scope.is_some() || cmd.file.is_some(),
+        "nothing to do: pass --tab, --scope, and/or a file"
+    );
+    let start = repo.unwrap_or(std::env::current_dir()?);
+    let repo = git::toplevel(&start).unwrap_or(start);
+    // The sidebar matches files by repo-relative path. An absolute argument re-roots
+    // lexically; a relative one resolves against the cwd first when that names a real
+    // file inside the repo, so `nav foo.rs` works from any subdirectory — and falls back
+    // to repo-relative otherwise, so a deleted file can still be named from anywhere.
+    if let Some(file) = &cmd.file {
+        let given = std::path::Path::new(file);
+        if given.is_absolute() {
+            if let Ok(stripped) = given.strip_prefix(&repo) {
+                cmd.file = Some(stripped.to_string_lossy().into_owned());
+            }
+        } else if let Ok(canon) = std::env::current_dir()?.join(given).canonicalize()
+            && let Ok(repo_canon) = repo.canonicalize()
+            && let Ok(stripped) = canon.strip_prefix(&repo_canon)
+        {
+            cmd.file = Some(stripped.to_string_lossy().into_owned());
+        }
+    }
+    let path = nav::write(&repo, &cmd)?;
+    println!("nav queued for {} at {}", repo.display(), path.display());
+    Ok(())
 }
 
 /// Diff scroll steps: a full page for `PageUp`/`PageDown`, half for `ctrl+u`/`ctrl+d`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,5 +12,16 @@ fn main() -> anyhow::Result<()> {
         }
         return Ok(());
     }
+    // `nav` is the other non-UI invocation, recognized as the first argument only — a repo
+    // path happening to be named `nav` still opens the UI when it arrives behind a flag.
+    // The same first-argument read excludes it in `is_reviewr_pane` (specs/nav.md).
+    if std::env::args().nth(1).as_deref() == Some("nav") {
+        let args: Vec<String> = std::env::args().skip(2).collect();
+        if let Err(error) = herdr_reviewr::nav_main(&args) {
+            eprintln!("reviewr: {error}");
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
     herdr_reviewr::run()
 }

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -1,0 +1,97 @@
+//! CLI navigation channel: `herdr-reviewr nav` writes a one-shot command file for the
+//! running sidebar on the same repo, which applies and removes it on its next wakeup.
+//! File-based so the CLI needs no socket into the TUI; keyed by repo path so concurrent
+//! sidebars on different repos never cross.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::app::Tab;
+use crate::model::Scope;
+
+/// A one-shot navigation command. Every field is optional; present ones apply in
+/// tab → scope → file order. Fields hold the CLI spellings, parsed on apply, so a
+/// stale file from a newer CLI degrades to a status-line error instead of a crash.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NavCommand {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tab: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+}
+
+pub fn parse_scope(name: &str) -> Option<Scope> {
+    match name {
+        "uncommitted" | "u" => Some(Scope::Uncommitted),
+        "branch" | "b" => Some(Scope::Branch),
+        "last-turn" | "t" => Some(Scope::LastTurn),
+        _ => None,
+    }
+}
+
+pub fn parse_tab(name: &str) -> Option<Tab> {
+    match name {
+        "changes" | "1" => Some(Tab::Changes),
+        "all" | "all-files" | "2" => Some(Tab::AllFiles),
+        "pr" | "3" => Some(Tab::Pr),
+        _ => None,
+    }
+}
+
+/// The command file for `repo`: in the system temp dir, named by an FNV-1a hash of the
+/// canonical repo path (stable across processes, unlike `DefaultHasher`).
+pub fn path_for(repo: &Path) -> PathBuf {
+    let canon = repo.canonicalize().unwrap_or_else(|_| repo.to_path_buf());
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in canon.as_os_str().as_encoded_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+    }
+    std::env::temp_dir().join(format!("herdr-reviewr-nav-{hash:016x}.json"))
+}
+
+/// Write `cmd` for the sidebar on `repo`, atomically, so a concurrent `take` never
+/// reads a partial file.
+pub fn write(repo: &Path, cmd: &NavCommand) -> anyhow::Result<PathBuf> {
+    let path = path_for(repo);
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, serde_json::to_vec(cmd)?)?;
+    fs::rename(&tmp, &path)?;
+    Ok(path)
+}
+
+/// Take the pending command for `repo`, if any: read it and remove the file, so a
+/// command applies exactly once. An unreadable file is dropped the same way.
+pub fn take(repo: &Path) -> Option<NavCommand> {
+    let path = path_for(repo);
+    let bytes = fs::read(&path).ok()?;
+    let _ = fs::remove_file(&path);
+    serde_json::from_slice(&bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_written_command_is_taken_exactly_once() {
+        let repo = std::env::temp_dir().join("reviewr-nav-test-repo");
+        let cmd = NavCommand {
+            tab: Some("changes".into()),
+            scope: Some("branch".into()),
+            file: Some("src/lib.rs".into()),
+        };
+        write(&repo, &cmd).unwrap();
+        assert_eq!(take(&repo), Some(cmd));
+        assert_eq!(take(&repo), None);
+    }
+
+    #[test]
+    fn distinct_repos_get_distinct_command_files() {
+        assert_ne!(path_for(Path::new("/a/repo")), path_for(Path::new("/b/repo")));
+    }
+}

--- a/tests/nav_flow.rs
+++ b/tests/nav_flow.rs
@@ -1,0 +1,66 @@
+//! End-to-end tests of CLI navigation (specs/nav.md): a command file written the way
+//! `herdr-reviewr nav` writes one, taken and applied the way the event loop does.
+
+mod common;
+
+use common::{Repo, app_on};
+use herdr_reviewr::app::Mode;
+use herdr_reviewr::apply_nav;
+use herdr_reviewr::nav::{self, NavCommand};
+
+/// A repo with edits in two nested files, so navigation has somewhere to go.
+fn nested_repo() -> Repo {
+    let repo = Repo::init();
+    repo.write("src/deep/inner.rs", "fn inner() {}\n");
+    repo.write("src/outer.rs", "fn outer() {}\n");
+    repo.commit_all("base");
+    repo.write("src/deep/inner.rs", "fn inner() { changed(); }\n");
+    repo.write("src/outer.rs", "fn outer() { changed(); }\n");
+    repo
+}
+
+#[test]
+fn a_command_opens_the_named_file_and_reports_it() {
+    let repo = nested_repo();
+    let mut app = app_on(&repo);
+    assert_ne!(app.diff_path.as_deref(), Some("src/outer.rs"));
+
+    nav::write(
+        repo.path(),
+        &NavCommand { file: Some("src/outer.rs".into()), ..NavCommand::default() },
+    )
+    .unwrap();
+    let cmd = nav::take(repo.path()).expect("the command file was just written");
+    apply_nav(&mut app, &cmd);
+
+    assert_eq!(app.diff_path.as_deref(), Some("src/outer.rs"));
+    assert_eq!(app.status, "nav: src/outer.rs");
+    assert!(nav::take(repo.path()).is_none(), "a command applies exactly once");
+}
+
+#[test]
+fn a_file_outside_the_scope_lands_in_the_status_line_and_moves_nothing() {
+    let repo = nested_repo();
+    let mut app = app_on(&repo);
+    let open_before = app.diff_path.clone();
+
+    apply_nav(
+        &mut app,
+        &NavCommand { file: Some("src/untouched.rs".into()), ..NavCommand::default() },
+    );
+
+    assert_eq!(app.diff_path, open_before);
+    assert!(app.status.contains("is not in the uncommitted scope"), "status: {}", app.status);
+}
+
+#[test]
+fn a_command_is_dropped_while_a_comment_is_being_composed() {
+    let repo = nested_repo();
+    let mut app = app_on(&repo);
+    app.mode = Mode::Composing { editing: None };
+
+    apply_nav(&mut app, &NavCommand { file: Some("src/outer.rs".into()), ..NavCommand::default() });
+
+    assert_ne!(app.diff_path.as_deref(), Some("src/outer.rs"));
+    assert!(app.status.starts_with("nav: ignored"), "status: {}", app.status);
+}


### PR DESCRIPTION
## What

`herdr-reviewr nav [--repo <path>] [--tab changes|all|pr] [--scope uncommitted|branch|last-turn] [--file <path> | <path>]` steers the running sidebar from outside — a script or a coding agent can put a specific diff on screen without synthesizing keypresses into the pane.

The channel is a one-shot JSON command file in the temp dir, keyed by a hash of the canonical repo path. The CLI writes it and exits; the sidebar's event loop (idle wait now capped at 300 ms) takes it — read + delete, so at most once — and applies tab → scope → file, reporting the outcome in its status line. Full decisions and their rejected alternatives are in `specs/nav.md`.

Design points worth a look:

- **Pane identity**: `nav` is a non-UI invocation, excluded in both halves per the contract in `src/main.rs` / `herdr/pane.sh` — recognized as the first argument only, so a repo path named `nav` behind a flag still opens the UI.
- **Normal-mode only**: a command never destroys a composed comment, a search, or an overlay; it drops whole and says so in the status line.
- **File re-rooting**: absolute paths re-root lexically; a relative path resolves against the cwd when it names a real file in the repo (so `nav foo.rs` works from any subdir) and passes through repo-relative otherwise, keeping deleted files nameable.
- **Hidden navigator**: `goto_file` leaves focus on the read pane when the navigator is hidden, per the existing contract in `specs/tui.md`.

## Motivation

I review with an agent driving the pane next to reviewr. "Look at this file" currently means the agent stepping `f` through the list blindly or the human clicking. With `nav`, the agent (or any script) lands the exact diff in one command. Happy to adjust scope or naming if you'd prefer a different surface for this.

## Verification

- `just ci` green locally (macOS, 1.97.0), including 3 new integration tests in `tests/nav_flow.rs` and 2 unit tests in `src/nav.rs`.
- Two pre-existing local failures worth flagging, both unrelated: `pane_actions::the_cli_fallback_resolves_the_config_dir_when_the_env_names_none` fails consistently under the full parallel suite on my machine (passes in isolation, fails identically on clean `main`), and `app_flow::search_overlay::engine_worker_end_to_end` flaked once on a transient `.git/objects/maintenance.lock`.
- Live QA via `just qa-install`: navigated a real sidebar across tabs/scopes/files on two repos, including cwd-relative resolution from a nested directory, the not-in-scope error path, and the composing guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSTSiK5N4Pt8pusL1bLnDf

## Checklist

- [ ] `just ci` is green
- [ ] The governing spec under `specs/` says the new behavior (or the change touches no behavior)
- [ ] `CHANGELOG.md` has a bullet under `## [Unreleased]` (or the change is invisible to users)
- [ ] Perf-relevant paths (reload, render, git, highlight): before/after numbers from `scripts/bench_tui.py` are in the description
