### PR TITLE
Honor the diff attribute from .gitattributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **`.gitattributes` is respected in the diff.** A file marked `-diff` or `binary` there — a
+  lockfile, a generated bundle, a snapshot fixture — used to open as a full text diff even
+  though git itself refuses to diff it. It now reads `binary — no line comments`, the same as
+  any other binary, and reviewr no longer reads either side of it. This holds for a file the
+  agent has only just written, before it is tracked. `All files` still shows the file's
+  content, since the attribute governs diffing, not reading.
+
 ## [0.32.0] — 2026-08-17
 
 ### Added

--- a/specs/diff-view.md
+++ b/specs/diff-view.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-24
-Last edited: 2026-08-15
+Last edited: 2026-08-18
 ---
 
 # Diff view
@@ -61,6 +61,7 @@ You can select content rows for comments in the file tabs. You cannot select a `
 ### The model
 
 - Old content comes from `git show`. New content comes from the worktree. In the `branch` scope, new content comes from `git show`. An `untracked` file has empty old content. A `deleted` file has empty new content.
+- A change that git reports as `binary` goes to the notice before this read. The viewer reads no content for it. `review-model.md` owns that decision, which obeys `.gitattributes`.
 - Changes go into hunks. The context margin is 3 unchanged lines.
 - The full file has highlight. Each hunk does not have its own highlight. A string or a comment that spans many lines has the correct color inside a hunk.
 - The language comes from the path. A path that is not known shows as plain.
@@ -153,7 +154,7 @@ Return to source is different per view.
 The viewer only reads. The viewer is computed again on each refresh. The viewer degrades. The viewer does not block.
 
 - A file over the size budget shows `too_large`. The viewer does not hang.
-- A binary file shows `binary — no line comments`.
+- A binary file shows `binary — no line comments`. A file that `.gitattributes` makes not diffable shows the same notice, because git gives no text diff for it (`review-model.md`).
 - If highlight fails, the viewer uses plain spans. The diff still shows.
 - A diff that is empty on both sides shows its header and a notice of one line. The pane is not empty. A rename only, or a mode-only change, shows that content. The content is closed to a fold.
 - A refresh computes the model again. Saved comments do not change. A comment that is in progress does not change.

--- a/specs/file-list.md
+++ b/specs/file-list.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-24
-Last edited: 2026-07-18
+Last edited: 2026-08-18
 ---
 
 # File list
@@ -77,7 +77,7 @@ The list is a flat sequence of visible rows over the tree.
 ### Presentation
 
 - A file row is `<marker> <name> <stats>`: the marker colored by kind, the basename bright, parent directories dimmed, stats right-aligned.
-- Stats read `+added −removed`: additions green, deletions red, a zero side dropped. A change with no countable lines (a binary file) shows no stats.
+- Stats read `+added −removed`: additions green, deletions red, a zero side dropped. A change with no countable lines shows no stats. Git gives no counts for a binary file, and none for a file that `.gitattributes` makes not diffable (`review-model.md`).
 - An ignored row dims whole, distinct from the marker colors. `All files` is the one place an ignored path is readable. An ignored file never carries a change marker, since every scope respects `.gitignore` (`review-model.md`).
 - A too-narrow path shortens with a middle ellipsis (`…/2026-06-23-changes/plan`), keeping the basename and stats visible.
 

--- a/specs/review-model.md
+++ b/specs/review-model.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-23
-Last edited: 2026-08-08
+Last edited: 2026-08-18
 ---
 
 # Review model
@@ -93,10 +93,21 @@ A row in the `Changes` list carries:
 | `kind`          | `added`, `modified`, `deleted`, `renamed`, or `untracked` |
 | `additions`     | lines added in the scope, all lines for an untracked file |
 | `deletions`     | lines removed in the scope                                |
+| `binary`        | git gives no text diff for this change                    |
 
 ### Diff
 
 The selected file's structured diff, built from its old and new content (`diff-view.md`). Comment anchors and snippets come from it. An untracked file diffs against empty old content. A binary file lists, and its pane reads `binary — no line comments`.
+
+#### The binary decision
+
+Git decides which changes have no text diff. reviewr obeys that decision. It does not make its own decision from the content.
+
+- The changeset reports the decision in `binary`. A tracked change is `binary` when git gives no line counts for it.
+- Git gives no line counts for binary content, for a path where `.gitattributes` unsets the `diff` attribute (`-diff`, or the `binary` macro), and for a diff driver that git will not use for text.
+- A `binary` change goes directly to the notice. reviewr does not read the old content or the new content of that file.
+- An untracked file never gets a git diff, so no line counts speak for it. reviewr asks git for its `diff` attribute directly, for all untracked paths of the scope together. The file is `binary` when that attribute is unset, or when the content has a NUL byte. The same bytes get the same result whether or not git tracks the file.
+- The decision applies to the diff only. `All files` shows the content of the same file (`diff-view.md`).
 
 ### File content
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1155,8 +1155,18 @@ impl App {
             self.preview_max_scroll.set(usize::MAX);
         }
         self.diff_path = Some(path.clone());
-        let (old, new) = self.content_sides(&path, previous_path.as_deref());
-        self.diff = self.cache.get(path, previous_path, &old, &new, &self.highlighter);
+        // Git already reported no text diff for this change — binary content, or a path whose
+        // `diff` attribute `.gitattributes` unsets. Take that verdict rather than re-deciding
+        // from content, which would paint a `-diff` lockfile as a full text diff, and skip
+        // both blob reads while we are at it (specs/review-model.md).
+        let new = if self.changed.get(&path).is_some_and(|a| a.binary) {
+            self.diff = FileDiff::binary_notice(path, previous_path);
+            String::new()
+        } else {
+            let (old, new) = self.content_sides(&path, previous_path.as_deref());
+            self.diff = self.cache.get(path, previous_path, &old, &new, &self.highlighter);
+            new
+        };
         // Hold the new side as the preview's render input, the same current content the File
         // view previews. A non-markdown file, a notice, or a deleted file (empty new side)
         // holds nothing, so its toggle stays inert (specs/diff-view.md).

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -272,6 +272,13 @@ impl FileDiff {
         Self { path, previous_path: None, state: FileState::Normal, view: View::File, rows }
     }
 
+    /// The Diff-view `binary` notice, for a change git already reported as having no text
+    /// diff. `set_diff` builds this rather than reading either side's blob, so a `-diff`
+    /// lockfile costs no `git show` at all (`specs/review-model.md`).
+    pub fn binary_notice(path: String, previous_path: Option<String>) -> Self {
+        Self { path, previous_path, state: FileState::Binary, view: View::Diff, rows: Vec::new() }
+    }
+
     /// The File-view `too_large` notice, for an over-budget file the caller declines to read.
     /// `set_file_view` checks the on-disk size and builds this rather than reading the bytes.
     pub fn too_large_notice(path: String) -> Self {

--- a/src/file_list.rs
+++ b/src/file_list.rs
@@ -39,13 +39,17 @@ pub struct Annotation {
     pub change: ChangeKind,
     pub additions: u32,
     pub deletions: u32,
+    /// Git reports no text diff for this change — binary content, or an unset `diff`
+    /// attribute (`specs/review-model.md`). Carried for the read pane, not painted here:
+    /// such a change has no countable lines, so it already shows no stats.
+    pub binary: bool,
 }
 
 impl From<&ChangedFile> for Annotation {
     /// The scope annotation a changed file carries — the one mapping, shared by the `Changes`
     /// entry build and `app.rs`'s changeset map so a new field can't be wired in one and missed.
     fn from(f: &ChangedFile) -> Self {
-        Self { change: f.kind, additions: f.additions, deletions: f.deletions }
+        Self { change: f.kind, additions: f.additions, deletions: f.deletions, binary: f.binary }
     }
 }
 
@@ -225,6 +229,7 @@ mod tests {
             additions: 1,
             deletions: 0,
             previous_path: None,
+            binary: false,
         }
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -947,6 +947,11 @@ pub fn clear_base_pick(repo: &Path) -> Result<(), GitFail> {
 }
 
 /// Run git with `input` piped to stdin, any non-zero exit a failure.
+///
+/// The write runs on its own thread. An input large enough to fill the stdin pipe — the
+/// untracked path set of [`diff_unset`] — would otherwise block here before anything read
+/// stdout, while git blocks writing the stdout it cannot flush: a deadlock with no timeout
+/// to break it, on the thread that draws the frame.
 fn git_stdin(repo: &Path, args: &[&str], input: &str) -> Result<String, GitFail> {
     use std::io::Write;
     use std::process::Stdio;
@@ -960,13 +965,13 @@ fn git_stdin(repo: &Path, args: &[&str], input: &str) -> Result<String, GitFail>
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| GitFail(format!("git {args:?}: {e}")))?;
-    child
-        .stdin
-        .take()
-        .expect("stdin piped")
-        .write_all(input.as_bytes())
-        .map_err(|e| GitFail(format!("git {args:?}: {e}")))?;
+    let mut stdin = child.stdin.take().expect("stdin piped");
+    let owned = input.to_string();
+    // A git that answers and exits before reading it all closes the pipe. That is its answer,
+    // not a failure of ours, so the write's result is dropped and the exit status decides.
+    let writer = std::thread::spawn(move || drop(stdin.write_all(owned.as_bytes())));
     let out = child.wait_with_output().map_err(|e| GitFail(format!("git {args:?}: {e}")))?;
+    let _ = writer.join();
     if !out.status.success() {
         return Err(GitFail(format!(
             "git {args:?}: {}",
@@ -1230,8 +1235,18 @@ fn assemble(
         if !seen.insert(path.clone()) {
             continue;
         }
-        let (additions, deletions) = counts.get(&path).copied().unwrap_or((0, 0));
-        files.push(ChangedFile { path, kind, additions, deletions, previous_path });
+        // A path missing from the numstat has no counts to contradict, so it reads as an
+        // ordinary empty change rather than as git's no-text-diff verdict.
+        let verdict = counts.get(&path).copied().unwrap_or(Some((0, 0)));
+        let (additions, deletions) = verdict.unwrap_or((0, 0));
+        files.push(ChangedFile {
+            path,
+            kind,
+            additions,
+            deletions,
+            previous_path,
+            binary: verdict.is_none(),
+        });
     }
 
     if include_untracked {
@@ -1240,18 +1255,24 @@ fn assemble(
         // `-z` keeps paths with spaces or special characters verbatim, and files inside a
         // brand-new directory list individually (.gitignore still applies).
         let others = git(repo, &["ls-files", "--others", "--exclude-standard", "-z"])?;
-        for path in others.split('\0').filter(|s| !s.is_empty()) {
+        let new_paths: Vec<&str> =
+            others.split('\0').filter(|p| !p.is_empty() && !seen.contains(*p)).collect();
+        let undiffable = diff_unset(repo, &new_paths)?;
+        for path in new_paths {
             let path = path.to_string();
-            if seen.insert(path.clone()) {
-                let additions = untracked_additions(repo, &path);
-                files.push(ChangedFile {
-                    path,
-                    kind: ChangeKind::Untracked,
-                    additions,
-                    deletions: 0,
-                    previous_path: None,
-                });
+            if !seen.insert(path.clone()) {
+                continue;
             }
+            let additions = untracked_additions(repo, &path);
+            let binary = additions.is_none() || undiffable.contains(path.as_str());
+            files.push(ChangedFile {
+                path,
+                kind: ChangeKind::Untracked,
+                additions: additions.unwrap_or(0),
+                deletions: 0,
+                previous_path: None,
+                binary,
+            });
         }
     }
 
@@ -1259,49 +1280,101 @@ fn assemble(
     Ok(files)
 }
 
+/// Of `paths`, those whose `diff` attribute git reports as unset — `-diff`, or the `binary`
+/// macro that implies it (`specs/review-model.md`). Empty when `paths` is, so a repository
+/// with nothing untracked pays nothing.
+///
+/// One `check-attr` for the whole set, never one per path — the same rule
+/// [`untracked_additions`] follows, and for the same reason. Only untracked paths come here:
+/// a tracked path already carries git's verdict in its `--numstat` record, at no cost.
+///
+/// Under `-z` the answer is `PATH\0diff\0VALUE\0` per path, and the input must be
+/// NUL-terminated too — a newline-separated list makes git read the newline as part of the
+/// path and answer `unspecified` for every one of them.
+fn diff_unset(repo: &Path, paths: &[&str]) -> Result<HashSet<String>> {
+    if paths.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let mut input = String::new();
+    for path in paths {
+        input.push_str(path);
+        input.push('\0');
+    }
+    let out = git_stdin(repo, &["check-attr", "-z", "--stdin", "diff"], &input)
+        .map_err(|e| anyhow::anyhow!("{}", e.0))?;
+    let mut fields = out.split('\0');
+    let mut unset = HashSet::new();
+    while let (Some(path), Some(_attr), Some(value)) = (fields.next(), fields.next(), fields.next())
+    {
+        if value == "unset" {
+            unset.insert(path.to_string());
+        }
+    }
+    Ok(unset)
+}
+
 /// Addition count of an untracked file: its line count, which is what `git diff` against
-/// nothing reports (0 for empty or binary). Read locally rather than shelling
-/// `git diff --no-index` per file — with `--untracked-files=all` a large untracked tree
-/// would otherwise fork git once per file on every poll and freeze the UI.
-fn untracked_additions(repo: &Path, path: &str) -> u32 {
-    let Ok(bytes) = std::fs::read(repo.join(path)) else { return 0 };
-    if bytes.is_empty() || bytes.contains(&0) {
-        return 0; // empty, or binary (a NUL byte) — git reports no line additions
+/// nothing reports. `None` where git would report no countable diff — binary content —
+/// matching the `-`/`-` numstat record a tracked binary produces. Read locally rather than
+/// shelling `git diff --no-index` per file — with `--untracked-files=all` a large untracked
+/// tree would otherwise fork git once per file on every poll and freeze the UI.
+///
+/// This is the content half of the untracked verdict only. An untracked path never reaches a
+/// `git diff`, so no numstat speaks for it; [`diff_unset`] asks git for the attribute half
+/// (specs/review-model.md).
+fn untracked_additions(repo: &Path, path: &str) -> Option<u32> {
+    let Ok(bytes) = std::fs::read(repo.join(path)) else { return Some(0) };
+    if bytes.contains(&0) {
+        return None; // binary (a NUL byte) — git reports no line additions
+    }
+    if bytes.is_empty() {
+        return Some(0);
     }
     // Lines = newline count, plus one for a final line with no trailing newline. A plain
     // byte count is fine for one already-read file; no need for the bytecount crate.
     #[allow(clippy::naive_bytecount)]
     let newlines = bytes.iter().filter(|&&b| b == b'\n').count();
     let trailing = usize::from(bytes.last() != Some(&b'\n'));
-    (newlines + trailing) as u32
+    Some((newlines + trailing) as u32)
 }
 
 // --- pure parsers (unit-tested without a repo) ---------------------------------
 
-/// Map of new-path to `(additions, deletions)` from `git diff --numstat -z`.
+/// Map of new-path to its line counts from `git diff --numstat -z`, `None` where git
+/// reports no countable diff — the `-`/`-` record.
 ///
 /// Under `-z` a non-rename record is `ADDS\tDELS\tPATH\0`; a rename/copy record is
 /// `ADDS\tDELS\t\0OLD\0NEW\0` — the counts ride the front, then old and new arrive as
-/// their own NUL fields (no `=>` arrow, no brace factoring). Binary files emit `-`/`-`,
-/// which parse to 0. The counts key under the new path, matching `parse_name_status`.
-fn parse_numstat(out: &str) -> HashMap<String, (u32, u32)> {
+/// their own NUL fields (no `=>` arrow, no brace factoring). The counts key under the new
+/// path, matching `parse_name_status`.
+///
+/// `-`/`-` is git's own no-text-diff verdict, and it already accounts for `.gitattributes`:
+/// binary content, an unset `diff` attribute (`-diff`, or the `binary` macro), and a driver
+/// git will not text-diff all land there. Reading it as `0`/`0` — as this once did — loses
+/// that verdict and leaves a `-diff` file to be diffed as text anyway.
+fn parse_numstat(out: &str) -> HashMap<String, Option<(u32, u32)>> {
     let mut map = HashMap::new();
     let mut it = out.split('\0');
     while let Some(field) = it.next() {
         // `splitn(3)` keeps any tabs inside the path (verbatim under `-z`) intact.
         let mut parts = field.splitn(3, '\t');
-        let add = parts.next().unwrap_or("0").parse().unwrap_or(0);
-        let del = parts.next().unwrap_or("0").parse().unwrap_or(0);
+        let add = parts.next().unwrap_or("");
+        let del = parts.next().unwrap_or("");
+        // Either side reading `-` is the whole record's verdict; git never mixes them.
+        let counts = match (add.parse(), del.parse()) {
+            (Ok(a), Ok(d)) => Some((a, d)),
+            _ => None,
+        };
         match parts.next() {
             // Non-rename: the path rode this same field.
             Some(path) if !path.is_empty() => {
-                map.insert(path.to_string(), (add, del));
+                map.insert(path.to_string(), counts);
             }
             // Rename/copy: the next two fields are the old and new paths.
             Some(_) => {
                 let _old = it.next();
                 if let Some(new) = it.next().filter(|n| !n.is_empty()) {
-                    map.insert(new.to_string(), (add, del));
+                    map.insert(new.to_string(), counts);
                 }
             }
             // No tab fields — a trailing empty record after the final NUL.
@@ -1685,10 +1758,19 @@ mod tests {
     }
 
     #[test]
-    fn numstat_parses_counts_and_ignores_binary() {
+    fn numstat_parses_counts_and_keeps_the_no_text_diff_verdict() {
         let m = parse_numstat("18\t8\tsrc/a.rs\0-\t-\tassets/logo.png\0");
-        assert_eq!(m["src/a.rs"], (18, 8));
-        assert_eq!(m["assets/logo.png"], (0, 0));
+        assert_eq!(m["src/a.rs"], Some((18, 8)));
+        // `-`/`-` is git refusing to text-diff, not a change of zero lines. Collapsing the
+        // two is what left a `-diff` path (`.gitattributes`) diffed as text.
+        assert_eq!(m["assets/logo.png"], None);
+    }
+
+    #[test]
+    fn numstat_separates_the_no_text_diff_verdict_from_an_empty_change() {
+        let m = parse_numstat("0\t0\tsrc/touched.rs\0-\t-\tflake.lock\0");
+        assert_eq!(m["src/touched.rs"], Some((0, 0)));
+        assert_eq!(m["flake.lock"], None);
     }
 
     #[test]
@@ -1696,7 +1778,7 @@ mod tests {
         // Under `-z` a rename is `ADDS\tDELS\t\0OLD\0NEW`: old and new are their own fields,
         // no `=>` arrow or brace form. Counts must key under the new path.
         let m = parse_numstat("3\t1\t\0src/old.rs\0src/new.rs\0");
-        assert_eq!(m["src/new.rs"], (3, 1));
+        assert_eq!(m["src/new.rs"], Some((3, 1)));
         assert!(!m.contains_key("src/old.rs"));
     }
 
@@ -1704,7 +1786,7 @@ mod tests {
     fn numstat_dir_removing_rename_has_no_double_slash() {
         // Regression: the old brace parser produced `a//file.rs` here, so counts never matched.
         let m = parse_numstat("4\t2\t\0a/b/file.rs\0a/file.rs\0");
-        assert_eq!(m["a/file.rs"], (4, 2));
+        assert_eq!(m["a/file.rs"], Some((4, 2)));
         assert!(!m.contains_key("a//file.rs"));
     }
 
@@ -1713,9 +1795,9 @@ mod tests {
         // binary, plain, rename, in sequence — the rename lookahead must stay aligned.
         // `\x00` (= NUL) is used as the separator so the digits after it read clearly.
         let m = parse_numstat("-\t-\tlogo.png\x009\t1\tsrc/a.rs\x005\t4\t\x00o.rs\x00n.rs\x00");
-        assert_eq!(m["logo.png"], (0, 0));
-        assert_eq!(m["src/a.rs"], (9, 1));
-        assert_eq!(m["n.rs"], (5, 4));
+        assert_eq!(m["logo.png"], None);
+        assert_eq!(m["src/a.rs"], Some((9, 1)));
+        assert_eq!(m["n.rs"], Some((5, 4)));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -73,6 +73,10 @@ pub struct ChangedFile {
     /// The old path of a renamed file; `None` for every other kind. Its old content lives
     /// at this path, so a rename diffs real content instead of reading as all-insertion.
     pub previous_path: Option<String>,
+    /// Git's own no-text-diff verdict for this change: binary content, or a path whose
+    /// `diff` attribute `.gitattributes` unsets. The pane reads it as the `binary` notice
+    /// without reading either side (`specs/review-model.md`).
+    pub binary: bool,
 }
 
 /// Which side of the diff a comment's lines live on.

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -2993,6 +2993,48 @@ fn a_file_view_comment_exports_as_path_line_with_a_context_snippet() {
 }
 
 #[test]
+fn a_diff_unset_file_reads_as_the_binary_notice_not_a_text_diff() {
+    // `.gitattributes` `-diff` on a text file: git refuses to text-diff it, and the pane
+    // takes that verdict instead of re-deciding from content (`specs/review-model.md`).
+    use herdr_reviewr::diff::{FileState, View};
+    let r = Repo::init();
+    r.write(".gitattributes", "flake.lock -diff\n");
+    r.write("flake.lock", "one\ntwo\n");
+    r.commit_all("init");
+    r.write("flake.lock", "one\nTWO\n");
+
+    let mut app = app_on(&r);
+    let row = file_row_of(&app, "flake.lock").expect("flake.lock listed");
+    app.select_file(row).unwrap();
+
+    assert_eq!(app.diff.state, FileState::Binary);
+    assert_eq!(app.diff.view, View::Diff);
+    assert!(app.diff.rows.is_empty(), "a notice has no rows to comment on");
+    assert!(app.visible.is_empty());
+}
+
+#[test]
+fn a_diff_unset_file_in_all_files_still_reads_its_content() {
+    // The attribute governs diffing, not reading. `All files` shows the file itself, so a
+    // `-diff` text file stays readable there (`specs/diff-view.md` File view).
+    use herdr_reviewr::app::Tab;
+    use herdr_reviewr::diff::{FileState, View};
+    let r = Repo::init();
+    r.write(".gitattributes", "flake.lock -diff\n");
+    r.write("flake.lock", "one\ntwo\n");
+    r.commit_all("init");
+
+    let mut app = app_on(&r);
+    enter_tab(&mut app, Tab::AllFiles);
+    let row = file_row_of(&app, "flake.lock").expect("flake.lock listed");
+    app.select_file(row).unwrap();
+
+    assert_eq!(app.diff.state, FileState::Normal);
+    assert_eq!(app.diff.view, View::File);
+    assert!(app.diff.rows.iter().any(|row| row.text().contains("two")));
+}
+
+#[test]
 fn an_oversize_file_in_all_files_degrades_to_a_notice() {
     use herdr_reviewr::app::Tab;
     use herdr_reviewr::diff::{FileState, View};

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -33,6 +33,90 @@ fn merge_base(repo: &Path, base: Option<&str>) -> Option<String> {
 }
 
 #[test]
+fn a_path_the_diff_attribute_unsets_carries_gits_no_text_diff_verdict() {
+    // `.gitattributes` `-diff` makes git refuse to text-diff a path even though its bytes
+    // are text. The changeset must carry that verdict, not re-decide from content
+    // (`specs/review-model.md`).
+    let r = Repo::init();
+    r.write(".gitattributes", "lock.txt -diff\n");
+    r.write("lock.txt", "one\ntwo\n");
+    r.write("plain.txt", "one\ntwo\n");
+    r.commit_all("init");
+
+    r.write("lock.txt", "one\nTWO\n");
+    r.write("plain.txt", "one\nTWO\n");
+
+    let files = changed_files(r.path(), Scope::Uncommitted, None).unwrap();
+    let files = by_path(&files);
+
+    assert!(files["lock.txt"].binary, "-diff is git's no-text-diff verdict");
+    assert_eq!((files["lock.txt"].additions, files["lock.txt"].deletions), (0, 0));
+    assert!(!files["plain.txt"].binary, "an ordinary text file still diffs");
+    assert_eq!((files["plain.txt"].additions, files["plain.txt"].deletions), (1, 1));
+}
+
+#[test]
+fn the_binary_macro_and_real_binary_content_both_carry_the_verdict() {
+    let r = Repo::init();
+    r.write(".gitattributes", "packed.dat binary\n");
+    r.write("packed.dat", "text bytes\n");
+    r.write("logo.png", "\u{0}\u{1}png\n");
+    r.write("empty.txt", "");
+    r.commit_all("init");
+
+    r.write("packed.dat", "other text\n");
+    r.write("logo.png", "\u{0}\u{2}png\n");
+    r.write("empty.txt", "\n"); // a real change of one countable line
+
+    let files = changed_files(r.path(), Scope::Uncommitted, None).unwrap();
+    let files = by_path(&files);
+
+    assert!(files["packed.dat"].binary, "the `binary` macro unsets `diff`");
+    assert!(files["logo.png"].binary, "NUL bytes are git's own verdict too");
+    assert!(!files["empty.txt"].binary, "a countable change is never the verdict");
+}
+
+#[test]
+fn an_untracked_file_the_diff_attribute_unsets_carries_the_verdict_too() {
+    // The common shape right after an agent scaffolds a project: the lockfile is written and
+    // marked `-diff`, but nothing is committed yet. Identical bytes must not be treated
+    // differently for being untracked (`specs/review-model.md`).
+    let r = Repo::init();
+    r.write("keep.rs", "fn a() {}\n");
+    r.commit_all("init");
+    r.write(".gitattributes", "flake.lock -diff\n");
+    r.write("flake.lock", "one\ntwo\n");
+    r.write("notes.txt", "one\ntwo\n");
+
+    let files = changed_files(r.path(), Scope::Uncommitted, None).unwrap();
+    let files = by_path(&files);
+
+    assert_eq!(files["flake.lock"].kind, ChangeKind::Untracked);
+    assert!(files["flake.lock"].binary, "-diff holds for an untracked path");
+    assert!(!files["notes.txt"].binary, "an ordinary untracked file still diffs");
+    assert_eq!(files["notes.txt"].additions, 2);
+}
+
+#[test]
+fn an_untracked_binary_file_carries_the_verdict_from_its_content() {
+    // No numstat speaks for an untracked path, so content answers the half `.gitattributes`
+    // does not (`specs/review-model.md`).
+    let r = Repo::init();
+    r.write("keep.rs", "fn a() {}\n");
+    r.commit_all("init");
+    r.write("blob.bin", "\u{0}\u{1}\u{2}");
+    r.write("notes.txt", "one\ntwo\n");
+
+    let files = changed_files(r.path(), Scope::Uncommitted, None).unwrap();
+    let files = by_path(&files);
+
+    assert!(files["blob.bin"].binary);
+    assert_eq!(files["blob.bin"].additions, 0);
+    assert!(!files["notes.txt"].binary);
+    assert_eq!(files["notes.txt"].additions, 2);
+}
+
+#[test]
 fn lists_every_change_kind_with_stats() {
     let r = Repo::init();
     r.write("keep.rs", "fn a() {}\n");


### PR DESCRIPTION
A file marked `-diff` (or `binary`) in `.gitattributes` — a lockfile, a generated bundle —
opens as a full text diff today, even though git refuses to diff it.

`parse_numstat` folded git's `-`/`-` record into `0`/`0`, so the verdict was lost and the pane
re-decided from content with a NUL scan, which text bytes pass. Keeping the verdict on
`ChangedFile::binary` fixes it, and the pane paints the `binary` notice without reading either
side's blob. No new git call: `--numstat` was already telling us.

Untracked paths never reach a `git diff`, so they get one batched `check-attr` over the
scope's untracked set, skipped when it's empty. Worth the fork — an agent writes a lockfile
before anything is tracked, and identical bytes shouldn't behave differently by tracking
state.

`All files` still shows the file's content; the attribute governs diffing, not reading.

Cost is one fork, flat in path count: `changed_files` 26.6ms → 29.0ms on the pinned fixture,
`all_files` unchanged. A `-diff` file now costs no `git show` at all — on a repo whose one
change is a 1 MB `-diff` lockfile, `bench_tui.py` `tab_enter_changes` went 75.3ms → 50.5ms.

Out of scope: `textconv` drivers (the worktree side has no plumbing equivalent), and
`linguist-*`, which is GitHub's, not git's.

`just ci` clean. Two tests are flaky here independent of this branch —
`search_overlay::engine_worker_end_to_end` and
`pane_actions::the_cli_fallback_resolves_the_config_dir_when_the_env_names_none` — both
reproduce on a clean `main`; let me know if they're known.
