### PR TITLE
Add copy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ([#75](https://github.com/persiyanov/herdr-reviewr/issues/75)). Named spellings re-resolve
   like git, so a later commit still diffs one back; the header reads `vs HEAD~1 (a1b2c3d)`.
   Type a SHA to freeze that commit; the header shows the abbrev once.
+- **Pane-local character copy mode.** Press `C` to select and copy text within either the files
+  or diff pane without crossing the internal split; source rows stay complete through elision,
+  wrapping, and horizontal scroll, while visual gutters and file-list chrome are excluded. File
+  selections use repository-relative paths, and double-click selects a complete token, including
+  dotted code chains.
+  With wrapping off, dragging to the right edge completes an overflowing final diff row without
+  requiring the selection to enter the next row.
+  ([#62](https://github.com/persiyanov/herdr-reviewr/issues/62))
 
 ### Changed
 - A unique SHA prefix shorter than seven characters completes to the abbreviated object id.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The keys below are defaults. You can rebind every action, even to several keys a
 | `Ctrl+F` | Find in file |
 | `w` | Toggle line wrap |
 | `m` | Preview markdown file |
+| `C` | Toggle character-level copy mode |
 | `p` | Rotate navigator |
 | `z` | Hide / show navigator |
 | `<` `>` | Grow / shrink navigator |
@@ -158,8 +159,14 @@ jumps, and `Ctrl+W` / `Ctrl+U` / `Ctrl+K` deletes.
 | `o` | Open PR in browser |
 | `r` | Refresh |
 
-The mouse works too: click files and tabs, drag to select, scroll. A link in rendered markdown
-opens in your browser (`http`/`https` only), and an anchor link jumps to its heading.
+Press `C` to toggle character-level copy mode. Drag within the diff or files pane to select and
+copy individual characters; the selection cannot cross into the other internal pane.
+File rows copy their complete repository-relative paths, and double-click selects one token
+(including dotted code chains). Diff rows are copied from their source text, so elision, wrapping,
+and horizontal scrolling do not discard text; with wrapping off, reaching the right edge also
+completes an overflowing final row.
+A link in rendered markdown opens in your browser (`http`/`https` only), and an anchor link jumps
+to its heading.
 
 ## The three tabs
 

--- a/specs/diff-view.md
+++ b/specs/diff-view.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-24
-Last edited: 2026-08-15
+Last edited: 2026-08-19
 ---
 
 # Diff view
@@ -139,6 +139,7 @@ Return to source is different per view.
 - A comment anchors as `review-model.md` defines. The comment has a `side`, a `start..end` range, and the verbatim snippet.
 - A selection runs on content rows. A fold is a hard limit. The selection cannot cross a fold.
 - A selection covers the same rows from either end. An extend up over the same rows and an extend down over the same rows anchor the same comment. The input box opens under the last line of the range in both cases (`tui.md`).
+- During a mouse drag, reaching the top or bottom edge of the diff scrolls the viewport and continues the selection into the newly visible rows. The logical anchor remains unchanged.
 - The export snippet is built again from the selected rows. Each line has a `+` prefix, a `−` prefix, or a space prefix. The marks are in the export. The marks are not on the screen.
 
 ### Config

--- a/specs/input.md
+++ b/specs/input.md
@@ -86,8 +86,10 @@ token.
 Diff selections use source lines, so horizontal scrolling and wrapping do not discard text; tabs
 remain tabs. The line-number and change-bar gutter is visual chrome: it is not highlighted or
 copied. With wrapping off, reaching the right edge of an overflowing row extends the endpoint to
-the source row's end only when hidden source text remains. PR and markdown-preview panes retain
-their rendered-text fallback because their content is composed from a different source model.
+the source row's end only when hidden source text remains. Dragging to the top or bottom edge
+scrolls a file or diff pane while keeping the source anchor, so selection can continue into rows
+outside the initial viewport. PR and markdown-preview panes retain their rendered-text fallback
+because their content is composed from a different source model.
 
 ### Changeset traversal
 

--- a/specs/input.md
+++ b/specs/input.md
@@ -40,6 +40,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 | —                                                        | open a link in rendered markdown            | —                                           | click the link                |
 | `wrap`                                                   | toggle line wrap                            | `w`                                         | —                             |
 | `preview`                                                | toggle the markdown preview                 | `m`                                         | —                             |
+| `copy-mode`                                              | toggle character-level pane copy            | `C`                                         | drag inside one pane          |
 | `navigator-position`                                     | move the navigator clockwise                | `p`                                         | —                             |
 | `navigator-hide`                                         | hide / show the navigator                   | `z`                                         | —                             |
 | `navigator-grow` / `navigator-shrink`                    | grow / shrink the navigator                 | `<` / `>`                                   | drag the divider              |
@@ -72,6 +73,21 @@ A divider drag belongs to the navigator position and split axis at mouse-down. A
 Writing a comment: select a range or land on a line, press `c`, type into the inline box, `enter` saves and `esc` cancels. A saved comment renders as a read-only card spliced under its line, titled with its location, so written feedback stays on screen. `e` reopens the card as an edit box in place, hiding the card while editing. `d` deletes it. A successful send names the agent it added the comments to. A successful copy reports that they were copied. The transient status shows on the footer, pluralizes `comment`, and fades without covering the primary action.
 
 ## Behavior
+
+### Character-level copy mode
+
+`C` toggles copy mode. A drag stays within the pane where it starts and copies on release.
+
+On the file tabs, copy mode resolves the selection against source rows rather than painted terminal
+cells. File rows copy complete, unelided repository-relative paths without indentation, markers,
+arrows, or stats. Double-clicking a visible token selects that token; dotted code chains are one
+token.
+
+Diff selections use source lines, so horizontal scrolling and wrapping do not discard text; tabs
+remain tabs. The line-number and change-bar gutter is visual chrome: it is not highlighted or
+copied. With wrapping off, reaching the right edge of an overflowing row extends the endpoint to
+the source row's end only when hidden source text remains. PR and markdown-preview panes retain
+their rendered-text fallback because their content is composed from a different source model.
 
 ### Changeset traversal
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -427,6 +427,8 @@ pub enum FooterAction {
     /// Toggle the markdown preview; the label names the destination view (`m preview`
     /// on source, `m source` in the preview).
     Preview,
+    /// Toggle reviewr's character-level copy mode (`C copy`).
+    CopyMode,
     NavigatorPosition,
     /// Hide the navigator or show it back; the label names the direction (`z hide` / `z show`).
     /// Visible, it waits in the `go` band; hidden, it joins row 1 (specs/input.md).
@@ -607,6 +609,8 @@ pub struct App {
     /// The comment editor's caret: a char index into `input` (`0..=chars().count()`).
     pub caret: usize,
     pub status: String,
+    /// Whether character-level pane-local copy mode owns mouse selection.
+    pub copy_mode: bool,
     /// Whether the footer's `?` shortcut list is expanded. Global place state, not tab-stashed: one
     /// toggle across every tab, moved only by `?` and `esc`, preserved through a poll and config
     /// recovery (`specs/input.md`, `overview.md` Continuity).
@@ -772,6 +776,7 @@ impl App {
             input: String::new(),
             caret: 0,
             status: String::new(),
+            copy_mode: false,
             keys_expanded: false,
             should_quit: false,
             pr: forge::PrView::Pending,
@@ -3544,6 +3549,7 @@ impl App {
             if self.pr_snapshot().is_some() {
                 out.push((A::OpenPr, Primary));
             }
+            out.push((A::CopyMode, Do));
             out.push((A::Search, Go));
             out.push((A::TogglePane, Go));
             out.push((A::NavigatorPosition, Go));
@@ -3644,6 +3650,7 @@ impl App {
             out.push((A::BasePick, Go));
         }
         out.push((A::Search, Go));
+        out.push((A::CopyMode, Do));
         // In-file find shows wherever the read pane has content to search (specs/find-in-file.md).
         if self.find_available() {
             out.push((A::Find, Go));

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -1,0 +1,946 @@
+//! Character-level, pane-local copy mode.
+
+use anyhow::Result;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
+use std::time::{Duration, Instant};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::app::App;
+use crate::export::{Clipboard, ExportTarget};
+use crate::file_list::RowKind;
+use crate::ui;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Pane {
+    Files,
+    Diff,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Selection {
+    pub pane: Pane,
+    pub start: (u16, u16),
+    pub end: (u16, u16),
+}
+
+/// The live copy gesture, including the small amount of state needed to recognize a
+/// terminal-style double click. The selection itself stays public because the event loop
+/// paints it after the normal frame.
+#[derive(Default, Debug)]
+pub struct State {
+    pub selection: Option<Selection>,
+    last_click: Option<Click>,
+    source_override: Option<SourceSelection>,
+}
+
+impl State {
+    pub fn clear(&mut self) {
+        self.selection = None;
+        self.last_click = None;
+        self.source_override = None;
+    }
+}
+
+/// A point in the source text behind a painted pane position.
+///
+/// The display column is measured after tab expansion, so it can be mapped back to a source
+/// character without making the rendered terminal buffer the source of truth.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct SourcePoint {
+    pub line: usize,
+    pub display_column: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SourceSelection {
+    start: SourcePoint,
+    end: SourcePoint,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Click {
+    pane: Pane,
+    point: (u16, u16),
+    at: Instant,
+}
+
+const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(500);
+
+pub fn mouse_event(
+    app: &mut App,
+    area: Rect,
+    event: MouseEvent,
+    state: &mut State,
+) -> Result<bool> {
+    match event.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+            let pane = [Pane::Files, Pane::Diff].into_iter().find(|&pane| {
+                ui::copy_pane_rect(area, app, pane).contains((event.column, event.row).into())
+            });
+            if let Some(pane) = pane {
+                let point =
+                    clamp_point(ui::copy_pane_rect(area, app, pane), event.column, event.row);
+                let double_click = state.last_click.take().is_some_and(|click| {
+                    click.pane == pane
+                        && click.point.1 == point.1
+                        && click.point.0.abs_diff(point.0) <= 2
+                        && click.at.elapsed() <= DOUBLE_CLICK_WINDOW
+                });
+                state.last_click = Some(Click { pane, point, at: Instant::now() });
+                if double_click {
+                    if let Some((selection, source)) = token_selection(app, area, pane, point) {
+                        state.selection = Some(selection);
+                        state.source_override = source;
+                    } else {
+                        state.selection = Some(Selection { pane, start: point, end: point });
+                        state.source_override = None;
+                    }
+                } else {
+                    state.selection = Some(Selection { pane, start: point, end: point });
+                    state.source_override = None;
+                }
+            } else {
+                state.last_click = None;
+            }
+            Ok(true)
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            state.last_click = None;
+            state.source_override = None;
+            if let Some(current) = state.selection.as_mut() {
+                current.end = clamp_point(
+                    ui::copy_pane_rect(area, app, current.pane),
+                    event.column,
+                    event.row,
+                );
+            }
+            Ok(true)
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            if let Some(current) = state.selection {
+                let text = selection_text(app, area, current, state.source_override)?;
+                if !text.is_empty() {
+                    Clipboard.export(&text)?;
+                    app.status = "copied".into();
+                }
+            }
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+/// The source hit rectangle remains the full pane. Only code-pane painting excludes its
+/// line-number/change-bar prefix; keeping hit-testing wide is what lets a drag begin in the
+/// gutter and still copy the corresponding source text without copying that chrome.
+pub fn visual_pane_rect(area: Rect, app: &App, pane: Pane) -> Rect {
+    let bounds = ui::copy_pane_rect(area, app, pane);
+    if pane == Pane::Diff && app.tab.is_file_tab() && !app.preview_active() {
+        let gutter = diff_gutter_prefix(app) as u16;
+        Rect::new(
+            bounds.x.saturating_add(gutter),
+            bounds.y,
+            bounds.width.saturating_sub(gutter),
+            bounds.height,
+        )
+    } else {
+        bounds
+    }
+}
+
+fn clamp_point(rect: Rect, col: u16, row: u16) -> (u16, u16) {
+    (
+        col.clamp(rect.x, rect.x.saturating_add(rect.width.saturating_sub(1))),
+        row.clamp(rect.y, rect.y.saturating_add(rect.height.saturating_sub(1))),
+    )
+}
+
+pub fn ordered(selection: Selection) -> ((u16, u16), (u16, u16)) {
+    if (selection.start.1, selection.start.0) <= (selection.end.1, selection.end.0) {
+        (selection.start, selection.end)
+    } else {
+        (selection.end, selection.start)
+    }
+}
+
+fn selection_text(
+    app: &App,
+    area: Rect,
+    selection: Selection,
+    source_override: Option<SourceSelection>,
+) -> Result<String> {
+    if let Some(source) = source_override
+        && let Some(lines) = source_lines(app, selection.pane)
+        && let Some(text) = stream_source(&lines, source.start, source.end)
+    {
+        return Ok(text);
+    }
+    if let Some(text) = model_selection_text(app, area, selection) {
+        return Ok(text);
+    }
+
+    visual_selection_text(app, area, selection)
+}
+
+fn model_selection_text(app: &App, area: Rect, selection: Selection) -> Option<String> {
+    if let Some(text) = whole_file_selection(app, area, selection) {
+        return Some(text);
+    }
+    let (start, screen_end) = ordered(selection);
+    let start = if selection.pane == Pane::Files && start.1 < screen_end.1 {
+        copy_file_selection_start_point(area, app, start.0, start.1)?
+    } else {
+        copy_source_point(area, app, selection.pane, start.0, start.1)?
+    };
+    let end = copy_source_point(area, app, selection.pane, screen_end.0, screen_end.1)?;
+    let end = if selection.pane == Pane::Diff {
+        extend_diff_end_if_overflowing(area, app, screen_end.0, screen_end.1, end)
+    } else {
+        end
+    };
+    let lines = source_lines(app, selection.pane)?;
+    stream_source(&lines, start, end)
+}
+
+fn extend_diff_end_if_overflowing(
+    area: Rect,
+    app: &App,
+    screen_col: u16,
+    screen_row: u16,
+    source_end: SourcePoint,
+) -> SourcePoint {
+    if app.wrap || app.preview_active() || !app.tab.is_file_tab() {
+        return source_end;
+    }
+    let bounds = ui::copy_pane_rect(area, app, Pane::Diff);
+    let content_end = bounds.x.saturating_add(bounds.width.saturating_sub(1));
+    if screen_col < content_end {
+        return source_end;
+    }
+    let Some(row) = app.visible.get(source_end.line) else {
+        return source_end;
+    };
+    let source_width = source_cells(&row.text()).iter().map(|cell| cell.width).sum();
+    SourcePoint {
+        line: source_end.line,
+        display_column: extend_display_end_if_overflowing(
+            source_width,
+            source_end.display_column,
+            screen_row >= bounds.y && screen_row < bounds.y.saturating_add(bounds.height),
+        ),
+    }
+}
+
+fn extend_display_end_if_overflowing(
+    source_width: usize,
+    selected_display_column: usize,
+    at_right_edge: bool,
+) -> usize {
+    if at_right_edge && source_width > selected_display_column.saturating_add(1) {
+        usize::MAX
+    } else {
+        selected_display_column
+    }
+}
+
+fn whole_file_selection(app: &App, area: Rect, selection: Selection) -> Option<String> {
+    if selection.pane != Pane::Files || !app.tab.is_file_tab() {
+        return None;
+    }
+    let (start, end) = ordered(selection);
+    if start.1 != end.1 {
+        return None;
+    }
+    let bounds = ui::copy_pane_rect(area, app, Pane::Files);
+    let index = ui::hit_file(area, app, start.0, start.1, app.file_rows.len(), app.file_scroll)?;
+    let end_index = ui::hit_file(area, app, end.0, end.1, app.file_rows.len(), app.file_scroll)?;
+    if index != end_index {
+        return None;
+    }
+    let row = app.file_rows.get(index)?;
+    let (source, shown, prefix) = copy_file_name_layout(app, row, bounds.width as usize);
+    let name_start = bounds.x.saturating_add(prefix as u16);
+    let name_end = name_start.saturating_add(shown.width().saturating_sub(1) as u16);
+    (start.0 <= name_start && end.0 >= name_end).then_some(source)
+}
+
+fn token_selection(
+    app: &App,
+    area: Rect,
+    pane: Pane,
+    point: (u16, u16),
+) -> Option<(Selection, Option<SourceSelection>)> {
+    match pane {
+        Pane::Files if app.tab.is_file_tab() => file_token_selection(app, area, point),
+        Pane::Files => visual_token_selection(app, area, Pane::Files, point),
+        Pane::Diff if app.tab.is_file_tab() && !app.preview_active() => {
+            diff_token_selection(app, area, point)
+        }
+        Pane::Diff => visual_token_selection(app, area, Pane::Diff, point),
+    }
+}
+
+fn file_token_selection(
+    app: &App,
+    area: Rect,
+    point: (u16, u16),
+) -> Option<(Selection, Option<SourceSelection>)> {
+    let bounds = ui::copy_pane_rect(area, app, Pane::Files);
+    let index = ui::hit_file(area, app, point.0, point.1, app.file_rows.len(), app.file_scroll)?;
+    let row = app.file_rows.get(index)?;
+    let (source, shown, prefix) = copy_file_name_layout(app, row, bounds.width as usize);
+    let name_start = bounds.x.saturating_add(prefix as u16);
+    let name_end = name_start.saturating_add(shown.width().saturating_sub(1) as u16);
+    if point.0 < name_start || point.0 > name_end {
+        return None;
+    }
+    let visual =
+        Selection { pane: Pane::Files, start: (name_start, point.1), end: (name_end, point.1) };
+    let end = source.width().saturating_sub(1);
+    Some((
+        visual,
+        Some(SourceSelection {
+            start: SourcePoint { line: index, display_column: 0 },
+            end: SourcePoint { line: index, display_column: end },
+        }),
+    ))
+}
+
+fn diff_token_selection(
+    app: &App,
+    area: Rect,
+    point: (u16, u16),
+) -> Option<(Selection, Option<SourceSelection>)> {
+    let source_point = copy_diff_source_point(area, app, point.0, point.1)?;
+    let bounds = ui::copy_pane_rect(area, app, Pane::Diff);
+    let content_start = bounds.x.saturating_add(diff_gutter_prefix(app) as u16);
+    if point.0 < content_start {
+        return None;
+    }
+    let text = app.visible.get(source_point.line)?.text();
+    let char_index = display_column_to_char_index(&text, source_point.display_column);
+    let (start_char, end_char) = token_char_range(&text, char_index)?;
+    let start_column = char_index_to_display_column(&text, start_char);
+    let end_column = char_index_to_display_column(&text, end_char.saturating_sub(1));
+    let start = diff_screen_point(app, area, source_point.line, start_column)?;
+    let end = diff_screen_point(app, area, source_point.line, end_column)?;
+    Some((
+        Selection { pane: Pane::Diff, start, end },
+        Some(SourceSelection {
+            start: SourcePoint { line: source_point.line, display_column: start_column },
+            end: SourcePoint { line: source_point.line, display_column: end_column },
+        }),
+    ))
+}
+
+fn visual_token_selection(
+    app: &App,
+    area: Rect,
+    pane: Pane,
+    point: (u16, u16),
+) -> Option<(Selection, Option<SourceSelection>)> {
+    let mut terminal = Terminal::new(TestBackend::new(area.width, area.height)).ok()?;
+    terminal.draw(|frame| ui::render(frame, app)).ok()?;
+    let buffer = terminal.backend().buffer();
+    let bounds = ui::copy_pane_rect(area, app, pane);
+    if !bounds.contains(point.into()) {
+        return None;
+    }
+    let is_token_cell = |x: u16| {
+        buffer
+            .cell((x, point.1))
+            .is_some_and(|cell| cell.symbol().chars().any(|ch| !ch.is_whitespace()))
+    };
+    if !is_token_cell(point.0) {
+        return None;
+    }
+    let left = (bounds.x..=point.0)
+        .rev()
+        .find(|&x| !is_token_cell(x))
+        .map_or(bounds.x, |x| x.saturating_add(1));
+    let right = (point.0..=bounds.x.saturating_add(bounds.width.saturating_sub(1)))
+        .find(|&x| !is_token_cell(x))
+        .map_or(bounds.x.saturating_add(bounds.width.saturating_sub(1)), |x| x.saturating_sub(1));
+    Some((Selection { pane, start: (left, point.1), end: (right, point.1) }, None))
+}
+
+fn token_char_range(text: &str, index: usize) -> Option<(usize, usize)> {
+    let chars: Vec<char> = text.chars().collect();
+    if index >= chars.len() || chars[index].is_whitespace() {
+        return None;
+    }
+    let dotted = is_dotted_token_char(chars[index]);
+    let accept = |ch: char| if dotted { is_dotted_token_char(ch) } else { !ch.is_whitespace() };
+    let mut start = index;
+    while start > 0 && accept(chars[start - 1]) {
+        start -= 1;
+    }
+    let mut end = index + 1;
+    while end < chars.len() && accept(chars[end]) {
+        end += 1;
+    }
+    if dotted {
+        while start < end && chars[start] == '.' {
+            start += 1;
+        }
+        while end > start && chars[end - 1] == '.' {
+            end -= 1;
+        }
+    }
+    (start < end).then_some((start, end))
+}
+
+fn is_dotted_token_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_' || ch == '.'
+}
+
+fn char_index_to_display_column(text: &str, char_index: usize) -> usize {
+    let mut display_column = 0;
+    for (index, ch) in text.chars().enumerate() {
+        if index >= char_index {
+            break;
+        }
+        display_column += if ch == '\t' {
+            4 - display_column % 4
+        } else {
+            UnicodeWidthChar::width(ch).unwrap_or(0)
+        };
+    }
+    display_column
+}
+
+fn diff_screen_point(
+    app: &App,
+    area: Rect,
+    line: usize,
+    display_column: usize,
+) -> Option<(u16, u16)> {
+    let bounds = ui::copy_pane_rect(area, app, Pane::Diff);
+    let heights = ui::diff_row_heights(app, area);
+    if line < app.diff_scroll || line >= heights.len() {
+        return None;
+    }
+    let row_y = bounds.y.saturating_add(
+        u16::try_from(
+            heights.iter().skip(app.diff_scroll).take(line - app.diff_scroll).sum::<usize>(),
+        )
+        .unwrap_or(u16::MAX),
+    );
+    let gutter_prefix = diff_gutter_prefix(app);
+    let code_width = (bounds.width as usize).saturating_sub(gutter_prefix).max(1);
+    let text = app.visible.get(line)?.text();
+    let cells = source_cells(&text);
+    let segments = source_segments(&cells, code_width, app.wrap);
+    let (segment_index, segment_start_column, segment_end_column) = segments
+        .iter()
+        .enumerate()
+        .map(|(index, &(start, end))| {
+            let start_column = cells[..start].iter().map(|cell| cell.width).sum::<usize>();
+            let end_column = cells[..end].iter().map(|cell| cell.width).sum::<usize>();
+            (index, start_column, end_column)
+        })
+        .find(|&(_, start, end)| display_column <= end || start == end)
+        .or_else(|| {
+            segments.last().map(|&(start, end)| {
+                let start_column = cells[..start].iter().map(|cell| cell.width).sum::<usize>();
+                let end_column = cells[..end].iter().map(|cell| cell.width).sum::<usize>();
+                (segments.len().saturating_sub(1), start_column, end_column)
+            })
+        })?;
+    let y = row_y.saturating_add(segment_index as u16);
+    let content_start = bounds.x.saturating_add(gutter_prefix as u16);
+    let offset = if app.wrap {
+        display_column
+            .saturating_sub(segment_start_column)
+            .min(segment_end_column.saturating_sub(segment_start_column).saturating_sub(1))
+    } else {
+        display_column.saturating_sub(app.h_scroll)
+    };
+    let x = content_start
+        .saturating_add(offset as u16)
+        .clamp(content_start, bounds.x.saturating_add(bounds.width.saturating_sub(1)));
+    Some((x, y.min(bounds.y.saturating_add(bounds.height.saturating_sub(1)))))
+}
+
+fn copy_source_point(area: Rect, app: &App, pane: Pane, col: u16, row: u16) -> Option<SourcePoint> {
+    if !app.tab.is_file_tab() {
+        return None;
+    }
+    match pane {
+        Pane::Files => copy_file_source_point(area, app, col, row),
+        Pane::Diff if !app.preview_active() => copy_diff_source_point(area, app, col, row),
+        Pane::Diff => None,
+    }
+}
+
+fn copy_file_source_point(area: Rect, app: &App, col: u16, row: u16) -> Option<SourcePoint> {
+    let bounds = ui::copy_pane_rect(area, app, Pane::Files);
+    if !bounds.contains((col, row).into()) {
+        return None;
+    }
+    let index = ui::hit_file(area, app, col, row, app.file_rows.len(), app.file_scroll)?;
+    let file_row = app.file_rows.get(index)?;
+    let (source, shown, prefix) = copy_file_name_layout(app, file_row, bounds.width as usize);
+    let visible_column = (col - bounds.x) as usize;
+    Some(SourcePoint {
+        line: index,
+        display_column: map_file_column(&source, &shown, visible_column.saturating_sub(prefix)),
+    })
+}
+
+fn copy_file_selection_start_point(
+    area: Rect,
+    app: &App,
+    col: u16,
+    row: u16,
+) -> Option<SourcePoint> {
+    let bounds = ui::copy_pane_rect(area, app, Pane::Files);
+    if !bounds.contains((col, row).into()) {
+        return None;
+    }
+    let index = ui::hit_file(area, app, col, row, app.file_rows.len(), app.file_scroll)?;
+    let file_row = app.file_rows.get(index)?;
+    let (source, shown, prefix) = copy_file_name_layout(app, file_row, bounds.width as usize);
+    let visible_column = (col - bounds.x) as usize;
+    Some(SourcePoint {
+        line: index,
+        display_column: file_selection_start_column(&source, &shown, prefix, visible_column),
+    })
+}
+
+fn copy_file_name_layout(
+    app: &App,
+    row: &crate::file_list::Row,
+    width: usize,
+) -> (String, String, usize) {
+    let source = file_row_text(app, row);
+    let indent = "  ".repeat(row.depth);
+    match &row.kind {
+        RowKind::Dir { expanded, .. } => {
+            let arrow = if *expanded { "▾ " } else { "▸ " };
+            let prefix = indent.width() + arrow.width();
+            // source is the complete relative directory path, while row.name is the
+            // directory text actually painted at this depth. Keeping those separate makes
+            // suffix mapping and double-click bounds agree with the visible row.
+            let shown = format!("{}/", row.name);
+            (source, shown, prefix)
+        }
+        RowKind::File { annotation, .. } => {
+            let marker =
+                annotation.as_ref().map_or(String::new(), |a| format!("{} ", a.change.marker()));
+            let (additions, deletions) =
+                annotation.as_ref().map_or((0, 0), |a| (a.additions, a.deletions));
+            let stats = stats_str(additions, deletions);
+            let gap = if stats.is_empty() { 0 } else { 2 };
+            let fixed = indent.width() + marker.width() + stats.width() + gap;
+            let shown = elide_head(&row.name, width.saturating_sub(fixed).max(1));
+            (source, shown, indent.width() + marker.width())
+        }
+    }
+}
+
+fn stats_str(additions: u32, deletions: u32) -> String {
+    match (additions, deletions) {
+        (0, 0) => String::new(),
+        (a, 0) => format!("+{a}"),
+        (0, d) => format!("−{d}"),
+        (a, d) => format!("+{a} −{d}"),
+    }
+}
+
+fn elide_head(name: &str, max: usize) -> String {
+    if name.width() <= max {
+        return name.to_string();
+    }
+    let budget = max.saturating_sub(1);
+    let mut tail = String::new();
+    let mut width = 0;
+    for ch in name.chars().rev() {
+        let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + char_width > budget {
+            break;
+        }
+        tail.insert(0, ch);
+        width += char_width;
+    }
+    if let Some(slash) = tail.find('/') {
+        tail = tail[slash..].to_string();
+    }
+    format!("…{tail}")
+}
+
+fn copy_diff_source_point(area: Rect, app: &App, col: u16, row: u16) -> Option<SourcePoint> {
+    let bounds = ui::copy_pane_rect(area, app, Pane::Diff);
+    if !bounds.contains((col, row).into()) {
+        return None;
+    }
+    let heights = ui::diff_row_heights(app, area);
+    let index = ui::hit_diff(area, app, col, row, &heights, app.diff_scroll)?;
+    let target = (row - bounds.y) as usize;
+    let previous: usize =
+        heights.iter().skip(app.diff_scroll).take(index.saturating_sub(app.diff_scroll)).sum();
+    let row_offset = target.saturating_sub(previous);
+    let source_row = app.visible.get(index)?;
+    if matches!(source_row, crate::diff::Row::Fold { .. }) {
+        return None;
+    }
+
+    let gutter_prefix = diff_gutter_prefix(app);
+    let code_width = (bounds.width as usize).saturating_sub(gutter_prefix);
+    let cells = source_cells(&source_row.text());
+    let segments = source_segments(&cells, code_width.max(1), app.wrap);
+    if row_offset >= segments.len() {
+        return None;
+    }
+    let content_start = bounds.x.saturating_add(gutter_prefix as u16);
+    let visible_column = col.saturating_sub(content_start) as usize;
+    let display_column = if app.wrap {
+        let (segment_start, segment_end) = segments[row_offset];
+        let before = cells[..segment_start].iter().map(|cell| cell.width).sum::<usize>();
+        let segment_width =
+            cells[segment_start..segment_end].iter().map(|cell| cell.width).sum::<usize>();
+        before + visible_column.min(segment_width)
+    } else {
+        app.h_scroll.saturating_add(visible_column)
+    };
+
+    Some(SourcePoint { line: index, display_column })
+}
+
+fn diff_gutter_prefix(app: &App) -> usize {
+    let total_lines: usize =
+        app.diff.rows.iter().map(|row| if row.is_content() { 1 } else { row.hidden() }).sum();
+    1 + total_lines.to_string().len().max(3) + 1
+}
+
+#[derive(Clone, Copy)]
+struct SourceCell {
+    ch: char,
+    width: usize,
+}
+
+fn source_cells(text: &str) -> Vec<SourceCell> {
+    let mut cells = Vec::new();
+    let mut column = 0;
+    for ch in text.chars() {
+        if ch == '\t' {
+            let width = 4 - column % 4;
+            cells.extend((0..width).map(|_| SourceCell { ch: ' ', width: 1 }));
+            column += width;
+        } else {
+            let width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            cells.push(SourceCell { ch, width });
+            column += width;
+        }
+    }
+    cells
+}
+
+fn source_segments(cells: &[SourceCell], width: usize, wrap: bool) -> Vec<(usize, usize)> {
+    if !wrap {
+        return vec![(0, cells.len())];
+    }
+    if cells.is_empty() {
+        return vec![(0, 0)];
+    }
+    let mut segments = Vec::new();
+    let mut start = 0;
+    while start < cells.len() {
+        let mut columns = 0;
+        let mut limit = start;
+        while limit < cells.len() {
+            let cell_width = cells[limit].width;
+            if columns + cell_width > width && limit > start {
+                break;
+            }
+            columns += cell_width;
+            limit += 1;
+        }
+        if limit == cells.len() {
+            segments.push((start, cells.len()));
+            break;
+        }
+        let break_at = (start..limit).rev().find(|&i| cells[i].ch == ' ').map(|i| i + 1);
+        let end = break_at.filter(|&end| end > start).unwrap_or(limit);
+        segments.push((start, end));
+        start = end;
+        while start < cells.len() && cells[start].ch == ' ' {
+            start += 1;
+        }
+    }
+    segments
+}
+
+fn source_lines(app: &App, pane: Pane) -> Option<Vec<Option<String>>> {
+    match pane {
+        Pane::Files if app.tab.is_file_tab() => {
+            Some(app.file_rows.iter().map(|row| Some(file_row_text(app, row))).collect())
+        }
+        Pane::Diff if app.tab.is_file_tab() && !app.preview_active() => Some(
+            app.visible
+                .iter()
+                .map(|row| (!matches!(row, crate::diff::Row::Fold { .. })).then(|| row.text()))
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+pub(crate) fn file_row_text(app: &App, row: &crate::file_list::Row) -> String {
+    match &row.kind {
+        RowKind::Dir { path, .. } => format!("{path}/"),
+        RowKind::File { index, .. } => {
+            app.entries.get(*index).map_or_else(|| row.name.clone(), |entry| entry.path.clone())
+        }
+    }
+}
+
+fn map_file_column(full: &str, shown: &str, column: usize) -> usize {
+    if shown.starts_with('…') {
+        return map_elided_column(full, shown, column);
+    }
+    let full_width = full.width();
+    let shown_width = shown.width();
+    if full.ends_with(shown) && full_width > shown_width {
+        return (full_width - shown_width + column).min(full_width);
+    }
+    column.min(full_width)
+}
+
+fn file_selection_start_column(
+    full: &str,
+    shown: &str,
+    prefix: usize,
+    visible_column: usize,
+) -> usize {
+    if visible_column <= prefix { 0 } else { map_file_column(full, shown, visible_column - prefix) }
+}
+
+/// Map a column in a possibly head-elided name back to the full source name.
+pub(crate) fn map_elided_column(full: &str, shown: &str, column: usize) -> usize {
+    let full_width = full.width();
+    if full_width <= shown.width() {
+        return column.min(full_width);
+    }
+    let Some(tail) = shown.strip_prefix('…') else {
+        return column.min(full_width);
+    };
+    if column == 0 {
+        return 0;
+    }
+    let tail_start = full_width.saturating_sub(tail.width());
+    (tail_start + column.saturating_sub(1)).min(full_width)
+}
+
+/// Convert a display column to a source character index, preserving tabs and wide glyphs.
+pub(crate) fn display_column_to_char_index(text: &str, column: usize) -> usize {
+    let mut display_column = 0;
+    for (char_index, ch) in text.chars().enumerate() {
+        let width = if ch == '\t' {
+            4 - display_column % 4
+        } else {
+            UnicodeWidthChar::width(ch).unwrap_or(0)
+        };
+        if column < display_column.saturating_add(width) {
+            return char_index;
+        }
+        display_column = display_column.saturating_add(width);
+    }
+    text.chars().count()
+}
+
+fn stream_source(
+    lines: &[Option<String>],
+    first: SourcePoint,
+    second: SourcePoint,
+) -> Option<String> {
+    let (start, end) = if first <= second { (first, second) } else { (second, first) };
+    let start_line = lines.get(start.line).and_then(Option::as_deref)?;
+    let end_line = lines.get(end.line).and_then(Option::as_deref)?;
+    let start_char = display_column_to_char_index(start_line, start.display_column);
+    let end_char = display_column_to_char_index(end_line, end.display_column);
+
+    if start.line == end.line {
+        return Some(inclusive_chars(start_line, start_char, end_char));
+    }
+
+    let mut selected = Vec::with_capacity(end.line - start.line + 1);
+    selected.push(from_char(start_line, start_char));
+    selected.extend(
+        lines[start.line + 1..end.line]
+            .iter()
+            .map(Option::as_deref)
+            .collect::<Option<Vec<_>>>()?
+            .into_iter()
+            .map(str::to_string),
+    );
+    selected.push(inclusive_chars(end_line, 0, end_char));
+    Some(selected.join("\n"))
+}
+
+fn from_char(text: &str, start: usize) -> String {
+    text.chars().skip(start).collect()
+}
+
+fn inclusive_chars(text: &str, start: usize, end: usize) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    if start >= chars.len() || start > end {
+        return String::new();
+    }
+    let end = end.min(chars.len().saturating_sub(1));
+    chars[start..=end].iter().collect()
+}
+
+fn visual_selection_text(app: &App, area: Rect, selection: Selection) -> Result<String> {
+    let mut terminal = Terminal::new(TestBackend::new(area.width, area.height))?;
+    terminal.draw(|frame| ui::render(frame, app))?;
+    let buffer = terminal.backend().buffer();
+    let bounds = visual_pane_rect(area, app, selection.pane);
+    let end_x = bounds.x.saturating_add(bounds.width.saturating_sub(1));
+    let (start, end) = ordered(selection);
+    let mut lines = Vec::new();
+    for y in start.1..=end.1 {
+        let (from, to) = if start.1 == end.1 {
+            (start.0, end.0)
+        } else if y == start.1 {
+            (start.0, end_x)
+        } else if y == end.1 {
+            (bounds.x, end.0)
+        } else {
+            (bounds.x, end_x)
+        };
+        lines.push(
+            (from.max(bounds.x)..=to.min(end_x))
+                .filter_map(|x| buffer.cell((x, y)))
+                .map(ratatui::buffer::Cell::symbol)
+                .collect::<String>()
+                .trim_end()
+                .to_string(),
+        );
+    }
+    Ok(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_columns_map_tabs_and_wide_glyphs_to_source_chars() {
+        let text = "\t界x";
+        assert_eq!(display_column_to_char_index(text, 0), 0);
+        assert_eq!(display_column_to_char_index(text, 3), 0);
+        assert_eq!(display_column_to_char_index(text, 4), 1);
+        assert_eq!(display_column_to_char_index(text, 5), 1);
+        assert_eq!(display_column_to_char_index(text, 6), 2);
+        assert_eq!(display_column_to_char_index(text, 99), 3);
+    }
+
+    #[test]
+    fn elided_names_map_the_visible_tail_and_overflow_to_the_full_name() {
+        let full = "src/very-long-file.rs";
+        let shown = "…/file.rs";
+        let tail_start = full.width() - "/file.rs".width();
+        assert_eq!(map_elided_column(full, shown, 1), tail_start);
+        assert_eq!(map_elided_column(full, shown, shown.width()), full.width());
+    }
+
+    #[test]
+    fn basename_columns_map_back_to_the_relative_path_suffix() {
+        let full = "app/controllers/application_controller.rb";
+        let shown = "application_controller.rb";
+        let prefix = full.width() - shown.width();
+        assert_eq!(map_file_column(full, shown, 0), prefix);
+        assert_eq!(map_file_column(full, shown, shown.width() - 1), full.width() - 1);
+    }
+
+    #[test]
+    fn directory_columns_map_the_visible_name_to_the_full_path_suffix() {
+        let full = "scripts/bench-results/";
+        let shown = "bench-results/";
+        let prefix = full.width() - shown.width();
+        assert_eq!(map_file_column(full, shown, 0), prefix);
+        assert_eq!(map_file_column(full, shown, shown.width() - 1), full.width() - 1);
+    }
+
+    #[test]
+    fn the_right_edge_expands_only_when_source_text_continues() {
+        assert_eq!(extend_display_end_if_overflowing(20, 9, true), usize::MAX);
+        assert_eq!(extend_display_end_if_overflowing(10, 9, true), 9);
+        assert_eq!(extend_display_end_if_overflowing(20, 9, false), 9);
+    }
+
+    #[test]
+    fn a_multi_file_selection_starts_at_the_full_first_path() {
+        let full = "scripts/bench-results/baseline-v0.18.1-chained.json";
+        let shown = "baseline-v0.18.1-chained.json";
+        let prefix = 4;
+        assert_eq!(file_selection_start_column(full, shown, prefix, prefix), 0);
+        assert_eq!(
+            file_selection_start_column(full, shown, prefix, prefix + 1),
+            full.width() - shown.width() + 1
+        );
+    }
+
+    #[test]
+    fn dotted_identifiers_are_one_double_click_token() {
+        let text = "some.model.method = x";
+        let model = text.chars().position(|ch| ch == 'm').unwrap();
+        assert_eq!(token_char_range(text, model), Some((0, "some.model.method".chars().count())));
+        assert_eq!(
+            token_char_range(text, text.chars().position(|ch| ch == '=').unwrap()),
+            Some((18, 19))
+        );
+    }
+
+    #[test]
+    fn source_selection_keeps_the_full_line_and_crosses_source_lines() {
+        let lines = vec![Some("a very long line".to_string()), Some("next line".to_string())];
+        assert_eq!(
+            stream_source(
+                &lines,
+                SourcePoint { line: 0, display_column: 0 },
+                SourcePoint { line: 0, display_column: usize::MAX },
+            ),
+            Some("a very long line".to_string())
+        );
+        assert_eq!(
+            stream_source(
+                &lines,
+                SourcePoint { line: 0, display_column: 2 },
+                SourcePoint { line: 1, display_column: usize::MAX },
+            ),
+            Some("very long line\nnext line".to_string())
+        );
+    }
+
+    #[test]
+    fn a_fold_elsewhere_does_not_force_visual_copy() {
+        let lines = vec![Some("kept".to_string()), None, Some("other".to_string())];
+        assert_eq!(
+            stream_source(
+                &lines,
+                SourcePoint { line: 0, display_column: 0 },
+                SourcePoint { line: 0, display_column: usize::MAX },
+            ),
+            Some("kept".to_string())
+        );
+        assert_eq!(
+            stream_source(
+                &lines,
+                SourcePoint { line: 0, display_column: 0 },
+                SourcePoint { line: 2, display_column: usize::MAX },
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn wrapped_source_segments_drop_only_continuation_padding() {
+        let cells = source_cells("alpha beta");
+        assert_eq!(source_segments(&cells, 5, true), vec![(0, 5), (6, 10)],);
+    }
+}

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -34,6 +34,7 @@ pub struct State {
     pub selection: Option<Selection>,
     last_click: Option<Click>,
     source_override: Option<SourceSelection>,
+    source_anchor: Option<SourcePoint>,
 }
 
 impl State {
@@ -41,6 +42,7 @@ impl State {
         self.selection = None;
         self.last_click = None;
         self.source_override = None;
+        self.source_anchor = None;
     }
 }
 
@@ -69,6 +71,18 @@ struct Click {
 
 const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(500);
 
+/// Return the direction in which an active drag should move the pane when the pointer reaches
+/// its edge. The caller applies the scroll and re-hits the pointer against the newly visible
+/// rows, so the selection remains logical rather than being tied to painted cells.
+pub(crate) fn edge_scroll_delta(area: Rect, app: &App, pane: Pane, row: u16) -> isize {
+    if !app.tab.is_file_tab() || (pane == Pane::Diff && app.preview_active()) {
+        return 0;
+    }
+    let bounds = ui::copy_pane_rect(area, app, pane);
+    let bottom = bounds.y.saturating_add(bounds.height.saturating_sub(1));
+    if row <= bounds.y { -1 } else { isize::from(row >= bottom) }
+}
+
 pub fn mouse_event(
     app: &mut App,
     area: Rect,
@@ -91,6 +105,7 @@ pub fn mouse_event(
                 });
                 state.last_click = Some(Click { pane, point, at: Instant::now() });
                 if double_click {
+                    state.source_anchor = None;
                     if let Some((selection, source)) = token_selection(app, area, pane, point) {
                         state.selection = Some(selection);
                         state.source_override = source;
@@ -101,16 +116,26 @@ pub fn mouse_event(
                 } else {
                     state.selection = Some(Selection { pane, start: point, end: point });
                     state.source_override = None;
+                    state.source_anchor = copy_source_point(area, app, pane, point.0, point.1);
                 }
             } else {
                 state.last_click = None;
+                state.source_anchor = None;
             }
             Ok(true)
         }
         MouseEventKind::Drag(MouseButton::Left) => {
             state.last_click = None;
             state.source_override = None;
+            let pane = state.selection.map(|selection| selection.pane);
+            let start_y = state.selection.map(|selection| selection.start.1);
+            let shifted_start = pane.zip(start_y).and_then(|(pane, start_y)| {
+                scroll_selection_anchor(app, area, pane, event.row, start_y)
+            });
             if let Some(current) = state.selection.as_mut() {
+                if let Some(start_y) = shifted_start {
+                    current.start.1 = start_y;
+                }
                 current.end = clamp_point(
                     ui::copy_pane_rect(area, app, current.pane),
                     event.column,
@@ -121,7 +146,8 @@ pub fn mouse_event(
         }
         MouseEventKind::Up(MouseButton::Left) => {
             if let Some(current) = state.selection {
-                let text = selection_text(app, area, current, state.source_override)?;
+                let text =
+                    selection_text(app, area, current, state.source_override, state.source_anchor)?;
                 if !text.is_empty() {
                     Clipboard.export(&text)?;
                     app.status = "copied".into();
@@ -131,6 +157,59 @@ pub fn mouse_event(
         }
         _ => Ok(false),
     }
+}
+
+fn scroll_selection_anchor(
+    app: &mut App,
+    area: Rect,
+    pane: Pane,
+    row: u16,
+    start_y: u16,
+) -> Option<u16> {
+    let delta = edge_scroll_delta(area, app, pane, row);
+    if delta == 0 {
+        return None;
+    }
+    let bounds = ui::copy_pane_rect(area, app, pane);
+    let old_scroll = match pane {
+        Pane::Files => app.file_scroll,
+        Pane::Diff => app.diff_scroll,
+    };
+    let heights = (pane == Pane::Diff).then(|| ui::diff_row_heights(app, area));
+    match pane {
+        Pane::Files => {
+            app.wheel_files(delta);
+            app.bound_file_scroll(bounds.height as usize);
+        }
+        Pane::Diff => {
+            app.wheel_diff(delta);
+            if let Some(heights) = heights.as_deref() {
+                app.bound_diff_scroll(heights, ui::diff_viewport_height(area, app));
+            }
+        }
+    }
+    let new_scroll = match pane {
+        Pane::Files => app.file_scroll,
+        Pane::Diff => app.diff_scroll,
+    };
+    if old_scroll == new_scroll {
+        return None;
+    }
+    let shift = if let Some(heights) = heights {
+        if new_scroll > old_scroll {
+            heights[old_scroll..new_scroll].iter().sum()
+        } else {
+            heights[new_scroll..old_scroll].iter().sum()
+        }
+    } else {
+        old_scroll.abs_diff(new_scroll)
+    } as u16;
+    let shifted = if new_scroll > old_scroll {
+        start_y.saturating_sub(shift)
+    } else {
+        start_y.saturating_add(shift)
+    };
+    Some(shifted.clamp(bounds.y, bounds.y.saturating_add(bounds.height.saturating_sub(1))))
 }
 
 /// The source hit rectangle remains the full pane. Only code-pane painting excludes its
@@ -171,12 +250,28 @@ fn selection_text(
     area: Rect,
     selection: Selection,
     source_override: Option<SourceSelection>,
+    source_anchor: Option<SourcePoint>,
 ) -> Result<String> {
     if let Some(source) = source_override
         && let Some(lines) = source_lines(app, selection.pane)
         && let Some(text) = stream_source(&lines, source.start, source.end)
     {
         return Ok(text);
+    }
+    if let Some(source_start) = source_anchor
+        && let Some(source_end) =
+            copy_source_point(area, app, selection.pane, selection.end.0, selection.end.1)
+    {
+        let source_end = if selection.pane == Pane::Diff {
+            extend_diff_end_if_overflowing(area, app, selection.end.0, selection.end.1, source_end)
+        } else {
+            source_end
+        };
+        if let Some(lines) = source_lines(app, selection.pane)
+            && let Some(text) = stream_source(&lines, source_start, source_end)
+        {
+            return Ok(text);
+        }
     }
     if let Some(text) = model_selection_text(app, area, selection) {
         return Ok(text);

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -28,6 +28,7 @@ pub enum Action {
     TabPr,
     Wrap,
     Preview,
+    CopyMode,
     NavigatorPosition,
     NavigatorHide,
     NavigatorGrow,
@@ -158,7 +159,7 @@ impl Key {
 
 /// Every action with its config name and default keys — the single source the default keymap,
 /// the name lookup, and the config error message are built from.
-const ACTIONS: [(Action, &str, &[Key]); 40] = [
+const ACTIONS: [(Action, &str, &[Key]); 41] = [
     (Action::Down, "down", &[Key::plain('j'), Key::named(KeyCode::Down)]),
     (Action::Up, "up", &[Key::plain('k'), Key::named(KeyCode::Up)]),
     (Action::NextHunk, "next-hunk", &[Key::plain(']')]),
@@ -180,6 +181,7 @@ const ACTIONS: [(Action, &str, &[Key]); 40] = [
     (Action::TabPr, "tab-pr", &[Key::plain('3')]),
     (Action::Wrap, "wrap", &[Key::plain('w')]),
     (Action::Preview, "preview", &[Key::plain('m')]),
+    (Action::CopyMode, "copy-mode", &[Key::plain('C')]),
     (Action::NavigatorPosition, "navigator-position", &[Key::plain('p')]),
     (Action::NavigatorHide, "navigator-hide", &[Key::plain('z')]),
     (Action::NavigatorGrow, "navigator-grow", &[Key::plain('<')]),
@@ -327,6 +329,7 @@ mod tests {
         assert_eq!(keymap.action_for(Key::plain('c')), Some(Action::Comment));
         assert_eq!(keymap.action_for(Key::plain('S')), Some(Action::Send));
         assert_eq!(keymap.action_for(Key::plain('m')), Some(Action::Preview));
+        assert_eq!(keymap.action_for(Key::plain('C')), Some(Action::CopyMode));
         assert_eq!(keymap.action_for(Key::plain('p')), Some(Action::NavigatorPosition));
         assert_eq!(keymap.action_for(Key::plain('z')), Some(Action::NavigatorHide));
         assert_eq!(keymap.action_for(Key::plain('x')), None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1905,10 +1905,8 @@ pub fn handle_mouse(
         MouseEventKind::Drag(MouseButton::Left) => {
             if app.preview_active() {
                 // No drag-selection in the read-only preview.
-            } else if let Some(i) =
-                ui::hit_diff(area, app, m.column, m.row, heights, app.diff_scroll)
-            {
-                app.drag_select_to(i);
+            } else {
+                drag_select_with_edge_scroll(app, area, m, heights);
             }
         }
         // The wheel scrolls the viewport of whichever pane it is over — never the cursor, so
@@ -1925,6 +1923,37 @@ pub fn handle_mouse(
         _ => {}
     }
     Ok(())
+}
+
+/// Extend a line selection against logical diff rows. When the pointer reaches the pane edge,
+/// move the viewport first and hit-test again so a drag can continue into rows that were not in
+/// the original frame (`specs/diff-view.md` Comment anchoring).
+fn drag_select_with_edge_scroll(app: &mut App, area: Rect, m: MouseEvent, heights: &[usize]) {
+    let target = drag_hit_diff(area, app, m.column, m.row, heights);
+    if let Some(index) = target {
+        app.drag_select_to(index);
+    }
+
+    let delta = copy::edge_scroll_delta(area, app, copy::Pane::Diff, m.row);
+    if delta == 0 || (target.is_none() && app.select_anchor.is_none()) {
+        return;
+    }
+    app.wheel_diff(delta);
+    let viewport = ui::diff_viewport_height(area, app);
+    app.bound_diff_scroll(heights, viewport);
+    if let Some(index) = drag_hit_diff(area, app, m.column, m.row, heights) {
+        app.drag_select_to(index);
+    }
+}
+
+fn drag_hit_diff(area: Rect, app: &App, column: u16, row: u16, heights: &[usize]) -> Option<usize> {
+    let bounds = ui::copy_pane_rect(area, app, copy::Pane::Diff);
+    let right = bounds.x.saturating_add(bounds.width.saturating_sub(1));
+    if column < bounds.x || column > right {
+        return None;
+    }
+    let clamped_row = row.clamp(bounds.y, bounds.y.saturating_add(bounds.height.saturating_sub(1)));
+    ui::hit_diff(area, app, column, clamped_row, heights, app.diff_scroll)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod app;
 pub mod azure_devops;
 pub mod browser;
 pub mod config;
+pub mod copy;
 pub mod diff;
 pub mod export;
 pub mod file_list;
@@ -74,9 +75,11 @@ pub fn run() -> Result<()> {
     let mut app = app_for(&cfg, &initial_config);
 
     let mut terminal = ratatui::init();
+    let mut mouse_capture = true;
+    set_mouse_capture(mouse_capture);
     // Bracketed paste so a multi-line paste arrives as one event, not raw keystrokes whose
     // embedded newlines would submit the comment early.
-    let _ = execute!(io::stdout(), EnableMouseCapture, EnableBracketedPaste);
+    let _ = execute!(io::stdout(), EnableBracketedPaste);
     // The kitty keyboard protocol reports modifiers on keys the legacy encoding drops — most
     // notably Ctrl/Alt+arrows — so word-jump by arrow works where the terminal supports it.
     let kbd = supports_keyboard_enhancement().unwrap_or(false);
@@ -93,7 +96,7 @@ pub fn run() -> Result<()> {
     // opens the pane with the reason in the status line, the same contract as a failed poll
     // refresh.
     if let Err(error) = terminal.draw(|f| ui::render(f, &app)) {
-        restore_terminal(kbd);
+        restore_terminal(kbd, mouse_capture);
         return Err(error.into());
     }
     // The cosmetic pane label, stamped after the first paint and cleared on a normal exit
@@ -121,7 +124,7 @@ pub fn run() -> Result<()> {
         initial_config = config::plugin_config(cfg.plugin_config_dir.as_deref());
         app = app_for(&cfg, &initial_config);
         if let Err(error) = terminal.draw(|f| ui::render(f, &app)) {
-            restore_terminal(kbd);
+            restore_terminal(kbd, mouse_capture);
             herdr::clear_pane_label();
             return Err(error.into());
         }
@@ -137,17 +140,28 @@ pub fn run() -> Result<()> {
         logln!("startup reload failed: {e:#}");
         app.status = format!("load failed: {e}");
     }
-    let result = event_loop(&mut terminal, &mut app, &cfg, kbd);
+    let result = event_loop(&mut terminal, &mut app, &cfg, kbd, &mut mouse_capture);
     herdr::clear_pane_label();
     result
 }
 
 /// Leave the alternate screen and release terminal input modes before any bounded worker drain.
-fn restore_terminal(kbd: bool) {
+fn set_mouse_capture(enabled: bool) {
+    let _ = if enabled {
+        execute!(io::stdout(), EnableMouseCapture)
+    } else {
+        execute!(io::stdout(), DisableMouseCapture)
+    };
+}
+
+fn restore_terminal(kbd: bool, mouse_capture: bool) {
     if kbd {
         let _ = execute!(io::stdout(), PopKeyboardEnhancementFlags);
     }
-    let _ = execute!(io::stdout(), DisableMouseCapture, DisableBracketedPaste);
+    if mouse_capture {
+        let _ = execute!(io::stdout(), DisableMouseCapture);
+    }
+    let _ = execute!(io::stdout(), DisableBracketedPaste);
     ratatui::restore();
 }
 
@@ -680,6 +694,7 @@ fn event_loop(
     app: &mut App,
     cfg: &Config,
     kbd: bool,
+    mouse_capture: &mut bool,
 ) -> Result<()> {
     let poll = cfg.poll;
     let mut last_poll = Instant::now();
@@ -719,6 +734,7 @@ fn event_loop(
     // Fetch the PR snapshot as soon as the panel opens, not on first switching to the tab, so the
     // tab is already populated when the user gets there (specs/forge-host.md).
     app.pr_pending = None;
+    let mut copy_state = copy::State::default();
     let result: Result<()> = (|| {
         while !app.should_quit {
             if let Ok((epoch, target, mut recovered)) = recovery_rx.try_recv() {
@@ -824,7 +840,14 @@ fn event_loop(
             }
             app.bound_file_scroll(file_vp);
             let painted_frame = PaintedFrameSnapshot::capture(app);
-            terminal.draw(|f| ui::render(f, app))?;
+            terminal.draw(|f| {
+                ui::render(f, app);
+                let bounds = copy_state
+                    .selection
+                    .map(|selection| copy::visual_pane_rect(area, app, selection.pane))
+                    .unwrap_or_default();
+                ui::render_copy_selection(f, copy_state.selection, bounds);
+            })?;
 
             // A world completion reconciles into the view only while the view it described is
             // still current; the worker's baseline is authoritative either way (specs/tui.md).
@@ -1080,7 +1103,25 @@ fn event_loop(
                 }
                 match event {
                     Event::Key(k) if k.kind == KeyEventKind::Press => {
-                        if let Err(e) = handle_key(app, k, area, painted_frame.keymap()) {
+                        let action = match k.code {
+                            KeyCode::Char(c) => painted_frame.keymap().action_for(keymap::Key {
+                                ctrl: k.modifiers.contains(KeyModifiers::CONTROL),
+                                alt: k.modifiers.contains(KeyModifiers::ALT),
+                                code: keymap::KeyCode::Char(c),
+                            }),
+                            _ => None,
+                        };
+                        if app.mode == Mode::Normal && action == Some(keymap::Action::CopyMode) {
+                            app.copy_mode = !app.copy_mode;
+                            if !app.copy_mode {
+                                copy_state.clear();
+                            }
+                            app.status = if app.copy_mode {
+                                "copy mode on — drag inside a pane".into()
+                            } else {
+                                "copy mode off".into()
+                            };
+                        } else if let Err(e) = handle_key(app, k, area, painted_frame.keymap()) {
                             app.status = format!("error: {e}");
                         }
                         logln!(
@@ -1104,7 +1145,11 @@ fn event_loop(
                     Event::Mouse(m) => {
                         // Reuse this frame's `area` and `heights` (computed above for the scroll
                         // settle) so a drag-select doesn't re-measure the whole diff per motion.
-                        if let Err(e) = handle_mouse(app, m, area, &heights, painted_frame.keymap())
+                        let copy_handled =
+                            app.copy_mode && copy::mouse_event(app, area, m, &mut copy_state)?;
+                        if !copy_handled
+                            && let Err(e) =
+                                handle_mouse(app, m, area, &heights, painted_frame.keymap())
                         {
                             app.status = format!("error: {e}");
                         }
@@ -1168,7 +1213,7 @@ fn event_loop(
         }
         Ok(())
     })();
-    restore_terminal(kbd);
+    restore_terminal(kbd, *mouse_capture);
     drain_pr_shutdown(&mut pr, &probe_rx, &pr_rx);
     result
 }
@@ -1641,7 +1686,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             K::Find => app.open_find(),
             K::Keys => app.toggle_keys(),
             // `edit`/`delete` off the diff, and `open-pr` off the `PR` tab, are inert.
-            K::Edit | K::Delete | K::OpenPr => {}
+            K::Edit | K::Delete | K::OpenPr | K::CopyMode => {}
         }
         return Ok(());
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,6 +20,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::{App, Band, Focus, FooterAction, Mode, Tab};
 use crate::config::NavigatorPosition;
+use crate::copy::{Pane as CopyPane, Selection as CopySelection};
 use crate::diff::{FileDiff, FileState, Row};
 use crate::file_list::{Annotation, RowKind};
 use crate::forge;
@@ -246,6 +247,46 @@ pub fn in_files_pane(area: Rect, app: &App, col: u16, row: u16) -> bool {
 #[must_use]
 pub fn in_diff_pane(area: Rect, app: &App, col: u16, row: u16) -> bool {
     contains(panes(area, app).diff, col, row)
+}
+
+/// The selectable content rectangle for an internal pane, excluding its border.
+#[must_use]
+pub fn copy_pane_rect(area: Rect, app: &App, pane: CopyPane) -> Rect {
+    let p = panes(area, app);
+    inner_rect(match pane {
+        CopyPane::Files => p.files,
+        CopyPane::Diff => p.diff,
+    })
+}
+
+/// Paint a character selection over the already-rendered frame.
+pub fn render_copy_selection(frame: &mut Frame, selection: Option<CopySelection>, bounds: Rect) {
+    let Some(selection) = selection else { return };
+    let style = Style::default().bg(Color::Rgb(90, 90, 120)).fg(Color::White);
+    let end_x = bounds.x.saturating_add(bounds.width.saturating_sub(1));
+    let end_y = bounds.y.saturating_add(bounds.height.saturating_sub(1));
+    let (start, end) =
+        if (selection.start.1, selection.start.0) <= (selection.end.1, selection.end.0) {
+            (selection.start, selection.end)
+        } else {
+            (selection.end, selection.start)
+        };
+    for y in start.1..=end.1.min(end_y) {
+        let (from, to) = if start.1 == end.1 {
+            (start.0, end.0)
+        } else if y == start.1 {
+            (start.0, end_x)
+        } else if y == end.1 {
+            (bounds.x, end.0)
+        } else {
+            (bounds.x, end_x)
+        };
+        for x in from.max(bounds.x)..=to.min(end_x) {
+            if let Some(cell) = frame.buffer_mut().cell_mut((x, y)) {
+                cell.set_style(style);
+            }
+        }
+    }
 }
 
 /// The logical diff-row index a click at `(col, row)` lands on, or `None` if outside the
@@ -1691,6 +1732,7 @@ fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
             return ("tab".into(), if app.focus == Focus::Files { "diff" } else { "files" }.into());
         }
         A::Preview => (hint(K::Preview), if app.preview_active() { "source" } else { "preview" }),
+        A::CopyMode => (hint(K::CopyMode), "copy"),
         A::NavigatorPosition => (hint(K::NavigatorPosition), "position"),
         A::NavigatorHide => {
             (hint(K::NavigatorHide), if app.navigator_hidden_here() { "show" } else { "hide" })
@@ -1771,7 +1813,12 @@ fn band_styles(band: Band, p: &Palette) -> (Style, Style) {
 fn action_entry(app: &App, action: FooterAction, band: Band) -> Vec<Span<'static>> {
     let p = app.palette();
     let (key, label) = action_key_label(app, action);
-    let (key_style, label_style) = band_styles(band, p);
+    let (key_style, label_style) = if action == FooterAction::CopyMode && app.copy_mode {
+        let active = Style::default().fg(p.peach).add_modifier(Modifier::BOLD);
+        (active, active)
+    } else {
+        band_styles(band, p)
+    };
     let mut spans = vec![Span::styled(key, key_style)];
     if !label.is_empty() {
         spans.push(Span::styled(format!(" {label}"), label_style));

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -10,6 +10,7 @@ use anyhow::{Result, bail};
 use common::{Repo, app_on, enter_tab, typed};
 use herdr_reviewr::app::{App, Band, Focus, FooterAction, Mode};
 use herdr_reviewr::config::NavigatorPosition;
+use herdr_reviewr::copy::Pane as CopyPane;
 use herdr_reviewr::export::ExportTarget;
 use herdr_reviewr::herdr::{AgentChoice, AgentSample};
 use herdr_reviewr::keymap::{Action, Key, KeyCode as BindingCode, Keymap};
@@ -172,6 +173,54 @@ fn the_wheel_scrolls_the_diff_without_moving_its_cursor() {
     assert_eq!(app.diff_cursor, 3, "the wheel leaves the comment cursor put");
     assert!(app.diff_scroll > 0, "the wheel moved the viewport");
     assert!(!app.reveal_diff, "the wheel does not request a reveal");
+}
+
+#[test]
+fn dragging_a_line_selection_at_the_diff_edge_scrolls_into_new_rows() {
+    let mut app = long_diff_app(40);
+    let area = Rect::new(0, 0, 120, 24);
+    let keymap = Keymap::default();
+    let heights = herdr_reviewr::ui::diff_row_heights(&app, area);
+    let bounds = herdr_reviewr::ui::copy_pane_rect(area, &app, CopyPane::Diff);
+    let column = bounds.x + bounds.width / 2;
+    let bottom = bounds.y + bounds.height.saturating_sub(1);
+    let event = |kind, row| MouseEvent { kind, column, row, modifiers: KeyModifiers::NONE };
+
+    handle_mouse(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column,
+            row: bounds.y,
+            modifiers: KeyModifiers::NONE,
+        },
+        area,
+        &heights,
+        &keymap,
+    )
+    .unwrap();
+    handle_mouse(
+        &mut app,
+        event(MouseEventKind::Drag(MouseButton::Left), bottom),
+        area,
+        &heights,
+        &keymap,
+    )
+    .unwrap();
+
+    assert!(app.select_anchor.is_some(), "the drag keeps a logical selection anchor");
+    assert!(app.diff_scroll > 0, "dragging at the bottom edge scrolls the diff");
+    let first_cursor = app.diff_cursor;
+
+    handle_mouse(
+        &mut app,
+        event(MouseEventKind::Drag(MouseButton::Left), bottom + 1),
+        area,
+        &heights,
+        &keymap,
+    )
+    .unwrap();
+    assert!(app.diff_cursor >= first_cursor, "the selection continues into newly visible rows");
 }
 
 #[test]

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -6,6 +6,7 @@ mod common;
 use common::{Repo, app_on, enter_tab};
 use herdr_reviewr::app::{App, BaseChoice, BasePicker, BaseProbe, Focus, Mode, Tab};
 use herdr_reviewr::config::NavigatorPosition;
+use herdr_reviewr::copy::Pane as CopyPane;
 use herdr_reviewr::herdr::AgentChoice;
 use herdr_reviewr::keymap::Keymap;
 use herdr_reviewr::model::Scope;
@@ -43,6 +44,48 @@ fn render_buffer(app: &App) -> Buffer {
 /// Render at a specific width (height fixed), for footer fit-to-width assertions.
 fn render_at(app: &App, width: u16) -> String {
     dump(&render_size(app, width, 12))
+}
+
+#[test]
+fn copy_area_uses_the_pr_read_pane_content_edge() {
+    let repo = Repo::init();
+    repo.write("base.txt", "base\n");
+    repo.commit_all("base");
+    repo.write("changed.rs", "let value = 1;\n");
+    let mut app = app_on(&repo);
+    enter_tab(&mut app, Tab::Pr);
+
+    let area = Rect::new(0, 0, 140, 40);
+    let body = ui::body_rect(area, &app);
+    let navigator_width = (u32::from(body.width) * u32::from(app.navigator_share()) / 100) as u16;
+    let read_width = body.width - navigator_width;
+    let expected = Rect::new(
+        body.x + 1,
+        body.y + 1,
+        read_width.saturating_sub(2),
+        body.height.saturating_sub(2),
+    );
+
+    assert_eq!(ui::copy_pane_rect(area, &app, CopyPane::Diff), expected);
+}
+
+#[test]
+fn code_copy_highlight_starts_after_the_visual_gutter() {
+    let repo = Repo::init();
+    repo.write("app/controllers/application_controller.rb", "some.model.method = x\n");
+    repo.commit_all("base");
+    repo.write("app/controllers/application_controller.rb", "some.model.method = y\n");
+    let app = app_on(&repo);
+    let area = Rect::new(0, 0, 140, 40);
+    let hit = ui::copy_pane_rect(area, &app, CopyPane::Diff);
+    let visual = herdr_reviewr::copy::visual_pane_rect(area, &app, CopyPane::Diff);
+
+    assert!(visual.x > hit.x, "the code gutter is not part of the copy highlight");
+    assert_eq!(
+        u32::from(visual.x - hit.x) + u32::from(visual.width),
+        u32::from(hit.width),
+        "the content width remains unchanged after moving past the gutter"
+    );
 }
 
 fn render_size(app: &App, width: u16, height: u16) -> Buffer {
@@ -759,6 +802,7 @@ fn the_expansion_aligns_row_one_into_the_labeled_grid() {
         do_line.contains("c comment") && do_line.trim_end().ends_with('?'),
         "row 1 is the `do` line with the primary and `?`:\n{do_line}"
     );
+    assert!(do_line.contains("C copy"), "the do band advertises copy mode:\n{do_line}");
     assert!(go_line.contains("scope"), "the go band lists the always-there keys:\n{go_line}");
     assert!(
         move_line.contains("hunk") && move_line.contains("file"),


### PR DESCRIPTION
## Summary

Fixes #62 by adding a reviewr-owned, pane-local text selection mode.

Reviewr normally captures mouse input for its own navigation, scrolling, and line-comment
selection. That prevented Herdr from receiving terminal mouse gestures, but simply disabling
reviewr's mouse capture made selection unsafe because reviewr's files sidebar is an internal
split rather than a separate Herdr pane: a terminal selection could span both the file list and
the diff.

## What changed

- Added a rebindable `C` action for character-level copy mode, shown in the expanded `?` footer.
- Kept reviewr mouse capture enabled by default; copy mode is an explicit, temporary interaction
  mode rather than a global mouse-capture change.
- Locks each drag to the internal pane where it starts, so selections cannot cross between the
  files list and diff.
- Resolves file-list selections against complete repository-relative paths, including nested
  directories and every row in a multi-file selection, rather than the displayed basename.
- Uses source-backed diff selection so elision, horizontal scrolling, and wrapping do not discard
  source text; tabs remain tabs. With wrapping off, reaching the right edge of an overflowing
  final diff row extends the endpoint to the source row's end only when hidden text remains, so
  selecting multiple long rows does not require entering the next row.
- Double-clicking a visible token selects that token in every pane; dotted code chains such as
  `some.model.method` are one token. PR and markdown-preview panes retain their rendered-text
  fallback.
- Excludes diff change markers and line-number gutters from both the highlight and copied text.
- Copies the selected text through reviewr's existing clipboard integration and reports `copied`
  in the reviewr status area.
- Highlights `C copy` in the footer while copy mode is active.
- Isolated the selection state, mouse handling, source-range calculation, and clipboard
  extraction in `src/copy.rs`; terminal orchestration remains in `src/lib.rs` and pane geometry
  remains in `src/ui.rs`.
- Updated the README, input specification, and changelog.

## Usage

1. Press `C` in normal mode.
2. Drag over text in either the files pane or diff pane.
3. Release to copy the selected characters.
4. Press `C` again to leave copy mode.

## Validation

- `cargo fmt --check` passes.
- `cargo clippy --all-targets --all-features -- -D warnings` passes.
- `cargo test --all-features` passes: 297 unit tests, 202 app-flow tests, 36 git-repository
  tests, 28 pane-action tests, 24 PR-candidate tests, 111 render tests, 1 send-flow test, and
  0 doc-test failures; 1 live-network test remains intentionally ignored.
- `git diff --check` passes.
- Release build and QA installation completed successfully.

## Perceived latency

Fixture benchmark, 15 iterations, painted-frame medians in milliseconds:

| action | upstream | this branch |
| --- | ---: | ---: |
| enter All files | 46.7 | 46.9 |
| enter Changes | 32.7 | 33.0 |
| enter All files then next file | 46.8 | 46.9 |
| next file in Changes | 6.5 | 6.1 |
| next file in All files | 0.5 | 0.4 |

The benchmark exercises the render and reload paths. The added selection overlay is only active
while copy mode is enabled; no input or rendering regression was observed outside those paths.

## Checklist

- [x] Formatting, Clippy, full tests, and the release build are green
- [x] The governing spec under `specs/` says the new behavior
- [x] `CHANGELOG.md` has a bullet under `## [Unreleased]`
- [x] Perf-relevant paths have before/after numbers from `scripts/bench_tui.py` above

Fixes #62