### PR TITLE
Forward the action script PATH to the reviewr pane so the PR tab finds the forge CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **The PR tab finds brew-installed forge CLIs.** herdr launches plugin panes with a minimal
+  `PATH`, so a `gh` in `/opt/homebrew/bin` never resolved and the PR tab read "GitHub CLI not
+  found. Install `gh`". Every open now forwards the action script's prepended `PATH` to the
+  pane — the same list it already relies on for `jq`/`git`.
+
 ## [0.32.0] — 2026-08-17
 
 ### Added

--- a/herdr/pane.sh
+++ b/herdr/pane.sh
@@ -271,8 +271,11 @@ overlay)
   ;;
 esac
 
+# The pane inherits herdr's minimal PATH (docs/herdr-api-notes.md), and its PR tab runs the
+# forge CLI — `gh`/`glab`/`az` — from PATH. Forward this script's prepended PATH so the pane
+# resolves the CLI, exactly as this script already does for its own jq/git calls.
 open_json=$("$H" plugin pane open --plugin "${HERDR_PLUGIN_ID:-persiyanov.reviewr}" --entrypoint pane \
-  "$@" --cwd "$cwd" "$focus" 2>/dev/null)
+  "$@" --cwd "$cwd" --env PATH="$PATH" "$focus" 2>/dev/null)
 new=$(printf '%s' "$open_json" | jq -r '.result.plugin_pane.pane.pane_id // empty' 2>/dev/null)
 [ -n "$new" ] || refuse "herdr plugin pane open failed"
 

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -78,6 +78,11 @@ A `split` or `zoomed` open attaches to the focused pane, or to the workspace's f
 
 A `tab` open names the fresh tab `reviewr`, using the `tab_id` the pane-open result reports. herdr otherwise labels a new tab with a bare number. The rename is cosmetic. When it fails, or an older herdr omits `tab_id`, the open still succeeds and the tab keeps its numeric label.
 
+Every open forwards this script's prepended `PATH` to the pane (`--env PATH`). herdr launches
+plugin panes with a minimal `PATH` (docs/herdr-api-notes.md), and the pane's PR tab executes
+the forge CLI — `gh`/`glab`/`az` — from `PATH`; without the forwarding, a brew-installed CLI
+renders as "GitHub CLI not found".
+
 **HH-EVENT-BESIDE-LAYOUT: a layout plugin handles the same event**
 
 1. The user sets `auto_open = false`. A layout plugin also handles `worktree.created`.

--- a/tests/pane_actions.rs
+++ b/tests/pane_actions.rs
@@ -540,6 +540,18 @@ fn the_flag_dispatch_matches_the_actions_anywhere_in_argv() {
 }
 
 #[test]
+fn open_forwards_the_prepended_path_so_the_pane_resolves_the_forge_cli() {
+    let dir = tempfile::tempdir().unwrap();
+    let (herdr, log) = fake_herdr(dir.path());
+
+    let output = run_open(dir.path(), &herdr);
+
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let calls = fs::read_to_string(&log).unwrap();
+    assert!(calls.contains("--env PATH="), "{calls}");
+}
+
+#[test]
 fn valid_non_default_placement_and_direction_reach_herdr_arguments() {
     let dir = tempfile::tempdir().unwrap();
     let config = dir.path().join("config.toml");


### PR DESCRIPTION
Fixes #70.

## Problem

herdr launches plugin panes with a minimal `PATH` (docs/herdr-api-notes.md). The PR tab runs the forge CLI via a bare `Command::new("gh")` (`src/forge.rs`), so on a stock Homebrew install (`/opt/homebrew/bin/gh`) the pane cannot resolve it and renders `GitHub CLI not found. Install 'gh'`. `pane.sh` already prepends common bin dirs for its own `jq`/`git` calls, but that list never reached the pane it opens — the one place a forge CLI actually executes.

## Change

`herdr/pane.sh` passes `--env PATH="$PATH"` on `plugin pane open`, so the pane inherits the same prepended list the script already relies on. Spec (`specs/herdr-host.md` → Pane placement), changelog bullet under `[Unreleased]` → Fixed, and a regression test asserting the open call carries `--env PATH=` land together, per CONTRIBUTING.

## Verification

`just ci` equivalents green locally on rustc 1.97.0: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` (551 tests, including the new `open_forwards_the_prepended_path_so_the_pane_resolves_the_forge_cli`), `cargo build --release`.

Also verified live: cycled the installed plugin's reviewr pane with the patched script, pressed `r` on the PR tab — fetch succeeds, no "CLI not found".
