### PR TITLE
Resolve brew host tools in herdr panes without forwarding PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.32.1] — 2026-08-18
+
+### Fixed
+- **Brew-installed host tools resolve from any launch.** herdr starts plugin panes with a
+  PATH that omits Homebrew, so the PR tab reported `gh` as missing. Reviewr now looks up
+  and spawns host tools against the usual bin dirs plus the inherited PATH, so
+  `gh`/`glab`/`az` resolve however the pane was opened.
+
 ## [0.32.0] — 2026-08-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "herdr-reviewr"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-reviewr"
-version = "0.32.0"
+version = "0.32.1"
 edition = "2024"
 rust-version = "1.97"
 description = "A terminal review pane for herdr: browse an agent's changes and send comments back to chat."

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "persiyanov.reviewr"
 name = "reviewr"
-version = "0.32.0"
+version = "0.32.1"
 # Turn tracking resolves each agent's `cwd` from `herdr agent list` to decide worktree
 # membership, and `cwd` is only verified present from 0.7.5 (docs/herdr-api-notes.md). On an
 # older herdr every agent would parse with no `cwd`, and `last turn` would never track.

--- a/specs/herdr-host.md
+++ b/specs/herdr-host.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-23
-Last edited: 2026-08-13
+Last edited: 2026-08-18
 ---
 
 # herdr host
@@ -21,6 +21,8 @@ The binary paints its empty frame before the first git scan, so the pane never s
 | `HH-PLACEMENT-CONFIGURED` | Every action or event open uses the placement named by `toggle_placement`. |
 | `HH-TURN-PER-WORKTREE`    | A turn belongs to the worktree, never to one agent.                        |
 | `HH-LAUNCHER-BLIND`       | A reviewr pane behaves the same however it was created.                    |
+
+The reviewr process can resolve host tools in `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, and `/bin` however it was launched.
 
 ## Pane identity
 

--- a/src/azure_devops.rs
+++ b/src/azure_devops.rs
@@ -7,7 +7,6 @@
 //! writes to Azure DevOps.
 
 use std::path::Path;
-use std::process::Command;
 use std::sync::atomic::AtomicBool;
 
 use serde_json::Value;
@@ -92,7 +91,7 @@ fn az_json(
     args: &[&str],
     cancelled: &AtomicBool,
 ) -> Result<Value, AzError> {
-    let mut cmd = Command::new("az");
+    let mut cmd = crate::proc::command("az");
     cmd.current_dir(repo).args(args).args(["--organization", org_url, "--output", "json"]);
     let stdout = crate::forge::run_provider(
         &mut cmd,

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -3,7 +3,7 @@
 //! See `specs/forge-host.md` (external links). Mirrors the clipboard-tool probe in
 //! `export.rs`: the first platform opener on `PATH` wins; none present errors clearly.
 
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use anyhow::{Context, Result};
 
@@ -20,7 +20,7 @@ pub fn open(url: &str) -> Result<()> {
         .copied()
         .find(|t| crate::proc::on_path(t))
         .context("no URL opener found (need `open` or `xdg-open`)")?;
-    let status = Command::new(tool)
+    let status = crate::proc::command(tool)
         .arg(url)
         .stdin(Stdio::null())
         .stdout(Stdio::null())

--- a/src/export.rs
+++ b/src/export.rs
@@ -5,7 +5,7 @@
 //! a comment only after `export` returns `Ok`.
 
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use anyhow::{Context, Result, bail};
 
@@ -83,7 +83,7 @@ impl ExportTarget for Clipboard {
             "no clipboard tool found (install wl-clipboard, xclip, or xsel) — \
              use Send instead",
         )?;
-        let mut child = Command::new(cmd)
+        let mut child = crate::proc::command(cmd)
             .args(args)
             .stdin(Stdio::piped())
             .spawn()

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -380,7 +380,7 @@ fn run_cli(cmd: &mut Command, cancelled: &AtomicBool) -> Result<String, CliError
 
 /// Run explicitly targeted `gh` arguments in `repo` and return stdout or a classified failure.
 fn gh(repo: &Path, host: &str, args: &[&str], cancelled: &AtomicBool) -> Result<String, GhError> {
-    let mut cmd = Command::new("gh");
+    let mut cmd = crate::proc::command("gh");
     cmd.current_dir(repo).args(args);
     run_provider(
         &mut cmd,

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,7 +5,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 
@@ -13,7 +12,7 @@ use crate::model::{ChangeKind, ChangedFile, Scope};
 
 /// Run `git -C <repo> <args>` and return stdout. Errors on non-zero exit.
 fn git(repo: &Path, args: &[&str]) -> Result<String> {
-    let out = Command::new("git")
+    let out = crate::proc::command("git")
         .arg("-C")
         .arg(repo)
         .args(["-c", "core.quotepath=false"])
@@ -28,7 +27,7 @@ fn git(repo: &Path, args: &[&str]) -> Result<String> {
 
 /// Like [`git`], but returns stdout even on non-zero exit (e.g. `diff --no-index`).
 fn git_lenient(repo: &Path, args: &[&str]) -> String {
-    Command::new("git")
+    crate::proc::command("git")
         .arg("-C")
         .arg(repo)
         .args(["-c", "core.quotepath=false"])
@@ -41,7 +40,7 @@ fn git_lenient(repo: &Path, args: &[&str]) -> String {
 /// Run `git -C <repo> <args>` and return its trimmed stdout, or `None` if the command fails to
 /// spawn, exits non-zero, or prints nothing. The one-line query workhorse for `rev-parse`/`merge-base`.
 fn git_line(repo: &Path, args: &[&str]) -> Option<String> {
-    let out = Command::new("git").arg("-C").arg(repo).args(args).output().ok()?;
+    let out = crate::proc::command("git").arg("-C").arg(repo).args(args).output().ok()?;
     if !out.status.success() {
         return None;
     }
@@ -51,7 +50,12 @@ fn git_line(repo: &Path, args: &[&str]) -> Option<String> {
 
 /// Whether `git -C <repo> <args>` spawns and exits zero. The predicate workhorse for existence checks.
 fn git_ok(repo: &Path, args: &[&str]) -> bool {
-    Command::new("git").arg("-C").arg(repo).args(args).output().is_ok_and(|o| o.status.success())
+    crate::proc::command("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .is_ok_and(|o| o.status.success())
 }
 
 /// Whether `path` is inside a git work tree.
@@ -81,7 +85,12 @@ pub enum Worktree {
 
 /// Resolve `path` to its worktree, distinguishing the two ways resolution yields no root.
 pub fn worktree_of(path: &Path) -> Worktree {
-    match Command::new("git").arg("-C").arg(path).args(["rev-parse", "--show-toplevel"]).output() {
+    match crate::proc::command("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+    {
         Err(_) => Worktree::Unknown,
         Ok(out) if !out.status.success() => Worktree::Outside,
         Ok(out) => match String::from_utf8_lossy(&out.stdout).trim() {
@@ -430,7 +439,7 @@ pub struct GitFail(pub String);
 /// Spawn one PR-fetch git read. `LC_ALL=C` pins Git's messages to English — remote discovery
 /// classifies a missing remote by stderr text, which Git otherwise localizes.
 fn run_git(repo: &Path, args: &[&str]) -> Result<std::process::Output, GitFail> {
-    Command::new("git")
+    crate::proc::command("git")
         .arg("-C")
         .arg(repo)
         .env("LC_ALL", "C")
@@ -950,7 +959,7 @@ pub fn clear_base_pick(repo: &Path) -> Result<(), GitFail> {
 fn git_stdin(repo: &Path, args: &[&str], input: &str) -> Result<String, GitFail> {
     use std::io::Write;
     use std::process::Stdio;
-    let mut child = Command::new("git")
+    let mut child = crate::proc::command("git")
         .arg("-C")
         .arg(repo)
         .env("LC_ALL", "C")
@@ -1032,7 +1041,7 @@ impl Drop for TempIndex<'_> {
 /// Like [`git`], but runs against a throwaway index via `GIT_INDEX_FILE` so the snapshot
 /// never disturbs the repo's real index.
 fn git_with_index(repo: &Path, index: &Path, args: &[&str]) -> Result<String> {
-    let out = Command::new("git")
+    let out = crate::proc::command("git")
         .arg("-C")
         .arg(repo)
         .args(["-c", "core.quotepath=false"])

--- a/src/gitlab.rs
+++ b/src/gitlab.rs
@@ -6,7 +6,6 @@
 //! same normalized [`PrSnapshot`] the GitHub provider does. It never writes to GitLab.
 
 use std::path::Path;
-use std::process::Command;
 use std::sync::atomic::AtomicBool;
 
 use serde_json::Value;
@@ -89,7 +88,7 @@ fn glab_raw(
     endpoint: &str,
     cancelled: &AtomicBool,
 ) -> Result<String, GlabError> {
-    let mut cmd = Command::new("glab");
+    let mut cmd = crate::proc::command("glab");
     cmd.current_dir(repo).args(glab_args(host, endpoint));
     crate::forge::run_provider(
         &mut cmd,

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -10,7 +10,6 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::process::Command;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
@@ -84,7 +83,7 @@ fn herdr_bin() -> String {
 /// own or drops it. So the whole of it — the argv, which carries a review's text in `pane
 /// send-text`, and herdr's JSON error envelope — goes to the log and only there.
 fn herdr(args: &[&str]) -> Result<String> {
-    let out = match Command::new(herdr_bin()).args(args).output() {
+    let out = match crate::proc::command(herdr_bin()).args(args).output() {
         Ok(out) => out,
         Err(e) => {
             logln!("herdr {args:?} could not run: {e}");

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1,10 +1,88 @@
 //! Small helpers for locating external command-line tools.
 
-/// Whether `name` resolves to an executable on `PATH` — a dependency-free `which`. Both shipped
-/// platforms are unix, so a file in a `PATH` directory is the executable. Shared by the clipboard
-/// probe (`export.rs`) and the URL-opener probe (`browser.rs`).
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Usual host bin dirs a stripped pane PATH may omit (`specs/herdr-host.md` HH-LAUNCHER-BLIND).
+const COMMON_BINS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"];
+
+fn host_path() -> OsString {
+    prepended_path(env::var_os("PATH").as_deref())
+}
+
+fn prepended_path(inherited: Option<&OsStr>) -> OsString {
+    let mut path = OsString::from(COMMON_BINS.join(":"));
+    if let Some(inherited) = inherited
+        && !inherited.is_empty()
+    {
+        path.push(":");
+        path.push(inherited);
+    }
+    path
+}
+
+fn resolve_on(path: &OsStr, name: &OsStr) -> Option<PathBuf> {
+    let as_path = Path::new(name);
+    if as_path.is_absolute() || as_path.parent().is_some_and(|p| !p.as_os_str().is_empty()) {
+        return as_path.is_file().then(|| as_path.to_path_buf());
+    }
+    env::split_paths(path).find_map(|dir| {
+        let candidate = dir.join(name);
+        candidate.is_file().then_some(candidate)
+    })
+}
+
+/// Resolve `program` on the host PATH and give the child that same PATH
+/// (`specs/herdr-host.md` HH-LAUNCHER-BLIND).
+pub(crate) fn command(program: impl AsRef<OsStr>) -> Command {
+    let program = program.as_ref();
+    let path = host_path();
+    let mut cmd = resolve_on(&path, program).map_or_else(|| Command::new(program), Command::new);
+    cmd.env("PATH", path);
+    cmd
+}
+
+/// Whether `name` resolves to an executable on the host PATH — a dependency-free `which`. Both
+/// shipped platforms are unix, so a file in a host-PATH directory is the executable. Shared by
+/// the clipboard probe (`export.rs`) and the URL-opener probe (`browser.rs`).
 #[must_use]
 pub fn on_path(name: &str) -> bool {
-    std::env::var_os("PATH")
-        .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join(name).is_file()))
+    resolve_on(&host_path(), OsStr::new(name)).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{COMMON_BINS, prepended_path, resolve_on};
+    use std::env;
+    use std::ffi::OsStr;
+    use std::path::PathBuf;
+
+    #[test]
+    fn prepended_path_puts_the_common_bins_in_front_of_the_inherited_path() {
+        let got = prepended_path(Some(OsStr::new("/usr/bin:/bin")));
+        let parts: Vec<PathBuf> = env::split_paths(&got).collect();
+        let mut expected: Vec<PathBuf> = COMMON_BINS.iter().map(PathBuf::from).collect();
+        expected.extend([PathBuf::from("/usr/bin"), PathBuf::from("/bin")]);
+        assert_eq!(parts, expected);
+    }
+
+    #[test]
+    fn prepended_path_keeps_the_common_bins_when_nothing_is_inherited() {
+        let got = prepended_path(None);
+        let parts: Vec<PathBuf> = env::split_paths(&got).collect();
+        let expected: Vec<PathBuf> = COMMON_BINS.iter().map(PathBuf::from).collect();
+        assert_eq!(parts, expected);
+    }
+
+    #[test]
+    fn resolve_on_finds_a_bare_name_in_a_path_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("gh");
+        std::fs::write(&bin, []).unwrap();
+        let path = env::join_paths([dir.path(), PathBuf::from("/usr/bin").as_path()]).unwrap();
+        assert_eq!(resolve_on(&path, OsStr::new("gh")).as_deref(), Some(bin.as_path()));
+        assert!(resolve_on(&path, OsStr::new("missing")).is_none());
+    }
 }


### PR DESCRIPTION
## Problem

#70: the PR tab shows `GitHub CLI not found` for a brew-installed `gh` at `/opt/homebrew/bin/gh`. herdr starts plugin panes with a PATH that omits Homebrew. `git` still works because it lives in `/usr/bin`. The same miss hits any brew tool the pane runs by name (`glab`, `az`, …).

#71 forwarded `pane.sh`'s PATH via `plugin pane open --env`. That only helps action-opened panes and breaks `HH-LAUNCHER-BLIND`.

## Change

Host-tool lookup lives in `src/proc.rs`. `command` and `on_path` walk `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin` plus the inherited PATH, spawn the resolved path, and give the child that same PATH so wrappers (`gh` → `git`) still find helpers.

Production `git` / `gh` / `glab` / `az` / clipboard / `open` / `herdr` go through it. Process env is not mutated (`unsafe_code` stays `forbid`). `pane.sh` is unchanged.

Spec: one sentence under `HH-LAUNCHER-BLIND`. Versions and changelog are `0.32.1`.

## Not this PR

- Merging #71
- Folding `pane.sh` into the binary
- Login-shell PATH scrape, mise/nix/`~/.local/bin`

## Verify

- `just ci` green
- `/bundled:review` and `/code-review` iterated to green
- `just qa-install` done; running panes still need a close/reopen, then `3` `r` on a brew-`gh` repo

Fixes #70.