### PR TITLE
Let the base picker take any git revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.33.0] — 2026-08-19
+
+### Added
+- **Typed base revisions.** The pick-base menu (`B`) takes any git revision, not only named
+  branches: `HEAD~1`, a tag, a unique SHA prefix
+  ([#75](https://github.com/persiyanov/herdr-reviewr/issues/75)). Named spellings re-resolve
+  like git, so a later commit still diffs one back; the header reads `vs HEAD~1 (a1b2c3d)`.
+  Type a SHA to freeze that commit; the header shows the abbrev once.
+
+### Changed
+- A unique SHA prefix shorter than seven characters completes to the abbreviated object id.
+  A pasted 40-hex stays a pin.
+
 ## [0.32.1] — 2026-08-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "herdr-reviewr"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-reviewr"
-version = "0.32.1"
+version = "0.33.0"
 edition = "2024"
 rust-version = "1.97"
 description = "A terminal review pane for herdr: browse an agent's changes and send comments back to chat."

--- a/README.md
+++ b/README.md
@@ -270,8 +270,13 @@ When the trunk is something else, or you review a stacked branch, press `B` (or 
 base name) and pick the branch. The pick is stored in the repo, shared by every reviewr pane
 on it, and holds until you pick again. Choosing the default branch clears it.
 
-`--base <ref>` pins the base for the pane and takes any rev (a branch, a tag, a SHA). It
-wins over the pick and disables the picker.
+You can also type a revision the list does not contain. `HEAD~2` and a tag keep that
+spelling and re-resolve like git, so a later commit still diffs one back; the header shows
+`vs HEAD~2 (a1b2c3d)`. A unique SHA prefix completes to the abbreviated SHA. Type a SHA
+(or paste a full object id) to freeze that commit; the header shows `vs a1b2c3d`.
+
+`--base <ref>` sets the base for this pane and takes any rev (a branch, a tag, a SHA,
+`HEAD~1`). It wins over the pick and disables the picker.
 
 A picked branch that is gone (deleted after a stacked review, or a typo) is skipped, and the
 header says so: `vs main · dev missing`. When nothing resolves, the scope stays empty and the

--- a/docs/plans/2026-08-19-typed-base-rev/plan.md
+++ b/docs/plans/2026-08-19-typed-base-rev/plan.md
@@ -1,0 +1,74 @@
+# Typed base revision: Plan
+
+Delivers `specs/review-model.md` Base branch, `specs/input.md` Base picker, and `specs/tui.md` header paint (issue #75).
+
+## Problem
+
+The picker stores a typed `HEAD~1` or tag as a frozen object id. A branch picked from the same list still follows. The header then shows only the hash, so `qa-pin-base` and `HEAD~1` are indistinguishable from a SHA and do not mean what git means.
+
+## Goal
+
+The pick is the spelling the reviewer named. It re-resolves like git. The header is `vs HEAD~1 (a1b2c3d)` unless the spelling is already that SHA. A SHA is a pin because it is the spelling.
+
+## Definition of Done
+
+- [x] Typing `HEAD~1` stores `HEAD~1`. The header reads `vs HEAD~1 (` plus the abbreviated SHA plus `)`. A later commit still diffs one back, and the hash in the header moves.
+- [x] A tag stores the tag name and re-resolves. A unique short SHA stores that short spelling and paints once, `vs a1b2c3d`.
+- [x] A listed branch still follows. Choosing the default row still clears.
+- [x] The probe row is the typed spelling, marked `(a1b2c3d)` unless the spelling is already a prefix of that SHA. Enter writes the spelling, not the object id.
+- [x] Reopening with a non-branch pick highlights a row named with that spelling.
+- [x] A spelling that does not resolve is skipped as `· HEAD~1 missing` and reactivates when it resolves again.
+- [x] `--base HEAD~1` paints the same `vs HEAD~1 (a1b2c3d)` form.
+- [x] README Base branch names live spellings and that a SHA is the freeze.
+
+## Out of Scope
+
+- PR-target auto-follow. Open decision in `specs/review-model.md`.
+- Origin-vs-local order. Open decision in `specs/review-model.md`.
+- Listing tags, reflog, or recent commits. Non-goal in `specs/input.md`.
+- Changing default-row-clears, the popup title, or miss copy.
+- Rewriting 40-hex picks already on disk. They remain SHA spellings and stay pins.
+- Release packaging.
+
+## Execution Plan
+
+1. [x] `src/git.rs`: `read_base_pick` admits one printable line that does not start with `-`. `HEAD~1`, a tag, and a short SHA are picks. Control bytes are still none. Rewrite `a_pick_git_could_never_have_written_is_no_pick` in `tests/git_repo.rs` so `main~5` is a spelling.
+
+2. [x] `src/git.rs`: a branch pick uses origin then local; anything else (`HEAD~1`, a tag, a SHA) uses `resolve_commit`. `ResolvedBase.name` is the stored spelling, never the abbreviated oid. `--base` keeps the stripped spelling as the name when it is not a branch. Tests in `tests/git_repo.rs`: write `HEAD~1`, a new commit moves the merge-base, a unique short SHA still resolves to that object, a tree-ish is skipped.
+
+3. [x] `src/app.rs`: `run_base_probe` names the Hit row with the query spelling and keeps `oid` for the marker. `base_picker_pick` writes `choice.name` for every non-default row. `open_base_picker` inserts the current pick when it is not a branch, using the stored spelling. Tests in `tests/app_flow.rs` replace pin-oid assertions with spelling assertions.
+
+4. [x] `src/ui.rs`: `base_label` / `base_parts` paint `vs HEAD~1 (a1b2c3d)`, paint a SHA spelling once, and clip the spelling before `(sha)`. `base_trail` shows `(a1b2c3d)` on a non-branch row whose name is not a prefix of its oid. Tests in `tests/render.rs` beside the named-rev paint.
+
+5. [x] `README.md` Base branch: typed revs keep their names and re-resolve. A SHA is the freeze.
+
+6. [x] Tests in the same commits as the code they check. `just ci`. QA: `just qa-install`, type `HEAD~1` and `qa-pin-base`, commit, confirm the names stay and the hashes move.
+
+## Likely Files
+
+| file                | change                                          |
+| ------------------- | ----------------------------------------------- |
+| `src/git.rs`        | pick shape, pick arm name, `--base` name        |
+| `src/app.rs`        | probe row spelling, write name, current-pick row |
+| `src/ui.rs`         | `vs HEAD~1 (sha)`, trail marker, clip           |
+| `README.md`         | Base branch                                     |
+| `tests/git_repo.rs` | live `HEAD~1`, short SHA, skip                  |
+| `tests/app_flow.rs` | store spelling, reopen row                      |
+| `tests/render.rs`   | header paint                                    |
+
+## Verification
+
+- `cargo test --test git_repo` → `HEAD~1` stored as `HEAD~1`, merge-base moves after a commit, a 40-hex pick still pins, a tree-ish is skipped.
+- `cargo test --test app_flow` → type `HEAD~1` writes `HEAD~1`, probe row is that spelling, reopen highlights it, default-row clear unchanged.
+- `cargo test --test render` → `vs HEAD~1 (`sha`)`, SHA-once, branch `vs main` unchanged.
+- No-writes: the persistence test asserts the only new ref is `refs/reviewr/base-pick`.
+- `just ci` green.
+- Tight: everything the diff adds is exercised by a DoD line.
+- [x] Gate: promote `specs/review-model.md`, `specs/input.md`, `specs/tui.md` to Current.
+
+## Replan
+
+- If a live `HEAD~1` header without the hash is unreadable in QA, do not pin. Keep `(sha)` as the witness.
+- 2026-08-19: store the named spelling and re-resolve. A SHA is the only pin. Replaces the pin-on-type plan.
+- 2026-08-19: probe only when the filter matches no row, after typing pauses. Enter with no row checks immediately.
+- 2026-08-19: initial plan (pin typed revs to a SHA).

--- a/examples/bench_latency.rs
+++ b/examples/bench_latency.rs
@@ -53,7 +53,8 @@ fn main() {
         "changed_files (branch, incl. resolve)",
         sample(5, || {
             let base = git::resolve_base(&repo, None).ok().and_then(|r| r.status.winner);
-            git::changed_files(&repo, Scope::Branch, base.map(|w| w.oid).as_deref()).unwrap();
+            git::changed_files(&repo, Scope::Branch, base.as_ref().map(git::ResolvedBase::oid))
+                .unwrap();
         }),
     );
     let all = git::all_files(&repo).unwrap();

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "persiyanov.reviewr"
 name = "reviewr"
-version = "0.32.1"
+version = "0.33.0"
 # Turn tracking resolves each agent's `cwd` from `herdr agent list` to decide worktree
 # membership, and `cwd` is only verified present from 0.7.5 (docs/herdr-api-notes.md). On an
 # older herdr every agent would parse with no `cwd`, and `last turn` would never track.

--- a/policies/ux-responsiveness.md
+++ b/policies/ux-responsiveness.md
@@ -20,3 +20,4 @@ reviewr runs live beside a working agent, so every action must feel instant and 
 - A genuinely slow or hung external call (git under a busy agent, `gh`) may show a delayed loading state and, while it is outstanding, wake the loop more often to deliver promptly.
 - A large file or a first-visit diff may pay a one-time inline cost when async prefetch is not warranted; note it rather than building speculative machinery.
 - Opening the base picker reads its branch list inline, measured at ~30ms (`specs/input.md`). This is a deliberate, permanent exception: an async open would either flash an empty list or blank the frame, both of which this policy forbids above.
+- Checking a non-empty base-picker query that matches no row as a git revision runs after a 150ms pause, or immediately on Enter. Same class as opening the picker: the row must exist before the next keystroke can pick it.

--- a/specs/input.md
+++ b/specs/input.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-07-17
-Last edited: 2026-08-17
+Last edited: 2026-08-19
 ---
 
 # Input
@@ -221,7 +221,7 @@ A plain-text field that edits at the caret, not only at the end. The search inpu
 | `Enter` / `Esc`                                 | save / cancel, cancel discards the draft         |
 
 - A paste arrives whole via bracketed paste. A multi-line paste keeps its newlines. `\r\n` and `\r` normalize to `\n`.
-- A paste outside the comment editor and the search input is ignored. It never starts or mutates a comment.
+- A paste outside the comment editor, the search input, the find input, and the base picker's filter is ignored. It never starts or mutates a comment.
 - Movement, insertion, and deletion are character-wise. Multi-byte and wide characters count as whole characters.
 - The terminal cursor follows every field's caret in display cells, anchoring an IME candidate
   window after wide characters.
@@ -255,27 +255,34 @@ Only the unmodified `enter` sends. `Alt+Enter` and `Shift+Enter` insert a newlin
 
 ### Base picker
 
-`base-pick` opens the picker over the body, like the comments list (`tui.md`). It works on the file tabs while the `branch` scope is active and no `--base` flag was passed. Elsewhere it is inert and stays out of the footer. While the comment editor is open, the base-name click is inert like the key.
+`base-pick` opens the picker over the body, like the comments list (`tui.md`). It works on the file tabs while the `branch` scope is active and no `--base` flag was passed. Elsewhere it is inert and stays out of the footer. While the comment editor is open, the base-name click is inert like the key. The picker still lists branches. It also opens when that list is empty, so a revision can be typed.
 
 The list holds one row per branch name, remote-tracking and local names merged. The checked-out branch is not listed, unless it is the default branch, whose row must stay reachable to clear a pick. Rows sort by most recent commit. Two rows outrank that order:
 
 - The open PR's target sorts first, starred (`forge-host.md`).
-- The default branch sorts next, marked `default`. Choosing it clears the pick (`review-model.md`).
+- The default branch sorts next, marked `default`. Choosing it clears the pick (`review-model.md`). Choosing a revision that resolves to the same commit does not.
 
-The highlight opens on the current base, else the first row. The highlight is place state (`overview.md`).
+When the current base is a spelling that is not a listed branch name, that spelling is a row. The highlight opens on it. Otherwise the highlight opens on the current base among the branch rows, else the first row. The highlight is place state (`overview.md`).
 
-| key                 | does                                            |
-| ------------------- | ----------------------------------------------- |
-| typed character     | narrow the list, matching anywhere in the name  |
-| `↓` / `↑`           | move the highlight                              |
-| `ctrl+n` / `ctrl+p` | move the highlight                              |
-| `enter`             | pick the highlighted branch                     |
-| `esc`               | cancel                                          |
+The query is checked as a commit only when the filter matches no row, and only after typing pauses. A unique abbreviated SHA, a tag, and `HEAD~1` all resolve. An ambiguous SHA prefix does not. A unique SHA prefix shorter than the abbreviated object id completes to that abbreviation — the row is `a1b2c3d`, not the typed prefix. A full object id, an already-abbreviated SHA, a tag, and `HEAD~1` keep the typed spelling. The highlight sits on that row. Choosing it stores that name (`review-model.md`).
 
-The filter is a text field with the comment editor's controls, above. `↑` and `↓` move the highlight, so the single-line filter keeps `←` and `→` for its caret. A pasted newline drops, so a branch name copied with its line ending filters as the bare name.
+A non-branch row is marked `(a1b2c3d)`. A SHA spelling paints as that abbreviated SHA and carries no marker. The marker is not a separate target. A click picks the spelling.
 
-- A click moves the highlight. A click on the highlighted row picks.
-- A filter matching no branch shows `no branches match`, and `enter` does nothing.
+| key                 | does                                                                 |
+| ------------------- | -------------------------------------------------------------------- |
+| typed character     | narrow the list, matching anywhere in the name                       |
+| `↓` / `↑`           | move the highlight                                                   |
+| `ctrl+n` / `ctrl+p` | move the highlight                                                   |
+| `enter`             | pick the highlighted row. With no row, check the query and pick it   |
+| `esc`               | cancel                                                               |
+
+The filter is a text field with the comment editor's controls, above. `↑` and `↓` move the highlight, so the single-line filter keeps `←` and `→` for its caret. A pasted newline drops, so a name copied with its line ending filters as the bare name.
+
+- A click moves the highlight. A click on the highlighted row picks. Every other gesture is inert, and none reaches the view behind.
+- An empty filter shows a dim `filter or type a revision` placeholder.
+- A filter matching no row shows `no branches match` once the query has been checked and is not a commit. Enter does nothing.
+- Enter with no highlighted row checks the query immediately. A resolving spelling is recorded. A miss stays on `no branches match`.
+- An empty query with no rows shows `type a revision`, and `enter` does nothing.
 - A pick applies immediately: the changeset rebuilds and the header renames (`review-model.md`).
 - A picker taller than the pane scrolls with the highlight.
 
@@ -285,6 +292,7 @@ The filter is a text field with the comment editor's controls, above. `↑` and 
 - No multi-key sequence bindings. A binding is one key, alone or with a `ctrl+`/`alt+` prefix.
 - No `down` / `up` crossing at a file's edges. The line cursor clamps there.
 - The `?` expansion omits the navigator-resize keys, the half-page keys, and the `expand` / `collapse` keys. Resizing is a divider drag first, and the fold and scroll meanings are contextual row-1 actions.
+- The base picker does not list tags, reflog entries, or recent commits. A revision that is not a branch is named by typing it.
 
 ## Related specs
 

--- a/specs/review-model.md
+++ b/specs/review-model.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-23
-Last edited: 2026-08-08
+Last edited: 2026-08-19
 ---
 
 # Review model
@@ -39,24 +39,27 @@ A scope selects which changes `Changes` shows and which files `All files` annota
 
 ### Base branch
 
-The `branch` scope diffs against the merge-base of the base branch and `HEAD`. The base is always a recorded choice, never inferred. The first source that resolves wins:
+The `branch` scope diffs against the merge-base of the base and `HEAD`. The base is always a recorded choice, never inferred. The first source that resolves wins:
 
-| # | source              | base is                                            |
-| - | ------------------- | -------------------------------------------------- |
-| 1 | `--base <ref>` flag | any rev, resolved verbatim, else as a branch name  |
-| 2 | the repo pick       | the branch chosen in the base picker (`input.md`)  |
-| 3 | `origin/HEAD`       | the default branch it names, when present          |
+| # | source              | base is                                              |
+| - | ------------------- | ---------------------------------------------------- |
+| 1 | `--base <ref>` flag | any rev, resolved verbatim, else as a branch name    |
+| 2 | the repo pick       | the revision named in the base picker (`input.md`)   |
+| 3 | `origin/HEAD`       | the default branch it names, when present            |
 
-A branch name resolves through `refs/remotes/origin/<name>`, then `refs/heads/<name>`. A leading `refs/heads/`, `refs/remotes/origin/`, or `origin/` prefix on a `--base` name is stripped first. A source that resolves to no ref is skipped, never an error. When no source resolves, `branch` shows nothing and the footer offers the picker (`input.md`). The other scopes are unaffected.
+A branch name resolves through `refs/remotes/origin/<name>`, then `refs/heads/<name>`. A leading `refs/heads/`, `refs/remotes/origin/`, or `origin/` prefix on a `--base` branch name is stripped first. A `--base` rev that is not a branch keeps the flag spelling, so `origin/HEAD` does not paint as live `HEAD`. A source that does not resolve to a commit is skipped, never an error. A spelling that starts with `-` does not resolve. When no source resolves, `branch` shows nothing and the footer offers the picker (`input.md`). The other scopes are unaffected.
 
 The pick:
 
-- The pick is one branch name per repository, shared by its worktrees.
+- The pick is one revision spelling per repository, shared by its worktrees.
+- A recorded spelling is one printable line. A blob that is not that shape is no pick.
+- A pick that is a branch name resolves through origin then local. Any other pick, `HEAD` included, resolves verbatim to a commit, the same first arm as `--base`. Two worktrees that record `HEAD~1` each diff against one commit back from that worktree's `HEAD`.
+- A SHA spelling is a pin because it is the spelling. A unique SHA prefix shorter than the abbreviated object id is recorded as that abbreviation. A full object id is kept as typed. `HEAD~1` and a tag keep their names and re-resolve. Type `HEAD~1`, and a new commit still diffs one back. Type the hash to freeze that moment.
 - The pick persists in a private ref under `refs/reviewr/` and survives pane restarts (`overview.md`).
 - The pick applies only after its ref write lands.
 - The pick reaches every other pane of the repository at that pane's next refresh.
 - The pick clears when the chosen branch is the one `origin/HEAD` names.
-- The pick is kept and skipped while its branch does not resolve. It reactivates when the branch resolves again.
+- The pick is kept and skipped while its spelling does not resolve. It reactivates when the spelling resolves again.
 - The pick can only be replaced, never cleared, in a repository with no default branch.
 
 The header names the base while the `branch` scope is active (`tui.md`). A base change rebuilds the changeset on the next frame, never waiting for a poll.
@@ -160,6 +163,7 @@ How the agent pane is found and filled is in `herdr-host.md`.
 - No auto-submit of the agent prompt.
 - No inferred base branch. The reflog and the commit graph never choose a base.
 - No global base list. A base is chosen per repository, never once for every repository.
+- No conversion of a named revision to a SHA at pick time. A SHA is a pin because that is what was named.
 
 ## Related specs
 

--- a/specs/tui.md
+++ b/specs/tui.md
@@ -1,7 +1,7 @@
 ---
 Status: Current
 Created: 2026-06-23
-Last edited: 2026-08-08
+Last edited: 2026-08-19
 ---
 
 # TUI
@@ -28,9 +28,10 @@ The terminal frame: the pane layout, the tabs, and how the view stays current.
 
 - The header carries the three tabs with the active one highlighted, the active scope, and the changed-file count with the scope's `+added −removed` totals, right-aligned one cell off the pane edge.
 - The `All files` tab's header label reads `Files`.
-- On the `branch` scope the header names the base after the scope, `vs dev`, the bare branch name however it resolved. Clicking it opens the base picker (`input.md`). With no resolving base it reads `no base`.
-- A skipped pick or `--base` shows after the base, `vs main · dev missing` — and after the empty state too, `no base · dev missing`, so a dormant choice never reads as never-chosen.
-- A base name the header cannot fit truncates with a trailing `…`. The picker always shows it whole. Too narrow for even one column of the name, the base leaves the header rather than paint a nameless `vs`.
+- On the `branch` scope the header names the base after the scope. Clicking it opens the base picker (`input.md`). With no resolving base it reads `no base`.
+- A branch-name base paints `vs dev`. Any other resolving spelling paints `vs HEAD~1 (a1b2c3d)`. A spelling that is already a prefix of that SHA paints once, `vs a1b2c3d`. The `--base` flag uses the same paint.
+- A skipped pick or `--base` shows after the base, `vs main · dev missing` — and after the empty state too, `no base · dev missing`, so a dormant choice never reads as never-chosen. A skipped non-branch spelling uses the stored spelling, `· HEAD~1 missing`.
+- A base name the header cannot fit truncates with a trailing `…`. A `spelling (sha)` base clips the spelling and keeps `(sha)` when `(sha)` still fits. The picker always shows it whole. Too narrow for even one column of the name, the base leaves the header rather than paint a nameless `vs`.
 - The header's line totals drop a zero side and vanish when nothing changed, like a file row's stats (`file-list.md`).
 - The active tab sets both panes: diff and changed files in `Changes`, content and repo tree in `All files`, checks and comments in `PR` (`diff-view.md`, `pr-tab.md`).
 - The comment input opens inline, directly under the last line of the selection, and grows as you type (`input.md`). It is never a footer band.

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 
@@ -27,6 +28,9 @@ const DEFAULT_STACK_PCT: u16 = 25;
 const MIN_NAVIGATOR_PCT: u16 = 15;
 const MAX_SIDE_PCT: u16 = 60;
 const MAX_STACK_PCT: u16 = 50;
+/// Pause after the last filter edit before probing an empty list as a rev
+/// (`specs/input.md` Base picker).
+const BASE_PROBE_DELAY: Duration = Duration::from_millis(150);
 /// The search screen's results-pane share: half the body by default, dragged within
 /// wide bounds — the geometry's minimum pane sizes clamp the rest (specs/search.md).
 const DEFAULT_SEARCH_PCT: u16 = 50;
@@ -123,35 +127,81 @@ struct ArmedCross {
 /// at open; the filter and highlight are the reviewer's own place state.
 #[derive(Clone, Debug)]
 pub struct BasePicker {
-    /// Every pickable branch name: the open PR's target starred first, the default branch
-    /// next, the rest by commit recency, the checked-out branch excluded.
+    /// Pickable rows: branches (PR target starred first, default next, recency, checked-out
+    /// excluded) plus a current non-branch spelling so the highlight can open on it.
     pub rows: Vec<BaseChoice>,
-    /// The highlighted row, an index into the filtered view.
+    /// The highlighted row, an index into the visible view.
     pub cursor: usize,
     /// The typed filter, matching anywhere in the name.
     pub query: String,
     /// The caret in `query`, a char index — the filter edits with the comment editor's
     /// controls, like every other text field (`specs/input.md`).
     pub caret: usize,
+    /// Empty-list commit probe (`specs/input.md` Base picker).
+    pub probe: BaseProbe,
+}
+
+/// Empty-list commit probe while the base picker is open (`specs/input.md`).
+#[derive(Clone, Debug, Default)]
+pub enum BaseProbe {
+    #[default]
+    Idle,
+    Pending(Instant),
+    Hit(BaseChoice),
+    Miss,
 }
 
 /// One base picker row (`specs/input.md` Base picker).
 #[derive(Clone, Debug)]
-pub struct BaseChoice {
-    pub name: String,
-    /// The open PR's target, shown starred.
-    pub starred: bool,
-    /// The default branch, marked `default`. Choosing it clears the pick
-    /// (`specs/review-model.md`).
-    pub is_default: bool,
+pub enum BaseChoice {
+    Branch { name: String, starred: bool, is_default: bool },
+    Rev { name: String, oid: String },
+}
+
+impl BaseChoice {
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Branch { name, .. } | Self::Rev { name, .. } => name,
+        }
+    }
+
+    #[must_use]
+    pub fn starred(&self) -> bool {
+        matches!(self, Self::Branch { starred: true, .. })
+    }
+
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Branch { is_default: true, .. })
+    }
+
+    #[must_use]
+    pub fn oid(&self) -> Option<&str> {
+        match self {
+            Self::Rev { oid, .. } => Some(oid),
+            Self::Branch { .. } => None,
+        }
+    }
 }
 
 impl BasePicker {
-    /// The filtered view: indices into `rows` whose name contains the query, matched
-    /// case-insensitively and anywhere in the name (`specs/input.md` Base picker).
+    /// Frozen rows whose name contains the query, matched case-insensitively and
+    /// anywhere in the name (`specs/input.md` Base picker).
     pub fn filtered(&self) -> Vec<usize> {
         let q = self.query.to_lowercase();
-        (0..self.rows.len()).filter(|&i| self.rows[i].name.to_lowercase().contains(&q)).collect()
+        (0..self.rows.len()).filter(|&i| self.rows[i].name().to_lowercase().contains(&q)).collect()
+    }
+
+    /// The on-screen rows: a live probe hit, else the frozen matches (`specs/input.md`).
+    pub fn visible(&self) -> Vec<&BaseChoice> {
+        let matched = self.filtered();
+        if let BaseProbe::Hit(probe) = &self.probe
+            && matched.is_empty()
+        {
+            return vec![probe];
+        }
+        matched.into_iter().map(|i| &self.rows[i]).collect()
     }
 }
 
@@ -1295,7 +1345,7 @@ impl App {
                     .branch_base
                     .winner
                     .as_ref()
-                    .and_then(|b| git::merge_base(&self.repo, &b.oid));
+                    .and_then(|b| git::merge_base(&self.repo, b.oid()));
                 let old =
                     mb.map(|m| git::file_content(&self.repo, &m, old_path)).unwrap_or_default();
                 (old, worktree_content(&self.repo, new_path))
@@ -2664,9 +2714,11 @@ impl App {
     /// (specs/search.md).
     fn edit_input(&mut self, f: impl FnOnce(&mut Vec<char>, &mut usize)) {
         let searching = self.mode == Mode::Search;
-        // The highlighted branch's own row, read before the filter narrows under it.
-        let highlighted =
-            self.base_picker.as_ref().and_then(|bp| bp.filtered().get(bp.cursor).copied());
+        // The highlighted row's name, read before the filter narrows under it.
+        let highlighted = self
+            .base_picker
+            .as_ref()
+            .and_then(|bp| bp.visible().get(bp.cursor).map(|c| c.name().to_string()));
         let Some((text, caret_ref)) = self.active_field() else { return };
         let mut v: Vec<char> = text.chars().collect();
         let mut caret = (*caret_ref).min(v.len());
@@ -2685,11 +2737,75 @@ impl App {
 
     /// Re-seat the base picker's highlight after a filter edit: it follows its own row into
     /// the narrowed view when the row survives, else rests on the first match
-    /// (`specs/overview.md` Continuity).
-    fn refilter_base_picker(&mut self, highlighted: Option<usize>) {
+    /// (`specs/overview.md` Continuity). An empty frozen list with a non-empty query
+    /// schedules a commit probe (`specs/input.md` Base picker).
+    fn refilter_base_picker(&mut self, highlighted: Option<String>) {
         let Some(bp) = self.base_picker.as_mut() else { return };
-        let filtered = bp.filtered();
-        bp.cursor = highlighted.and_then(|h| filtered.iter().position(|&i| i == h)).unwrap_or(0);
+        bp.probe = if bp.filtered().is_empty() && !bp.query.is_empty() {
+            BaseProbe::Pending(Instant::now() + BASE_PROBE_DELAY)
+        } else {
+            BaseProbe::Idle
+        };
+        let cursor = {
+            let vis = bp.visible();
+            highlighted.and_then(|h| vis.iter().position(|c| c.name() == h)).unwrap_or(0)
+        };
+        bp.cursor = cursor;
+    }
+
+    /// Remaining wait until the empty-list probe, if one is pending.
+    #[must_use]
+    pub fn base_probe_wait(&self) -> Option<Duration> {
+        match self.base_picker.as_ref()?.probe {
+            BaseProbe::Pending(at) => Some(at.saturating_duration_since(Instant::now())),
+            _ => None,
+        }
+    }
+
+    /// Run the empty-list commit probe if its pause has elapsed (`specs/input.md`).
+    pub fn tick_base_picker_probe(&mut self) {
+        let at = match self.base_picker.as_ref().map(|bp| &bp.probe) {
+            Some(BaseProbe::Pending(at)) => *at,
+            _ => return,
+        };
+        if Instant::now() < at {
+            return;
+        }
+        self.run_base_probe();
+    }
+
+    /// Check the query as a commit now. Tests call this instead of sleeping.
+    pub fn run_base_probe(&mut self) {
+        let Some(bp) = &self.base_picker else { return };
+        if bp.query.is_empty() || !bp.filtered().is_empty() {
+            if let Some(bp) = self.base_picker.as_mut() {
+                bp.probe = BaseProbe::Idle;
+            }
+            return;
+        }
+        let query = bp.query.clone();
+        let hit = git::resolve_spelling(&self.repo, &query).map(|resolved| {
+            resolved.map(|c| match c {
+                git::ResolvedBase::Branch { name, .. } => {
+                    BaseChoice::Branch { name, starred: false, is_default: false }
+                }
+                git::ResolvedBase::Rev { spelling, oid } => {
+                    BaseChoice::Rev { name: git::complete_sha_prefix(&spelling, &oid), oid }
+                }
+            })
+        });
+        let Some(bp) = self.base_picker.as_mut() else { return };
+        match hit {
+            Ok(Some(choice)) => {
+                bp.probe = BaseProbe::Hit(choice);
+                bp.cursor = 0;
+            }
+            Ok(None) => bp.probe = BaseProbe::Miss,
+            Err(e) => {
+                bp.probe = BaseProbe::Miss;
+                self.status = e.0;
+            }
+        }
     }
 
     /// Move the caret with a function of the current `Vec<char>` view; a no-op without an
@@ -3663,7 +3779,9 @@ impl App {
 
     /// Open the base picker: one row per branch name, the open PR's target starred first,
     /// the default branch next, the rest by commit recency (`specs/input.md` Base picker).
-    /// The highlight opens on the current base, else the first row.
+    /// A current non-branch pick is inserted as a row. The highlight opens on the current
+    /// base, else the first row. Still opens when that list is empty, so a revision can
+    /// be typed.
     pub fn open_base_picker(&mut self) {
         if !self.base_pick_available() || self.mode != Mode::Normal {
             return;
@@ -3676,29 +3794,34 @@ impl App {
                 return;
             }
         };
-        if names.is_empty() {
-            // Nothing to choose: refuse with the cause, like an empty send
-            // (`specs/input.md` Base picker).
-            self.status = "no branches to pick".to_string();
-            return;
-        }
         let target = self
             .pr_snapshot()
             .filter(|s| s.state == forge::PrState::Open)
             .map(|s| s.base_ref.clone());
         let mut rows: Vec<BaseChoice> = names
             .into_iter()
-            .map(|name| BaseChoice {
+            .map(|name| BaseChoice::Branch {
                 starred: target.as_deref() == Some(name.as_str()),
                 is_default: default.as_deref() == Some(name.as_str()),
                 name,
             })
             .collect();
         // A stable sort, so recency still orders the promoted pair and the rest alike.
-        rows.sort_by_key(|r| (!r.starred, !r.is_default));
-        let current = self.branch_base.winner.as_ref().map(|b| b.name.as_str());
-        let cursor = current.and_then(|c| rows.iter().position(|r| r.name == c)).unwrap_or(0);
-        self.base_picker = Some(BasePicker { rows, cursor, query: String::new(), caret: 0 });
+        rows.sort_by_key(|r| (!r.starred(), !r.is_default()));
+        if let Some(git::ResolvedBase::Rev { spelling, oid }) = &self.branch_base.winner
+            && !rows.iter().any(|r| r.name() == spelling)
+        {
+            rows.insert(0, BaseChoice::Rev { name: spelling.clone(), oid: oid.clone() });
+        }
+        let current = self.branch_base.winner.as_ref().map(git::ResolvedBase::name);
+        let cursor = current.and_then(|c| rows.iter().position(|r| r.name() == c)).unwrap_or(0);
+        self.base_picker = Some(BasePicker {
+            rows,
+            cursor,
+            query: String::new(),
+            caret: 0,
+            probe: BaseProbe::Idle,
+        });
         self.mode = Mode::BasePick;
     }
 
@@ -3709,38 +3832,47 @@ impl App {
         self.base_picker = None;
     }
 
-    /// Move the highlight through the filtered view (`specs/input.md`).
+    /// Move the highlight through the visible view (`specs/input.md`).
     pub fn base_picker_move(&mut self, delta: isize) {
         let Some(bp) = self.base_picker.as_mut() else { return };
-        let len = bp.filtered().len();
+        let len = bp.visible().len();
         if len > 0 {
             bp.cursor = step(bp.cursor.min(len - 1), delta, len);
         }
     }
 
-    /// Move the highlight to filtered `row`, for a click. A row past the end is inert
+    /// Move the highlight to visible `row`, for a click. A row past the end is inert
     /// (`specs/input.md`).
     pub fn base_picker_goto(&mut self, row: usize) {
         if let Some(bp) = self.base_picker.as_mut()
-            && row < bp.filtered().len()
+            && row < bp.visible().len()
         {
             bp.cursor = row;
         }
     }
 
-    /// Pick the highlighted branch: persist it as the repo pick — or clear the pick when
-    /// the highlight is the default branch — then rebuild the changeset against it, so the
-    /// list and the header rename together (`specs/input.md`, `specs/review-model.md`).
-    /// With no filter match there is no highlight, and `enter` does nothing.
+    /// Pick the highlighted row: persist its spelling — or clear the pick when the
+    /// highlight is the default branch — then rebuild the changeset against it
+    /// (`specs/input.md`, `specs/review-model.md`). With no visible row, Enter checks the
+    /// query immediately and records it if it resolves.
     pub fn base_picker_pick(&mut self) -> Result<()> {
         let Some(bp) = &self.base_picker else { return Ok(()) };
-        let Some(&row) = bp.filtered().get(bp.cursor) else { return Ok(()) };
-        let choice = bp.rows[row].clone();
+        if bp.visible().is_empty() {
+            if bp.query.is_empty() {
+                return Ok(());
+            }
+            self.run_base_probe();
+        }
+        let choice = {
+            let Some(bp) = &self.base_picker else { return Ok(()) };
+            bp.visible().get(bp.cursor).map(|c| (*c).clone())
+        };
+        let Some(choice) = choice else { return Ok(()) };
         self.close_base_picker();
-        let write = if choice.is_default {
+        let write = if choice.is_default() {
             git::clear_base_pick(&self.repo)
         } else {
-            git::write_base_pick(&self.repo, &choice.name)
+            git::write_base_pick(&self.repo, choice.name())
         };
         if let Err(e) = write {
             self.status = e.0;
@@ -4046,7 +4178,7 @@ mod tests {
         let mut old = App::blocked(PathBuf::from("."), Scope::Branch, None);
         old.mode = Mode::BasePick;
         old.base_picker = Some(super::BasePicker {
-            rows: vec![super::BaseChoice {
+            rows: vec![super::BaseChoice::Branch {
                 name: "dev".to_string(),
                 starred: false,
                 is_default: false,
@@ -4054,9 +4186,10 @@ mod tests {
             cursor: 0,
             query: "d".to_string(),
             caret: 1,
+            probe: super::BaseProbe::Idle,
         });
         old.branch_base = crate::git::BaseStatus {
-            winner: Some(crate::git::ResolvedBase {
+            winner: Some(crate::git::ResolvedBase::Branch {
                 name: "main".to_string(),
                 oid: "0".repeat(40),
             }),
@@ -4068,11 +4201,11 @@ mod tests {
         assert_eq!(recovered.mode, Mode::BasePick);
         let bp = recovered.base_picker.as_ref().expect("the picker state is carried");
         assert_eq!(bp.query, "d");
-        assert_eq!(bp.rows[0].name, "dev");
+        assert_eq!(bp.rows[0].name(), "dev");
         // The header's base rides with the carried frame — recovery never paints
         // `no base` beside a populated list (`specs/tui.md`).
         let base = recovered.branch_base.winner.as_ref().expect("the resolved base is carried");
-        assert_eq!(base.name, "main");
+        assert_eq!(base.name(), "main");
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -532,12 +532,37 @@ pub fn pr_local(repo: &Path, base_flag: Option<&str>) -> Result<PrLocalState, Gi
     Ok(PrLocalState { head_oid, base_oid: bases.into_iter().next(), names, detached: false })
 }
 
-/// The winning base: the source's bare name and its pinned commit
+/// The winning base: a branch (origin then local) or any other spelling
 /// (`specs/review-model.md` Base branch).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ResolvedBase {
-    pub name: String,
-    pub oid: String,
+pub enum ResolvedBase {
+    Branch { name: String, oid: String },
+    Rev { spelling: String, oid: String },
+}
+
+impl ResolvedBase {
+    fn branch(name: String, oid: String) -> Self {
+        Self::Branch { name, oid }
+    }
+
+    fn rev(spelling: String, oid: String) -> Self {
+        Self::Rev { spelling, oid }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Branch { name, .. } => name,
+            Self::Rev { spelling, .. } => spelling,
+        }
+    }
+
+    #[must_use]
+    pub fn oid(&self) -> &str {
+        match self {
+            Self::Branch { oid, .. } | Self::Rev { oid, .. } => oid,
+        }
+    }
 }
 
 /// The chain outcome the header paints: the winner and the first recorded choice the
@@ -558,27 +583,27 @@ pub struct BaseStatus {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct BaseResolution {
     pub status: BaseStatus,
-    candidates: Vec<(String, String)>,
+    candidates: Vec<ResolvedBase>,
     recorded: Vec<String>,
 }
 
 impl BaseResolution {
     fn oids(&self) -> Vec<String> {
-        self.candidates.iter().map(|(_, oid)| oid.clone()).collect()
+        self.candidates.iter().map(|c| c.oid().to_string()).collect()
     }
 }
 
 /// Resolve the base chain: the `--base` flag, then the repo pick, then the branch
-/// `origin/HEAD` names (`specs/review-model.md` Base branch). A source that resolves to no
-/// ref is skipped, never an error; a skipped flag or pick that would have outranked the
-/// winner is recorded for the header (`specs/tui.md`).
+/// `origin/HEAD` names (`specs/review-model.md` Base branch). A source that does not
+/// resolve to a commit is skipped, never an error; a skipped flag or pick that would have
+/// outranked the winner is recorded for the header (`specs/tui.md`).
 pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResolution, GitFail> {
-    let mut candidates: Vec<(String, String)> = Vec::new();
+    let mut candidates: Vec<ResolvedBase> = Vec::new();
     let mut recorded: Vec<String> = Vec::new();
     let mut skipped: Option<String> = None;
-    let push = |name: String, oid: String, c: &mut Vec<(String, String)>| {
-        if !c.iter().any(|(_, o)| *o == oid) {
-            c.push((name, oid));
+    let push = |c: ResolvedBase, list: &mut Vec<ResolvedBase>| {
+        if !list.iter().any(|x| x.oid() == c.oid()) {
+            list.push(c);
         }
     };
     let record = |name: String, r: &mut Vec<String>| {
@@ -587,26 +612,20 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
         }
     };
     if let Some(flag) = base_flag.filter(|b| !b.is_empty()) {
-        // The flag is the power-user escape hatch: any rev works verbatim (a SHA, a tag,
-        // `upstream/main`), and a branch-name spelling falls back to prefix-stripped
-        // resolution. The header and the name shield use the bare spelling either way.
-        let entry = strip_base_prefix(flag);
-        record(entry.clone(), &mut recorded);
-        let probe = format!("{flag}^{{commit}}");
-        if let Some(oid) = git_tristate(repo, &["rev-parse", "--verify", "--quiet", &probe])? {
-            push(entry, oid, &mut candidates);
-        } else {
-            match resolve_base_entry(repo, &entry)? {
-                Some(oid) => push(entry, oid, &mut candidates),
-                None => skipped = Some(entry),
-            }
+        let (hit, skip) = classify_flag(repo, flag)?;
+        if let Some(c) = hit {
+            record(c.name().to_string(), &mut recorded);
+            push(c, &mut candidates);
+        }
+        if let Some(s) = skip {
+            record(s.clone(), &mut recorded);
+            skipped = Some(s);
         }
     }
     if let Some(pick) = read_base_pick(repo)? {
         record(pick.clone(), &mut recorded);
-        match resolve_base_entry(repo, &pick)? {
-            Some(oid) => push(pick, oid, &mut candidates),
-            // Only a failure that outranks the eventual winner reads as skipped.
+        match resolve_spelling(repo, &pick)? {
+            Some(c) => push(c, &mut candidates),
             None if candidates.is_empty() => skipped = skipped.or(Some(pick)),
             None => {}
         }
@@ -614,11 +633,10 @@ pub fn resolve_base(repo: &Path, base_flag: Option<&str>) -> Result<BaseResoluti
     if let Some(name) = default_branch_name(repo)? {
         record(name.clone(), &mut recorded);
         if let Some(oid) = resolve_base_entry(repo, &name)? {
-            push(name, oid, &mut candidates);
+            push(ResolvedBase::branch(name, oid), &mut candidates);
         }
     }
-    let winner =
-        candidates.first().map(|(name, oid)| ResolvedBase { name: name.clone(), oid: oid.clone() });
+    let winner = candidates.first().cloned();
     Ok(BaseResolution { status: BaseStatus { winner, skipped }, candidates, recorded })
 }
 
@@ -819,9 +837,98 @@ fn remote_identity(
     Err(GitFail(format!("git {args:?}: {}", stderr.trim())))
 }
 
-/// One base branch name pinned to an OID: `refs/remotes/origin/<name>`, then
-/// `refs/heads/<name>` (`specs/review-model.md` Base branch).
+/// Peel `rev` to a commit object id (`specs/review-model.md`). A leading `-` is not a
+/// rev. An ambiguous abbreviated SHA is a miss, not an error.
+pub fn resolve_commit(repo: &Path, rev: &str) -> Result<Option<String>, GitFail> {
+    if rev.is_empty() || rev.starts_with('-') {
+        return Ok(None);
+    }
+    let probe = format!("{rev}^{{commit}}");
+    git_tristate(repo, &["rev-parse", "--verify", "--quiet", &probe])
+}
+
+/// The abbreviated object id the header and the picker paint (`specs/tui.md`).
+#[must_use]
+pub fn abbreviate_oid(oid: &str) -> String {
+    const N: usize = 7;
+    if oid.len() <= N { oid.to_string() } else { oid[..N].to_string() }
+}
+
+/// Whether `spelling` is a hex prefix of `oid` (`specs/tui.md`: paint once).
+#[must_use]
+pub fn spelling_is_sha_prefix(spelling: &str, oid: &str) -> bool {
+    let s = spelling.to_ascii_lowercase();
+    !s.is_empty()
+        && s.bytes().all(|b| b.is_ascii_hexdigit())
+        && oid.to_ascii_lowercase().starts_with(&s)
+}
+
+/// Shown name and optional abbreviated SHA for a non-branch spelling (`specs/tui.md`,
+/// `specs/input.md`). A SHA prefix paints once; anything else keeps the spelling and
+/// carries the mark.
+#[must_use]
+pub fn rev_paint(spelling: &str, oid: &str) -> (String, Option<String>) {
+    let abbrev = abbreviate_oid(oid);
+    if spelling_is_sha_prefix(spelling, oid) {
+        (abbrev, None)
+    } else {
+        (spelling.to_string(), Some(abbrev))
+    }
+}
+
+/// Complete a unique SHA prefix to the abbreviated object id. A spelling that is
+/// already that abbrev, or a longer hex prefix of the oid (a pasted 40-hex), is kept
+/// (`specs/input.md`).
+#[must_use]
+pub fn complete_sha_prefix(spelling: &str, oid: &str) -> String {
+    let abbrev = abbreviate_oid(oid);
+    if spelling_is_sha_prefix(spelling, oid) && spelling.len() < abbrev.len() {
+        abbrev
+    } else {
+        spelling.to_string()
+    }
+}
+
+/// A branch name the picker would list, not `HEAD` and not a rev-walk (`specs/review-model.md`).
+#[must_use]
+pub fn is_branch_label(value: &str) -> bool {
+    branch_name_shaped(value) && !value.eq_ignore_ascii_case("HEAD")
+}
+
+/// Origin then local, else a verbatim commit (`specs/review-model.md`).
+pub(crate) fn resolve_spelling(
+    repo: &Path,
+    spelling: &str,
+) -> Result<Option<ResolvedBase>, GitFail> {
+    if let Some(oid) = resolve_base_entry(repo, spelling)? {
+        return Ok(Some(ResolvedBase::branch(spelling.to_string(), oid)));
+    }
+    Ok(resolve_commit(repo, spelling)?.map(|oid| ResolvedBase::rev(spelling.to_string(), oid)))
+}
+
+/// `--base`: verbatim first, else prefix-stripped as a branch. A miss keeps the flag
+/// spelling unless the stripped form is a branch name (`specs/review-model.md`).
+fn classify_flag(
+    repo: &Path,
+    flag: &str,
+) -> Result<(Option<ResolvedBase>, Option<String>), GitFail> {
+    let entry = strip_base_prefix(flag);
+    let verbatim = resolve_commit(repo, flag)?;
+    let via_branch = resolve_base_entry(repo, &entry)?;
+    Ok(match (verbatim, via_branch) {
+        (Some(oid), None) => (Some(ResolvedBase::rev(flag.to_string(), oid)), None),
+        (Some(oid), Some(_)) | (None, Some(oid)) => (Some(ResolvedBase::branch(entry, oid)), None),
+        (None, None) => {
+            let skip = if is_branch_label(&entry) { entry } else { flag.to_string() };
+            (None, Some(skip))
+        }
+    })
+}
+
 fn resolve_base_entry(repo: &Path, name: &str) -> Result<Option<String>, GitFail> {
+    if !is_branch_label(name) {
+        return Ok(None);
+    }
     for prefix in ["refs/remotes/origin/", "refs/heads/"] {
         let probe = format!("{prefix}{name}^{{commit}}");
         if let Some(oid) = git_tristate(repo, &["rev-parse", "--verify", "--quiet", &probe])? {
@@ -906,13 +1013,13 @@ pub fn file_content(repo: &Path, rev: &str, path: &str) -> String {
 
 // --- base pick (branch scope) --------------------------------------------------
 //
-// See `specs/review-model.md` Base branch. The pick is one branch name per repository:
-// a blob under one private ref, and refs are shared across a repository's worktrees, so
-// every pane reads the same pick.
+// See `specs/review-model.md` Base branch. The pick is one revision spelling per
+// repository: a blob under one private ref, and refs are shared across a repository's
+// worktrees, so every pane reads the same pick.
 
 const BASE_PICK_REF: &str = "refs/reviewr/base-pick";
 
-/// The recorded pick's branch name, or `None` when no pick is recorded. One git call, so a
+/// The recorded pick's spelling, or `None` when no pick is recorded. One git call, so a
 /// concurrent clear from another pane can never split the read the way an exists-then-read
 /// pair would; a failed read is no pick, matching the chain's skip-never-error contract
 /// (`specs/review-model.md`).
@@ -923,14 +1030,19 @@ pub fn read_base_pick(repo: &Path) -> Result<Option<String>, GitFail> {
     }
     let name = String::from_utf8_lossy(&out.stdout);
     let name = name.trim();
-    Ok(branch_name_shaped(name).then(|| name.to_string()))
+    Ok(pick_spelling_shaped(name).then(|| name.to_string()))
 }
 
-/// Whether a recorded pick is shaped like the branch name reviewr writes there. The ref is
-/// shared repository state any tool can write, and a pick that resolves to nothing still
-/// paints its name in the header, so a value git could never have produced is no pick at
-/// all — the chain's skip-never-error contract (`specs/review-model.md`), and the rule git
-/// itself applies to a refname.
+/// One printable line, not a git option (`specs/review-model.md`). `HEAD~1` and a tag are
+/// picks. Control bytes are not.
+fn pick_spelling_shaped(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with('-')
+        && value.bytes().all(|byte| byte > b' ' && byte != 0x7f)
+}
+
+/// Shape of a branch name the origin-then-local walk will accept. `HEAD` and rev-walk
+/// spellings (`HEAD~1`) are not: git would parse them through `origin/HEAD`.
 fn branch_name_shaped(value: &str) -> bool {
     !value.is_empty()
         && !value.starts_with('-')

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1064,6 +1064,11 @@ fn event_loop(
             if let Some(started) = pr.wait_started {
                 timeout = timeout.min(INDICATOR_DELAY.saturating_sub(started.elapsed()));
             }
+            if app.config_error().is_none()
+                && let Some(wait) = app.base_probe_wait()
+            {
+                timeout = timeout.min(wait);
+            }
             if event::poll(timeout)? {
                 if !painted_frame.still_current(app) {
                     continue;
@@ -1125,6 +1130,9 @@ fn event_loop(
                     }
                     _ => {}
                 }
+            }
+            if app.config_error().is_none() {
+                app.tick_base_picker_probe();
             }
             if app.should_quit {
                 break;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -23,6 +23,7 @@ use crate::config::NavigatorPosition;
 use crate::diff::{FileDiff, FileState, Row};
 use crate::file_list::{Annotation, RowKind};
 use crate::forge;
+use crate::git;
 use crate::herdr::AgentChoice;
 use crate::keymap::Keymap;
 use crate::model::Comment;
@@ -634,11 +635,9 @@ fn scope_chip(app: &App) -> String {
     format!("[{}]", app.scope.label())
 }
 
-/// The `branch` scope's base label as `(lead, name, tail)`: `vs ` + the bare name however it
-/// resolved, or the empty-state `no base` in the name slot with no lead. The skipped-choice
-/// tail ` · <name> missing` follows either, so a dormant choice never reads as never-chosen
-/// (`specs/tui.md`). `None` off the `branch` scope.
-fn base_label(app: &App) -> Option<(String, String, String)> {
+/// The `branch` scope's base label as `(lead, shown, marker, tail)` (`specs/tui.md`).
+/// `shown` is the spelling or a SHA-once abbrev. `marker` is ` (sha)` for a named rev.
+fn base_label(app: &App) -> Option<(String, String, String, String)> {
     if app.scope != crate::model::Scope::Branch {
         return None;
     }
@@ -647,17 +646,23 @@ fn base_label(app: &App) -> Option<(String, String, String)> {
         None => String::new(),
     };
     Some(match &app.branch_base.winner {
-        Some(b) => ("vs ".to_string(), b.name.clone(), tail),
-        None => (String::new(), "no base".to_string(), tail),
+        Some(git::ResolvedBase::Branch { name, .. }) => {
+            ("vs ".to_string(), name.clone(), String::new(), tail)
+        }
+        Some(git::ResolvedBase::Rev { spelling, oid }) => {
+            let (shown, mark) = git::rev_paint(spelling, oid);
+            ("vs ".to_string(), shown, mark.map(|m| format!(" ({m})")).unwrap_or_default(), tail)
+        }
+        None => (String::new(), "no base".to_string(), String::new(), tail),
     })
 }
 
 /// The base label as painted: truncated with a trailing `…` to what the header can fit,
 /// the name first and the skipped tail only in what remains, so a long missing name can
 /// never evict the resolved base (`specs/tui.md`) — one source for the paint and the
-/// click hit-test.
+/// click hit-test. A `spelling (sha)` clips the spelling and keeps `(sha)` when it fits.
 fn base_parts(app: &App, keymap: &Keymap, width: u16) -> Option<(String, String, String)> {
-    let (lead, name, tail) = base_label(app)?;
+    let (lead, shown, marker, tail) = base_label(app)?;
     // Everything else on the line plus the base's own gap and the suffix's minimum gap.
     let fixed = header_prefix_len(&tab_spans(keymap))
         + scope_chip(app).len()
@@ -667,7 +672,12 @@ fn base_parts(app: &App, keymap: &Keymap, width: u16) -> Option<(String, String,
         + HEADER_LEAD.len()
         + 1;
     let budget = (width as usize).saturating_sub(fixed);
-    let name = truncate_width(&name, budget);
+    let marker_w = marker.width();
+    let name = if marker_w > 0 && budget > marker_w {
+        format!("{}{marker}", truncate_width(&shown, budget - marker_w))
+    } else {
+        truncate_width(&format!("{shown}{marker}"), budget)
+    };
     if name.is_empty() {
         // Not even one column for the name: the base leaves the header whole rather than
         // paint a nameless `vs` the click would still claim (`specs/tui.md`).
@@ -2224,32 +2234,51 @@ pub fn hit_picker_row(area: Rect, app: &App, col: u16, row: u16) -> Option<usize
 
 // --- Base picker (specs/input.md Base picker) ----------------------------------------------
 
-/// A row's dim trail: `default` on the default branch, whose pick clears the record
+/// A row's dim trail: `default` on the default branch, or `(sha)` on a named rev
 /// (`specs/input.md` Base picker).
-fn base_trail(row: &crate::app::BaseChoice) -> &'static str {
-    if row.is_default { "default" } else { "" }
+fn row_shown(row: &crate::app::BaseChoice) -> String {
+    match row {
+        crate::app::BaseChoice::Rev { name, oid } => git::rev_paint(name, oid).0,
+        crate::app::BaseChoice::Branch { name, .. } => name.clone(),
+    }
 }
 
-/// The names pad to the widest, so the dim `default` mark starts in one column.
-fn base_name_width(bp: &crate::app::BasePicker) -> usize {
-    bp.rows.iter().map(|r| r.name.width()).max().unwrap_or(0)
+fn base_trail(row: &crate::app::BaseChoice) -> String {
+    if row.is_default() {
+        return "default".into();
+    }
+    let crate::app::BaseChoice::Rev { name, oid } = row else {
+        return String::new();
+    };
+    match git::rev_paint(name, oid).1 {
+        Some(abbrev) => format!("({abbrev})"),
+        None => String::new(),
+    }
+}
+
+/// Content width of one base-picker row: star lead, painted name, and dim trail.
+fn base_row_width(row: &crate::app::BaseChoice) -> usize {
+    let trail = base_trail(row);
+    let trail_w = if trail.is_empty() { 0 } else { 2 + trail.width() };
+    3 + row_shown(row).width() + trail_w
 }
 
 /// Sized like the agent picker's box, plus the filter line above the rows. The box holds its
 /// full-list size while the filter narrows, so the frame never jumps under typing.
 fn base_picker_popup(area: Rect, app: &App) -> Rect {
     let Some(bp) = &app.base_picker else { return Rect::default() };
-    let name_width = base_name_width(bp);
-    // The star lead + the padded name + the dim trail.
-    let widest =
-        bp.rows.iter().map(|r| 3 + name_width + 2 + base_trail(r).width()).max().unwrap_or(0);
+    let hit = match &bp.probe {
+        crate::app::BaseProbe::Hit(c) => Some(c),
+        _ => None,
+    };
+    let widest = bp.rows.iter().chain(hit).map(base_row_width).max().unwrap_or(0);
     menu_popup(area, app, widest, BASE_PICKER_TITLE, bp.rows.len().max(1) + 3)
 }
 
 const BASE_PICKER_TITLE: &str = "Pick base branch";
 
 fn base_picker_scroll(bp: &crate::app::BasePicker, rows: usize) -> usize {
-    menu_scroll(bp.cursor, bp.filtered().len(), rows)
+    menu_scroll(bp.cursor, bp.visible().len(), rows)
 }
 
 fn render_base_picker(frame: &mut Frame, app: &App, area: Rect) {
@@ -2274,46 +2303,54 @@ fn render_base_picker(frame: &mut Frame, app: &App, area: Rect) {
     // One cell of right margin keeps the scrolled query off the popup's border.
     let avail = (inner.width as usize).saturating_sub(prefix.width() + 1);
     let (filter_spans, caret_cell_col) =
-        input_line(&bp.query, bp.caret, avail, "type to filter…", p);
+        input_line(&bp.query, bp.caret, avail, "filter or type a revision", p);
     let mut filter = Line::from(filter_spans);
     filter.spans.insert(0, Span::styled(prefix, text_style(p)));
     frame.render_widget(Paragraph::new(filter), Rect { height: 1, ..inner });
     anchor_input_cursor(frame, inner, prefix.width() + caret_cell_col, 0);
 
     let list_area = Rect { y: inner.y + 1, height: inner.height.saturating_sub(1), ..inner };
-    let filtered = bp.filtered();
-    if filtered.is_empty() {
-        let none = Line::from(Span::styled(" no branches match", Style::default().fg(p.overlay0)));
+    let visible = bp.visible();
+    if visible.is_empty() {
+        let msg = if bp.query.is_empty() {
+            " type a revision"
+        } else if matches!(bp.probe, crate::app::BaseProbe::Miss) {
+            " no branches match"
+        } else {
+            return;
+        };
+        let none = Line::from(Span::styled(msg, Style::default().fg(p.overlay0)));
         frame.render_widget(Paragraph::new(none), list_area);
         return;
     }
-    let name_width = base_name_width(bp);
+    let width = list_area.width as usize;
     let first = base_picker_scroll(bp, list_area.height as usize);
-    let items: Vec<ListItem> = filtered
+    let items: Vec<ListItem> = visible
         .iter()
         .enumerate()
         .skip(first)
         .take(list_area.height as usize)
-        .map(|(vi, &ri)| {
-            let row = &bp.rows[ri];
+        .map(|(vi, row)| {
             // The star marks the open PR's target; the name is the only part at full
-            // brightness, like the agent picker's rows (`specs/input.md`).
-            let lead = if row.starred { " ★ " } else { "   " };
-            let pad = name_width.saturating_sub(row.name.width());
-            let spans = vec![
+            // brightness, like the agent picker's rows (`specs/input.md`). The dim
+            // trail right-aligns to the row so a probe and the full list put `(sha)`
+            // in the same place.
+            let lead = if row.starred() { " ★ " } else { "   " };
+            let label = row_shown(row);
+            let trail = base_trail(row);
+            let gap = if trail.is_empty() { 0 } else { 2 };
+            let pad = width.saturating_sub(lead.width() + label.width() + gap + trail.width());
+            let mut spans = vec![
                 Span::styled(lead.to_string(), Style::default().fg(p.yellow)),
-                Span::styled(row.name.clone(), text_style(p)),
-                Span::styled(
-                    format!("{}  {}", " ".repeat(pad), base_trail(row)),
-                    Style::default().fg(p.overlay0),
-                ),
+                Span::styled(label, text_style(p)),
             ];
-            selectable_row(
-                p,
-                spans,
-                list_area.width as usize,
-                (vi == bp.cursor).then_some(p.surface2),
-            )
+            if !trail.is_empty() {
+                spans.push(Span::styled(
+                    format!("{}{trail}", " ".repeat(pad + gap)),
+                    Style::default().fg(p.overlay0),
+                ));
+            }
+            selectable_row(p, spans, width, (vi == bp.cursor).then_some(p.surface2))
         })
         .collect();
     frame.render_widget(List::new(items), list_area);
@@ -2325,7 +2362,7 @@ pub fn hit_base_picker_row(area: Rect, app: &App, col: u16, row: u16) -> Option<
     let bp = app.base_picker.as_ref()?;
     let inner = picker_inner(base_picker_popup(area, app));
     let first = base_picker_scroll(bp, inner.height.saturating_sub(1) as usize);
-    menu_hit(inner, 1, first, bp.filtered().len(), col, row)
+    menu_hit(inner, 1, first, bp.visible().len(), col, row)
 }
 
 // --- Search screen (specs/search.md) -------------------------------------------------------

--- a/src/world.rs
+++ b/src/world.rs
@@ -96,7 +96,7 @@ pub fn build_changed(input: &WorldInput) -> Result<(git::BaseStatus, Vec<Changed
             // nothing resolves is not a failure: it returns the legible no-base state.
             let resolution = git::resolve_base(&input.repo, input.base.as_deref())
                 .map_err(|e| anyhow::anyhow!("{}", e.0))?;
-            let base_oid = resolution.status.winner.as_ref().map(|w| w.oid.clone());
+            let base_oid = resolution.status.winner.as_ref().map(|w| w.oid().to_string());
             let changed = git::changed_files(&input.repo, input.scope, base_oid.as_deref())?;
             Ok((resolution.status, changed))
         }

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -5340,10 +5340,10 @@ fn the_base_picker_opens_only_on_the_branch_scope_without_a_flag() {
     app.open_base_picker();
     assert_eq!(app.mode, Mode::BasePick);
     let bp = app.base_picker.as_ref().expect("picker state");
-    let names: Vec<&str> = bp.rows.iter().map(|r| r.name.as_str()).collect();
+    let names: Vec<&str> = bp.rows.iter().map(herdr_reviewr::app::BaseChoice::name).collect();
     assert!(!names.contains(&"feature"), "the checked-out branch is not listed");
-    assert_eq!(bp.rows[0].name, "main", "the default branch sorts ahead of recency");
-    assert!(bp.rows[0].is_default);
+    assert_eq!(bp.rows[0].name(), "main", "the default branch sorts ahead of recency");
+    assert!(bp.rows[0].is_default());
     assert!(names.contains(&"dev"));
     assert_eq!(bp.cursor, 0, "the highlight opens on the current base");
     app.close_base_picker();
@@ -5362,7 +5362,10 @@ fn typing_filters_and_enter_picks_the_highlight() {
     let r = based_repo();
     let mut app = app_on(&r);
     app.set_scope(Scope::Branch).unwrap();
-    assert_eq!(app.branch_base.winner.as_ref().map(|b| b.name.as_str()), Some("main"));
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name),
+        Some("main")
+    );
     app.open_base_picker();
     app.input_push('d');
     app.input_push('e');
@@ -5370,7 +5373,10 @@ fn typing_filters_and_enter_picks_the_highlight() {
     assert_eq!(bp.filtered().len(), 1, "the filter matches anywhere in the name");
     app.base_picker_pick().unwrap();
     assert_eq!(app.mode, Mode::Normal, "a pick closes the picker");
-    assert_eq!(app.branch_base.winner.as_ref().map(|b| b.name.as_str()), Some("dev"));
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name),
+        Some("dev")
+    );
     let picked = r.git(&["show", "refs/reviewr/base-pick"]);
     assert_eq!(picked.trim(), "dev", "the pick persists in the private ref");
     assert!(
@@ -5400,13 +5406,19 @@ fn picking_the_default_clears_the_pick() {
     herdr_reviewr::git::write_base_pick(r.path(), "dev").unwrap();
     let mut app = app_on(&r);
     app.set_scope(Scope::Branch).unwrap();
-    assert_eq!(app.branch_base.winner.as_ref().map(|b| b.name.as_str()), Some("dev"));
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name),
+        Some("dev")
+    );
     app.open_base_picker();
     let bp = app.base_picker.as_ref().unwrap();
-    assert_eq!(bp.rows[bp.cursor].name, "dev", "the highlight opens on the current base");
+    assert_eq!(bp.rows[bp.cursor].name(), "dev", "the highlight opens on the current base");
     app.base_picker_goto(0);
     app.base_picker_pick().unwrap();
-    assert_eq!(app.branch_base.winner.as_ref().map(|b| b.name.as_str()), Some("main"));
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name),
+        Some("main")
+    );
     assert_eq!(
         herdr_reviewr::git::read_base_pick(r.path()).unwrap(),
         None,
@@ -5433,19 +5445,20 @@ fn a_filter_with_no_match_leaves_enter_inert_and_backspace_recovers() {
 }
 
 #[test]
-fn a_repo_with_no_pickable_branch_refuses_to_open_the_picker() {
+fn a_repo_with_no_pickable_branch_still_opens_the_picker() {
     let r = Repo::init();
     r.write("a.rs", "one\n");
     r.commit_all("init");
     let mut app = app_on(&r);
     app.set_scope(Scope::Branch).unwrap();
 
-    // One branch, checked out, and no origin default: nothing to choose, so the picker
-    // refuses with the cause rather than opening empty (`specs/input.md` Base picker).
+    // One branch, checked out, and no origin default: the picker opens empty so a
+    // revision can still be typed (`specs/input.md` Base picker).
     app.open_base_picker();
-    assert_eq!(app.mode, Mode::Normal);
-    assert!(app.base_picker.is_none());
-    assert_eq!(app.status, "no branches to pick");
+    assert_eq!(app.mode, Mode::BasePick);
+    let bp = app.base_picker.as_ref().unwrap();
+    assert!(bp.rows.is_empty());
+    assert!(bp.visible().is_empty());
 }
 
 #[test]
@@ -5471,7 +5484,7 @@ fn the_filter_edits_with_the_comment_editors_controls() {
     app.input_push('e');
     let bp = app.base_picker.as_ref().unwrap();
     assert_eq!(bp.query, "dev");
-    assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name, "dev", "the narrowed view still picks");
+    assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name(), "dev", "the narrowed view still picks");
 
     // A branch name pasted with the trailing newline it was copied with still filters:
     // the single-line field takes a newline as a space (`specs/input.md`).
@@ -5480,7 +5493,7 @@ fn the_filter_edits_with_the_comment_editors_controls() {
     app.input_paste("dev\n");
     let bp = app.base_picker.as_ref().unwrap();
     assert_eq!(bp.query, "dev", "the trailing newline never lands in the query");
-    assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name, "dev", "the pasted name filters");
+    assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name(), "dev", "the pasted name filters");
 }
 
 #[test]
@@ -5491,11 +5504,11 @@ fn the_highlight_follows_its_row_through_a_narrowing_filter() {
     app.open_base_picker();
     app.base_picker_move(1); // main -> dev
     let bp = app.base_picker.as_ref().unwrap();
-    assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name, "dev");
+    assert_eq!(bp.rows[bp.filtered()[bp.cursor]].name(), "dev");
     app.input_push('d');
     let bp = app.base_picker.as_ref().unwrap();
     assert_eq!(
-        bp.rows[bp.filtered()[bp.cursor]].name,
+        bp.rows[bp.filtered()[bp.cursor]].name(),
         "dev",
         "the highlight keeps its row when the row survives the filter"
     );
@@ -5535,4 +5548,174 @@ fn the_base_picker_owns_the_whole_footer_bar_and_survives_a_config_error() {
     app.set_config_error("theme = \"not-a-theme\"".to_string());
     assert_eq!(app.mode, Mode::BasePick);
     assert_eq!(app.base_picker.as_ref().unwrap().query, "d");
+}
+
+#[test]
+fn typing_head_tilde_stores_the_spelling() {
+    let r = based_repo();
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    for ch in "HEAD~1".chars() {
+        app.input_push(ch);
+    }
+    assert!(app.base_picker.as_ref().unwrap().visible().is_empty());
+    assert!(app.base_probe_wait().is_some(), "typing schedules the empty-list probe");
+    app.tick_base_picker_probe();
+    assert!(app.base_picker.as_ref().unwrap().visible().is_empty(), "the pause has not elapsed");
+    app.run_base_probe();
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(bp.visible().len(), 1);
+    assert_eq!(bp.visible()[0].name(), "HEAD~1");
+    assert_eq!(bp.visible()[0].oid(), Some(parent.as_str()));
+    app.base_picker_pick().unwrap();
+    assert_eq!(app.mode, Mode::Normal);
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::oid),
+        Some(parent.as_str())
+    );
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name),
+        Some("HEAD~1")
+    );
+    assert_eq!(herdr_reviewr::git::read_base_pick(r.path()).unwrap().as_deref(), Some("HEAD~1"));
+
+    r.write("a.rs", "three\n");
+    r.commit_all("later");
+    let moved = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    assert_ne!(moved, parent);
+    app.reload().unwrap();
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name),
+        Some("HEAD~1")
+    );
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::oid),
+        Some(moved.as_str()),
+        "a later commit still diffs one back"
+    );
+}
+
+#[test]
+fn enter_on_an_empty_list_probes_immediately() {
+    let r = based_repo();
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    for ch in "HEAD~1".chars() {
+        app.input_push(ch);
+    }
+    app.base_picker_pick().unwrap();
+    assert_eq!(app.mode, Mode::Normal);
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::oid),
+        Some(parent.as_str())
+    );
+    assert_eq!(herdr_reviewr::git::read_base_pick(r.path()).unwrap().as_deref(), Some("HEAD~1"));
+}
+
+#[test]
+fn a_typed_sha_prefix_stores_the_abbreviated_sha() {
+    let r = based_repo();
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    let prefix = short[..4].to_string();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    for ch in prefix.chars() {
+        app.input_push(ch);
+    }
+    app.base_picker_pick().unwrap();
+    assert_eq!(
+        herdr_reviewr::git::read_base_pick(r.path()).unwrap().as_deref(),
+        Some(short.as_str())
+    );
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name),
+        Some(short.as_str())
+    );
+    app.open_base_picker();
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(bp.visible()[bp.cursor].name(), short);
+}
+
+#[test]
+fn a_short_sha_with_a_newline_can_be_pasted_and_picked() {
+    let r = based_repo();
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    app.input_paste(&format!("{short}\n"));
+    assert_eq!(app.base_picker.as_ref().unwrap().query, short);
+    app.base_picker_pick().unwrap();
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::oid),
+        Some(parent.as_str())
+    );
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name),
+        Some(short.as_str())
+    );
+    assert_eq!(
+        herdr_reviewr::git::read_base_pick(r.path()).unwrap().as_deref(),
+        Some(short.as_str())
+    );
+}
+
+#[test]
+fn a_current_named_rev_is_the_highlighted_row_on_reopen() {
+    let r = based_repo();
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    herdr_reviewr::git::write_base_pick(r.path(), "HEAD~1").unwrap();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(bp.visible()[bp.cursor].name(), "HEAD~1");
+    assert_eq!(bp.visible()[bp.cursor].oid(), Some(parent.as_str()));
+}
+
+#[test]
+fn picking_the_default_tips_sha_does_not_clear_the_pick() {
+    let r = based_repo();
+    let main = r.git(&["rev-parse", "main"]).trim().to_string();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    app.input_paste(&main);
+    app.base_picker_pick().unwrap();
+    assert_eq!(
+        herdr_reviewr::git::read_base_pick(r.path()).unwrap().as_deref(),
+        Some(main.as_str())
+    );
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::oid),
+        Some(main.as_str())
+    );
+}
+
+#[test]
+fn checking_out_a_picked_branch_does_not_turn_it_into_a_pin() {
+    let r = based_repo();
+    herdr_reviewr::git::write_base_pick(r.path(), "dev").unwrap();
+    r.git(&["checkout", "-q", "dev"]);
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    assert_eq!(
+        app.branch_base.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name),
+        Some("dev")
+    );
+    app.open_base_picker();
+    let bp = app.base_picker.as_ref().unwrap();
+    assert!(
+        bp.rows.iter().all(|row| row.oid().is_none()),
+        "a live branch pick must not grow a SHA row"
+    );
+    assert!(bp.visible()[bp.cursor].oid().is_none(), "the highlight must not be a pin");
+    assert_eq!(herdr_reviewr::git::read_base_pick(r.path()).unwrap().as_deref(), Some("dev"));
 }

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -7,10 +7,10 @@ use std::path::Path;
 
 use common::Repo;
 use herdr_reviewr::git::{
-    all_files, changed_against_tree, changed_files as changed_files_oid, clear_base_pick,
-    default_branch_name, file_content, list_branches, merge_base as merge_base_oid, read_base_pick,
-    read_baseline_ref, resolve_base, snapshot_worktree, worktree_key, write_base_pick,
-    write_baseline_ref,
+    ResolvedBase, abbreviate_oid, all_files, changed_against_tree,
+    changed_files as changed_files_oid, clear_base_pick, default_branch_name, file_content,
+    list_branches, merge_base as merge_base_oid, read_base_pick, read_baseline_ref, resolve_base,
+    resolve_commit, snapshot_worktree, worktree_key, write_base_pick, write_baseline_ref,
 };
 use herdr_reviewr::model::{ChangeKind, ChangedFile, Scope};
 
@@ -24,12 +24,12 @@ fn changed_files(
     base: Option<&str>,
 ) -> anyhow::Result<Vec<ChangedFile>> {
     let winner = resolve_base(repo, base).map_err(|e| anyhow::anyhow!("{}", e.0))?.status.winner;
-    changed_files_oid(repo, scope, winner.as_ref().map(|w| w.oid.as_str()))
+    changed_files_oid(repo, scope, winner.as_ref().map(herdr_reviewr::git::ResolvedBase::oid))
 }
 
 fn merge_base(repo: &Path, base: Option<&str>) -> Option<String> {
     let winner = resolve_base(repo, base).ok()?.status.winner?;
-    merge_base_oid(repo, &winner.oid)
+    merge_base_oid(repo, winner.oid())
 }
 
 #[test]
@@ -108,16 +108,16 @@ fn the_chain_is_flag_then_pick_then_default() {
 
     // Default branch alone: `origin/HEAD` names `main` (specs/review-model.md).
     let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
-    assert_eq!(winner.name, "main");
+    assert_eq!(winner.name(), "main");
 
     // A pick outranks the default.
     write_base_pick(r.path(), "picked-base").unwrap();
     let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
-    assert_eq!(winner.name, "picked-base");
+    assert_eq!(winner.name(), "picked-base");
 
     // The flag outranks the pick.
     let winner = resolve_base(r.path(), Some("flagged-base")).unwrap().status.winner.unwrap();
-    assert_eq!(winner.name, "flagged-base");
+    assert_eq!(winner.name(), "flagged-base");
 }
 
 #[test]
@@ -167,7 +167,15 @@ fn a_prefixed_flag_spelling_resolves_to_the_bare_name() {
     // `--base origin/main` resolves as a verbatim rev, but the header and the PR name
     // shield carry the bare spelling (specs/tui.md, specs/forge-host.md).
     let winner = resolve_base(r.path(), Some("origin/main")).unwrap().status.winner.unwrap();
-    assert_eq!(winner.name, "main");
+    assert_eq!(winner.name(), "main");
+
+    // A prefixed rev that is not a branch keeps the flag spelling, so `origin/HEAD` does
+    // not paint as live `HEAD`.
+    let winner = resolve_base(r.path(), Some("origin/HEAD")).unwrap().status.winner.unwrap();
+    assert_eq!(winner.name(), "origin/HEAD");
+
+    let status = resolve_base(r.path(), Some("origin/HEAD~99")).unwrap().status;
+    assert_eq!(status.skipped.as_deref(), Some("origin/HEAD~99"));
 
     // A prefixed spelling that resolves to nothing is skipped under the same bare name,
     // so the header reads `· gone missing`, never `· origin/gone missing`.
@@ -191,14 +199,14 @@ fn a_pick_git_could_never_have_written_is_no_pick() {
     r.write_raw_base_pick("dev\u{1b}]0;pwned\u{7}");
     assert_eq!(read_base_pick(r.path()).unwrap(), None);
 
-    // Nor a rev expression: `main~5` resolves to a commit no branch names, and the header
-    // would paint it as though a branch were chosen.
+    // A leftover expression in the blob is a spelling (`specs/review-model.md`). Too
+    // deep to resolve, it is skipped, not discarded.
     r.write_raw_base_pick("main~5");
-    assert_eq!(read_base_pick(r.path()).unwrap(), None);
+    assert_eq!(read_base_pick(r.path()).unwrap().as_deref(), Some("main~5"));
 
     let status = resolve_base(r.path(), None).unwrap().status;
-    assert_eq!(status.skipped, None, "a malformed pick is not a recorded choice either");
-    assert_eq!(status.winner.unwrap().name, "main");
+    assert_eq!(status.skipped.as_deref(), Some("main~5"));
+    assert_eq!(status.winner.unwrap().name(), "main");
 }
 
 #[test]
@@ -215,21 +223,21 @@ fn a_dormant_pick_is_skipped_and_reactivates() {
 
     // The pick wins while its branch resolves.
     let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
-    assert_eq!(winner.name, "dev");
+    assert_eq!(winner.name(), "dev");
 
     // The branch disappears: the pick is kept and skipped, the default wins, and the
     // header can say so (specs/review-model.md).
     r.git(&["branch", "-D", "dev"]);
     let status = resolve_base(r.path(), None).unwrap().status;
     let winner = status.winner.unwrap();
-    assert_eq!(winner.name, "main");
+    assert_eq!(winner.name(), "main");
     assert_eq!(status.skipped.as_deref(), Some("dev"));
     assert_eq!(read_base_pick(r.path()).unwrap().as_deref(), Some("dev"));
 
     // The branch returns: the pick reactivates without a new choice.
     r.git(&["branch", "dev", "main"]);
     let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
-    assert_eq!(winner.name, "dev");
+    assert_eq!(winner.name(), "dev");
 }
 
 #[test]
@@ -269,6 +277,153 @@ fn the_pick_persists_in_a_private_ref_and_clears() {
     let reviewr_refs: Vec<&str> = refs.lines().filter(|l| !l.starts_with("refs/heads/")).collect();
     assert_eq!(reviewr_refs, ["refs/reviewr/base-pick"]);
     assert_eq!(r.git(&["status", "--porcelain"]).trim(), "");
+}
+
+#[test]
+fn a_head_tilde_pick_re_resolves_after_a_commit() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("base.rs", "2\n");
+    r.commit_all("one");
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    write_base_pick(r.path(), "HEAD~1").unwrap();
+
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
+    assert_eq!(winner.oid(), parent);
+    assert_eq!(winner.name(), "HEAD~1");
+    assert!(matches!(winner, ResolvedBase::Rev { .. }));
+    assert_eq!(read_base_pick(r.path()).unwrap().as_deref(), Some("HEAD~1"));
+
+    r.write("base.rs", "3\n");
+    r.commit_all("two");
+    let moved = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    assert_ne!(moved, parent);
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
+    assert_eq!(winner.name(), "HEAD~1");
+    assert_eq!(winner.oid(), moved, "a later commit still diffs one back");
+    assert_eq!(merge_base(r.path(), None).as_deref(), Some(moved.as_str()));
+}
+
+#[test]
+fn a_sha_pick_stays_pinned() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("base.rs", "2\n");
+    r.commit_all("one");
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    write_base_pick(r.path(), &parent).unwrap();
+
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
+    assert_eq!(winner.oid(), parent);
+    assert_eq!(winner.name(), parent);
+    assert!(matches!(winner, ResolvedBase::Rev { .. }));
+
+    r.write("base.rs", "3\n");
+    r.commit_all("two");
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
+    assert_eq!(winner.oid(), parent, "a SHA spelling is a pin");
+    assert_eq!(merge_base(r.path(), None).as_deref(), Some(parent.as_str()));
+}
+
+#[test]
+fn a_tag_pick_re_resolves() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("base.rs", "2\n");
+    r.commit_all("one");
+    let first = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    r.git(&["tag", "qa-pin-base", &first]);
+    write_base_pick(r.path(), "qa-pin-base").unwrap();
+
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
+    assert_eq!(winner.name(), "qa-pin-base");
+    assert_eq!(winner.oid(), first);
+    assert!(matches!(winner, ResolvedBase::Rev { .. }));
+
+    let tip = r.git(&["rev-parse", "HEAD"]).trim().to_string();
+    r.git(&["tag", "-f", "qa-pin-base", &tip]);
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
+    assert_eq!(winner.name(), "qa-pin-base");
+    assert_eq!(winner.oid(), tip, "moving the tag moves the base");
+}
+
+#[test]
+fn a_unique_short_sha_pick_keeps_that_spelling() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    let oid = r.git(&["rev-parse", "HEAD"]).trim().to_string();
+    let short = abbreviate_oid(&oid);
+    write_base_pick(r.path(), &short).unwrap();
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
+    assert_eq!(winner.name(), short);
+    assert_eq!(winner.oid(), oid);
+    assert!(matches!(winner, ResolvedBase::Rev { .. }));
+}
+
+#[test]
+fn a_unique_short_sha_resolves_and_a_too_deep_or_dashed_rev_does_not() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    let oid = r.git(&["rev-parse", "HEAD"]).trim().to_string();
+    let short = abbreviate_oid(&oid);
+    assert_eq!(resolve_commit(r.path(), &short).unwrap().as_deref(), Some(oid.as_str()));
+    assert_eq!(resolve_commit(r.path(), "HEAD~1").unwrap(), None, "too deep is a miss");
+    assert_eq!(resolve_commit(r.path(), "-n").unwrap(), None, "a leading dash is not a rev");
+}
+
+#[test]
+fn a_tree_ish_does_not_resolve_as_a_commit() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    let tree = r.git(&["rev-parse", "HEAD^{tree}"]).trim().to_string();
+    assert_eq!(resolve_commit(r.path(), &tree).unwrap(), None);
+}
+
+#[test]
+fn a_flag_that_is_not_a_branch_keeps_its_spelling() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    r.write("base.rs", "1b\n");
+    r.commit_all("main-2");
+    r.set_origin_default("main", "HEAD");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("base.rs", "2\n");
+    r.commit_all("diverge");
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let winner = resolve_base(r.path(), Some("HEAD~1")).unwrap().status.winner.unwrap();
+    assert_eq!(winner.oid(), parent);
+    assert_eq!(winner.name(), "HEAD~1");
+    assert!(matches!(winner, ResolvedBase::Rev { .. }));
+}
+
+#[test]
+fn a_missing_head_tilde_pick_is_skipped_and_reactivates() {
+    let r = Repo::init();
+    r.write("base.rs", "1\n");
+    r.commit_all("base");
+    r.set_origin_default("main", "HEAD");
+    write_base_pick(r.path(), "HEAD~1").unwrap();
+
+    let status = resolve_base(r.path(), None).unwrap().status;
+    assert_eq!(status.winner.as_ref().map(herdr_reviewr::git::ResolvedBase::name), Some("main"));
+    assert_eq!(status.skipped.as_deref(), Some("HEAD~1"));
+
+    r.write("base.rs", "2\n");
+    r.commit_all("two");
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let winner = resolve_base(r.path(), None).unwrap().status.winner.unwrap();
+    assert_eq!(winner.name(), "HEAD~1");
+    assert_eq!(winner.oid(), parent);
 }
 
 #[test]

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -4,7 +4,7 @@
 mod common;
 
 use common::{Repo, app_on, enter_tab};
-use herdr_reviewr::app::{App, BaseChoice, BasePicker, Focus, Mode, Tab};
+use herdr_reviewr::app::{App, BaseChoice, BasePicker, BaseProbe, Focus, Mode, Tab};
 use herdr_reviewr::config::NavigatorPosition;
 use herdr_reviewr::herdr::AgentChoice;
 use herdr_reviewr::keymap::Keymap;
@@ -149,10 +149,15 @@ fn backspacing_a_wide_character_leaves_the_terminal_cursor_unpainted() {
 fn the_base_picker_anchors_the_terminal_cursor_at_its_caret() {
     let mut app = edited_app();
     app.base_picker = Some(BasePicker {
-        rows: vec![BaseChoice { name: "main".to_string(), starred: false, is_default: true }],
+        rows: vec![BaseChoice::Branch {
+            name: "main".to_string(),
+            starred: false,
+            is_default: true,
+        }],
         cursor: 0,
         query: String::new(),
         caret: 0,
+        probe: BaseProbe::Idle,
     });
     app.mode = Mode::BasePick;
     let mut terminal = Terminal::new(TestBackend::new(140, 40)).unwrap();
@@ -3041,6 +3046,196 @@ fn the_branch_header_names_the_base_and_its_click_opens_the_picker() {
 }
 
 #[test]
+fn a_named_rev_paints_the_spelling_and_abbrev() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.set_origin_default("main", "main");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("hello.rs", "alpha\nBETA\n");
+    r.commit_all("edit");
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    herdr_reviewr::git::write_base_pick(r.path(), "HEAD~1").unwrap();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let line0 = render(&app).lines().next().unwrap().to_string();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    assert!(
+        line0.contains(&format!("vs HEAD~1 ({short})")),
+        "a named rev paints the spelling and the abbreviated SHA: {line0}"
+    );
+}
+
+#[test]
+fn a_sha_pick_paints_once() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.set_origin_default("main", "main");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("hello.rs", "alpha\nBETA\n");
+    r.commit_all("edit");
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    herdr_reviewr::git::write_base_pick(r.path(), &parent).unwrap();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    let line0 = render(&app).lines().next().unwrap().to_string();
+    assert!(line0.contains(&format!("vs {short}")), "a SHA spelling paints once: {line0}");
+    assert!(
+        !line0.contains(&format!("vs {short} (")),
+        "a SHA spelling does not repeat as a marker: {line0}"
+    );
+
+    herdr_reviewr::git::write_base_pick(r.path(), &short).unwrap();
+    app.reload().unwrap();
+    let line0 = render(&app).lines().next().unwrap().to_string();
+    assert!(
+        line0.contains(&format!("vs {short}")),
+        "an abbreviated SHA spelling paints once: {line0}"
+    );
+    assert!(
+        !line0.contains(&format!("vs {short} (")),
+        "an abbreviated SHA spelling does not repeat as a marker: {line0}"
+    );
+}
+
+#[test]
+fn a_flag_named_rev_paints_the_same_form() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.set_origin_default("main", "main");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("hello.rs", "alpha\nBETA\n");
+    r.commit_all("edit");
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let mut app = App::new(r.path_buf(), Scope::Branch, Some("HEAD~1".to_string()));
+    app.reload().unwrap();
+    let line0 = render(&app).lines().next().unwrap().to_string();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    assert!(
+        line0.contains(&format!("vs HEAD~1 ({short})")),
+        "the --base flag uses the same paint: {line0}"
+    );
+}
+
+#[test]
+fn a_probe_row_is_the_typed_spelling() {
+    let (r, mut app) = based_app();
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    app.open_base_picker();
+    for ch in "HEAD~1".chars() {
+        app.input_push(ch);
+    }
+    app.run_base_probe();
+    let frame = render(&app);
+    assert!(frame.contains("HEAD~1"), "the probe row is the typed spelling:\n{frame}");
+    assert!(
+        frame.contains(&format!("({short})")),
+        "a named rev is marked with the abbreviated SHA:\n{frame}"
+    );
+}
+
+#[test]
+fn a_probe_row_right_aligns_the_sha_like_the_open_list() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.set_origin_default("main", "main");
+    r.git(&["branch", "dev"]);
+    r.git(&["branch", &format!("release/{}", "x".repeat(40))]);
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("hello.rs", "alpha\nBETA\n");
+    r.commit_all("edit");
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    app.open_base_picker();
+    for ch in "HEAD~1".chars() {
+        app.input_push(ch);
+    }
+    app.run_base_probe();
+    let marker = format!("({short})");
+    let picker_row = |frame: &str| {
+        frame
+            .lines()
+            .find(|l| l.contains(&marker) && !l.contains("vs "))
+            .expect("the picker row paints")
+            .to_string()
+    };
+    let probe = picker_row(&render(&app));
+    let probe_at = probe.find(&marker).unwrap();
+    app.base_picker_pick().unwrap();
+    app.open_base_picker();
+    let open = picker_row(&render(&app));
+    let open_at = open.find(&marker).unwrap();
+    assert_eq!(
+        probe_at, open_at,
+        "typing a rev puts `(sha)` in the same column as opening the list:\nopen: {open}\nprobe: {probe}"
+    );
+    let name_end = probe.find("HEAD~1").expect("the spelling paints") + "HEAD~1".len();
+    assert!(probe_at > name_end + 2, "the SHA is right-aligned, not glued to the name:\n{probe}");
+}
+
+#[test]
+fn a_short_sha_prefix_probe_completes_to_the_abbrev() {
+    let (r, mut app) = based_app();
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    let prefix = short[..4].to_string();
+    app.open_base_picker();
+    for ch in prefix.chars() {
+        app.input_push(ch);
+    }
+    app.run_base_probe();
+    let bp = app.base_picker.as_ref().unwrap();
+    assert_eq!(bp.visible()[0].name(), short, "the row is the abbreviated SHA, not the prefix");
+    let frame = render(&app);
+    assert!(
+        frame.lines().any(|l| l.contains(&short) && !l.contains(&format!("({short})"))),
+        "a unique prefix completes to the abbreviated SHA with no marker:\n{frame}"
+    );
+}
+
+#[test]
+fn a_seven_char_sha_probe_is_not_marked() {
+    let (r, mut app) = based_app();
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    app.open_base_picker();
+    for ch in short.chars() {
+        app.input_push(ch);
+    }
+    app.run_base_probe();
+    let frame = render(&app);
+    assert!(frame.contains(&short), "the probe row is the abbreviated SHA:\n{frame}");
+    assert!(
+        !frame.contains(&format!("({short})")),
+        "a spelling that already is that SHA carries no marker:\n{frame}"
+    );
+}
+
+#[test]
+fn a_skipped_named_rev_uses_the_stored_spelling() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.set_origin_default("main", "main");
+    herdr_reviewr::git::write_base_pick(r.path(), "HEAD~1").unwrap();
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let line0 = render(&app).lines().next().unwrap().to_string();
+    assert!(
+        line0.contains("vs main · HEAD~1 missing"),
+        "a skipped non-branch spelling uses the stored spelling: {line0}"
+    );
+}
+
+#[test]
 fn a_skipped_pick_warns_beside_the_resolved_base() {
     let r = Repo::init();
     r.write("hello.rs", "alpha\n");
@@ -3082,6 +3277,28 @@ fn a_dormant_pick_shows_beside_the_empty_state() {
         line0.contains("no base · gone missing"),
         "a dormant choice never reads as never-chosen: {line0}"
     );
+}
+
+#[test]
+fn a_named_rev_clips_the_spelling_and_keeps_the_sha() {
+    let r = Repo::init();
+    r.write("hello.rs", "alpha\n");
+    r.commit_all("init");
+    r.set_origin_default("main", "main");
+    r.git(&["checkout", "-q", "-b", "feature"]);
+    r.write("hello.rs", "alpha\nBETA\n");
+    r.commit_all("edit");
+    let parent = r.git(&["rev-parse", "HEAD~1"]).trim().to_string();
+    let long = format!("release-{}", "x".repeat(80));
+    r.git(&["tag", &long, &parent]);
+    herdr_reviewr::git::write_base_pick(r.path(), &long).unwrap();
+    let mut app = app_on(&r);
+    app.set_scope(Scope::Branch).unwrap();
+    let line0 = dump(&render_size(&app, 80, 20)).lines().next().unwrap().to_string();
+    let short = herdr_reviewr::git::abbreviate_oid(&parent);
+    assert!(line0.contains(&format!("({short})")), "the SHA marker survives the clip: {line0}");
+    assert!(line0.contains('…'), "the spelling truncates: {line0}");
+    assert!(line0.contains("1 changed"), "the right-aligned stats survive: {line0}");
 }
 
 #[test]


### PR DESCRIPTION
## Problem

The pick-base menu (`B`) only listed named branches. Reviewing an agent's work one or two commits back meant making a throwaway branch. Issue #75.

## Change

The pick is the spelling the reviewer typed. It re-resolves like git.

- `HEAD~1` and a tag keep that name. A later commit still diffs one back. The header is `vs HEAD~1 (a1b2c3d)`.
- A unique SHA prefix completes to the 7-char abbrev. A pasted 40-hex stays a pin. SHA is the only freeze; the header shows the abbrev once.
- `--base` branch names still strip prefixes; a non-branch flag (`origin/HEAD`, `HEAD~1`) keeps the typed spelling so it does not paint as live `HEAD`.
- The empty-list probe waits 150ms after typing, or runs immediately on Enter. Config error skips the probe (CFG-BLOCKED-INERT).

Classify lives in `git.rs` (`resolve_spelling` / `classify_flag`). Paint lives in `ui.rs` (`rev_paint`). Specs `review-model`, `input`, and `tui` are Current. Version is `0.33.0`.

## Verify

- `just ci` green
- `/bundled:review` and `/code-review` green
- `just qa-install` done; panes need a close/reopen, then `B` and type `HEAD~1` / a unique SHA prefix / a tag