### PR TITLE
feat(changes): show image previews instead of the binary notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Image previews in Changes.** A supported image in the Diff view paints a visual preview
+  instead of the binary notice. Classification reads raw bytes (never UTF-8 lossy). Other
+  binaries, text diffs, and line comments keep their existing behavior. There is no
+  before/after split yet.
+
 ## [0.36.2] — 2026-08-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +70,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +97,15 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "atomic"
@@ -79,10 +123,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bincode"
@@ -124,6 +221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +239,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -172,6 +296,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,12 +318,32 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "castaway"
@@ -227,6 +377,12 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "compact_str"
@@ -345,7 +501,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -359,6 +515,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -497,7 +659,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -542,6 +704,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,7 +736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -564,6 +746,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "num-complex",
+ "pulp",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -598,6 +797,21 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "fff-grep"
@@ -737,6 +951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,6 +1025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "git2"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +1064,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -909,8 +1150,10 @@ dependencies = [
  "anyhow",
  "dirs 6.0.0",
  "fff-search",
+ "image",
  "pulldown-cmark",
  "ratatui",
+ "ratatui-image",
  "serde",
  "serde_json",
  "similar",
@@ -1010,6 +1253,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfb5a63225620b59df34a235d1fb56ff7b766909c3212a8ff927511a22b181d"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1304,46 @@ dependencies = [
  "walkdir",
  "winapi-util",
 ]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -1099,6 +1392,17 @@ checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -1184,10 +1488,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -1239,6 +1559,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1282,6 +1608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1642,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -1368,10 +1713,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "neo_frizbee"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2f6120a8da26bea3587731072111062c5d8c51ca3a3a75a716bd8b735d5882"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -1387,6 +1748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1765,21 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notify"
@@ -1431,7 +1816,27 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
+ "num-traits",
 ]
 
 [[package]]
@@ -1452,12 +1857,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1532,6 +1958,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
 dependencies = [
  "approx",
+ "bytemuck",
  "fast-srgb8",
  "libm",
  "palette_derive",
@@ -1587,6 +2029,18 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pathdiff"
@@ -1670,7 +2124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1721,6 +2175,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,12 +2209,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1760,6 +2255,68 @@ dependencies = [
  "memchr",
  "unicase",
 ]
+
+[[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quantette"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5d37e94c17b8870a5b936001d2845a6782a22ebdb1706c84294eca777f6729"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "libm",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "palette",
+ "rand 0.10.2",
+ "rand_xoshiro",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -1792,12 +2349,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_core",
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1805,6 +2409,33 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ratatui"
@@ -1854,6 +2485,23 @@ dependencies = [
  "crossterm",
  "instability",
  "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "11.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000b7a22eae639460bc6ec8bb1cc689ecae5b0ed21935cd7d7dd52d38270c86"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.6",
+ "ratatui",
+ "rustix 0.38.44",
+ "self_cell",
+ "thiserror 1.0.69",
+ "windows",
 ]
 
 [[package]]
@@ -1908,6 +2556,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,6 +2633,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -1959,6 +2672,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2721,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +2743,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2011,8 +2763,8 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2028,6 +2780,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2802,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -2162,6 +2929,15 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "similar"
@@ -2310,6 +3086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,8 +3100,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
- "windows-sys 0.61.2",
+ "rustix 1.1.4",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2330,9 +3112,9 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2342,7 +3124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -2377,7 +3159,7 @@ dependencies = [
  "nix",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf",
@@ -2445,6 +3227,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2697,6 +3493,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +3520,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"
@@ -2794,6 +3607,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,7 +3654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -2866,6 +3685,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,7 +3716,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2897,10 +3726,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2909,6 +3802,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2946,6 +3848,22 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
@@ -2954,7 +3872,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.53.1",
  "windows_i686_msvc 0.53.1",
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
@@ -2966,6 +3884,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2981,6 +3905,12 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
@@ -2993,9 +3923,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -3011,6 +3953,12 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
@@ -3020,6 +3968,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3035,6 +3989,12 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
@@ -3044,6 +4004,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3070,10 +4036,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
@@ -3177,3 +4158,27 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ dirs = "6"
 fff-search = "0.10.0"
 pulldown-cmark = { version = "0.13.4", default-features = false }
 ratatui = "0.30"
+# No chafa-dyn: the herdr plugin ships a portable binary without libchafa at runtime.
+# Halfblocks remains the unicode fallback when Kitty/Sixel/iTerm2 are unavailable.
+ratatui-image = { version = "11.0.6", default-features = false, features = ["crossterm", "image-defaults"] }
+image = "0.25"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 similar = { version = "3.1.1", features = ["text"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,6 +5,7 @@
 //! whole interaction model is testable without a backend. `src/main.rs` owns the
 //! terminal and maps input events onto these methods.
 
+use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -18,10 +19,12 @@ use crate::forge;
 use crate::git;
 use crate::herdr::{self, AgentChoice, SendTarget};
 use crate::highlight::Highlighter;
+use crate::image_view::{self, ContentKind, ImagePane};
 use crate::logln;
 use crate::model::{Comment, CommentStore, CommitPick, Rev, Scope, Side};
 use crate::theme::{self, Palette};
 use crate::world::{PickStatus, PickVerdict};
+use ratatui_image::picker::Picker;
 
 /// Navigator shares and bounds, as percentages of the body's split axis.
 const DEFAULT_SIDE_PCT: u16 = 32;
@@ -112,6 +115,9 @@ struct TabStash {
     /// Whether this tab has ever completed a reload. A never-visited tab has nothing worth
     /// painting, so its first entry loads before the frame instead of deferring.
     visited: bool,
+    /// Image preview state for the Changes tab (`specs/diff-view.md`). `All files` leaves
+    /// this empty in v1.
+    image_pane: Option<ImagePane>,
 }
 
 /// A file crossing offered by the footer, waiting for the hunk step that armed it to repeat: the
@@ -681,6 +687,16 @@ pub struct App {
     /// content does not render as a preview: a non-markdown file, a notice, or an empty new
     /// side (a deleted or empty file). One half of the `previewable()` signal.
     preview_text: String,
+    /// Fitted image protocol for the Changes Diff view when `diff.state` is `Image`
+    /// (`specs/diff-view.md` Image preview). Cleared for every non-image open.
+    /// `RefCell` so paint can fit the protocol into the pane area without `&mut App`.
+    image_pane: RefCell<Option<ImagePane>>,
+    /// True when the open file is an image but decode/encode failed — UI paints
+    /// `could not display image` instead of the binary notice.
+    image_failed: Cell<bool>,
+    /// Graphics-protocol picker for image encode. Defaults to halfblocks (tests); `run`
+    /// replaces it with a stdio-queried picker after alternate-screen entry.
+    image_picker: Picker,
     /// The preview's maximum useful scroll (rendered lines minus the viewport), noted
     /// by the renderer each frame so [`Self::preview_scroll_by`] can clamp. `usize::MAX`
     /// until the first paint.
@@ -896,6 +912,9 @@ impl App {
             preview: false,
             preview_scroll: 0,
             preview_text: String::new(),
+            image_pane: RefCell::new(None),
+            image_failed: Cell::new(false),
+            image_picker: Picker::halfblocks(),
             preview_max_scroll: std::cell::Cell::new(usize::MAX),
             preview_scrolled: false,
             pane_width: std::cell::Cell::new(0),
@@ -1409,6 +1428,7 @@ impl App {
             self.diff = FileDiff::empty();
             self.diff_path = None;
             self.visible.clear();
+            self.clear_image_pane();
             self.reset_diff_view();
             return;
         };
@@ -1440,7 +1460,39 @@ impl App {
             self.preview_max_scroll.set(usize::MAX);
         }
         self.diff_path = Some(path.clone());
-        let (old, new) = self.content_sides(&path, previous_path.as_deref());
+        let (old_bytes, new_bytes) = self.content_sides_bytes(&path, previous_path.as_deref());
+        let display = image_view::display_side(&old_bytes, &new_bytes);
+        match image_view::classify(display) {
+            ContentKind::Image => {
+                self.set_image_diff(path, previous_path, display);
+                return;
+            }
+            ContentKind::TooLarge => {
+                self.clear_image_pane();
+                self.diff = FileDiff::too_large_diff_notice(path, previous_path);
+                self.preview_text.clear();
+                self.rebuild_visible();
+                self.settle_read();
+                return;
+            }
+            ContentKind::Binary => {
+                // Display side is a non-image binary. Still run the text path when the other
+                // side might be text-only? Spec: non-image binary → binary notice. If either
+                // side has NUL, existing build also yields Binary — prefer the explicit notice.
+                self.clear_image_pane();
+                self.diff = FileDiff::binary_notice(path, previous_path);
+                self.preview_text.clear();
+                self.rebuild_visible();
+                self.settle_read();
+                return;
+            }
+            ContentKind::Text => {}
+        }
+        // Text display side, but the opposite side may still be binary — keep the historical
+        // NUL check inside `FileDiff::build` via the lossy string sides.
+        let old = String::from_utf8_lossy(&old_bytes).into_owned();
+        let new = String::from_utf8_lossy(&new_bytes).into_owned();
+        self.clear_image_pane();
         self.diff = self.cache.get(path, previous_path, &old, &new, &self.highlighter);
         // Hold the new side as the preview's render input, the same current content the File
         // view previews. A non-markdown file, a notice, or a deleted file (empty new side)
@@ -1452,6 +1504,81 @@ impl App {
         }
         self.rebuild_visible();
         self.settle_read();
+    }
+
+    /// Open a decoded image in the Diff pane (`specs/diff-view.md` Image preview).
+    fn set_image_diff(&mut self, path: String, previous_path: Option<String>, bytes: &[u8]) {
+        self.preview_text.clear();
+        self.preview = false;
+        if let Some(image) = image_view::decode(bytes) {
+            let hash = image_view::bytes_hash(bytes);
+            // Reuse the fitted protocol when the same bytes are still open (a poll).
+            let reuse = self
+                .image_pane
+                .borrow()
+                .as_ref()
+                .is_some_and(|p| p.path == path && p.content_hash == hash);
+            if !reuse {
+                *self.image_pane.borrow_mut() = Some(ImagePane::new(path.clone(), hash, image));
+            }
+            self.image_failed.set(false);
+            self.diff = FileDiff::image_notice(path, previous_path);
+        } else {
+            self.clear_image_pane();
+            self.image_failed.set(true);
+            self.diff = FileDiff::image_notice(path, previous_path);
+        }
+        self.rebuild_visible();
+        self.settle_read();
+    }
+
+    fn clear_image_pane(&mut self) {
+        *self.image_pane.borrow_mut() = None;
+        self.image_failed.set(false);
+    }
+
+    /// Install the graphics picker discovered after alternate-screen entry (`lib::run`).
+    pub fn set_image_picker(&mut self, picker: Picker) {
+        self.image_picker = picker;
+        // Re-open the image so the protocol is encoded with the real terminal capability.
+        if self.diff.state == crate::diff::FileState::Image
+            && let Some(path) = self.diff_path.clone()
+        {
+            let previous = self.diff.previous_path.clone();
+            *self.image_pane.borrow_mut() = None;
+            self.set_diff(path, previous);
+        }
+    }
+
+    /// Fit the open image into `area` for paint. Returns whether a protocol is ready.
+    pub fn ensure_image_fitted(&self, area: ratatui::layout::Size) -> bool {
+        let mut pane = self.image_pane.borrow_mut();
+        let Some(pane) = pane.as_mut() else {
+            return false;
+        };
+        if pane.ensure_fitted(&self.image_picker, area) {
+            self.image_failed.set(false);
+            true
+        } else {
+            self.image_failed.set(true);
+            false
+        }
+    }
+
+    /// Whether the Diff pane should paint the image-error notice.
+    #[must_use]
+    pub fn image_display_failed(&self) -> bool {
+        self.diff.state == crate::diff::FileState::Image
+            && (self.image_failed.get() || self.image_pane.borrow().is_none())
+    }
+
+    /// Borrow the image pane for paint after a successful [`Self::ensure_image_fitted`].
+    pub fn with_image_protocol<R>(
+        &self,
+        f: impl FnOnce(&ratatui_image::protocol::Protocol) -> R,
+    ) -> Option<R> {
+        let pane = self.image_pane.borrow();
+        pane.as_ref().and_then(ImagePane::protocol).map(f)
     }
 
     /// Build the File view for `path`: its current worktree content as `Context` rows, no
@@ -1466,6 +1593,7 @@ impl App {
         }
         self.diff_path = Some(path.to_string());
         self.expanded_folds.clear(); // the File view has no folds
+        self.clear_image_pane(); // image preview is Changes-only in v1
         let (diff, content) = self.file_view(path);
         // Keep the preview's render input current without a per-frame rebuild. A file the
         // source view degrades to a notice never previews, so its
@@ -1567,12 +1695,19 @@ impl App {
     /// merge-base on the branch scope), new from the worktree. A rename reads its old side
     /// from `previous_path`, so the diff shows real edits, not a wholesale delete-and-add.
     fn content_sides(&self, path: &str, previous_path: Option<&str>) -> (String, String) {
+        let (old, new) = self.content_sides_bytes(path, previous_path);
+        (String::from_utf8_lossy(&old).into_owned(), String::from_utf8_lossy(&new).into_owned())
+    }
+
+    /// Raw old/new bytes for the current scope — image classification must not go through
+    /// UTF-8 lossy (`specs/diff-view.md` Image preview).
+    fn content_sides_bytes(&self, path: &str, previous_path: Option<&str>) -> (Vec<u8>, Vec<u8>) {
         let new_path = path;
         let old_path = previous_path.unwrap_or(new_path);
         match self.scope {
             Scope::Uncommitted => {
-                let old = git::file_content(&self.repo, "HEAD", old_path);
-                let new = worktree_content(&self.repo, new_path);
+                let old = git::file_bytes(&self.repo, "HEAD", old_path);
+                let new = worktree_bytes(&self.repo, new_path);
                 (old, new)
             }
             Scope::Branch => {
@@ -1581,25 +1716,24 @@ impl App {
                     .winner
                     .as_ref()
                     .and_then(|b| git::merge_base(&self.repo, b.oid()));
-                let old =
-                    mb.map(|m| git::file_content(&self.repo, &m, old_path)).unwrap_or_default();
-                (old, worktree_content(&self.repo, new_path))
+                let old = mb.map(|m| git::file_bytes(&self.repo, &m, old_path)).unwrap_or_default();
+                (old, worktree_bytes(&self.repo, new_path))
             }
             Scope::LastTurn => {
                 let old = self
                     .turn_baseline
                     .as_deref()
-                    .map(|b| git::file_content(&self.repo, b, old_path))
+                    .map(|b| git::file_bytes(&self.repo, b, old_path))
                     .unwrap_or_default();
-                (old, worktree_content(&self.repo, new_path))
+                (old, worktree_bytes(&self.repo, new_path))
             }
             // Both sides from the commits: `A^` and `B`.
             Scope::Commits => {
-                let Some(pick) = &self.commit_pick else { return (String::new(), String::new()) };
+                let Some(pick) = &self.commit_pick else { return (Vec::new(), Vec::new()) };
                 let old = git::parent_or_empty(&self.repo, &pick.oldest)
-                    .map(|a| git::file_content(&self.repo, &a, old_path))
+                    .map(|a| git::file_bytes(&self.repo, &a, old_path))
                     .unwrap_or_default();
-                (old, git::file_content(&self.repo, &pick.newest, new_path))
+                (old, git::file_bytes(&self.repo, &pick.newest, new_path))
             }
         }
     }
@@ -1694,6 +1828,12 @@ impl App {
         self.select_anchor = None;
     }
 
+    /// Whether the Diff pane is showing an image preview (no text rows).
+    #[must_use]
+    pub fn image_active(&self) -> bool {
+        self.diff.state == crate::diff::FileState::Image
+    }
+
     /// Scroll the diff horizontally by `delta` columns, clamped at the left edge. A no-op
     /// while wrap is on, since the renderer ignores `h_scroll` when wrapping — so the offset
     /// never silently accumulates and then jumps the view when wrap is toggled off.
@@ -1710,8 +1850,8 @@ impl App {
 
     /// Toggle line wrap; reset the horizontal scroll, which only applies with wrap off.
     pub fn toggle_wrap(&mut self) {
-        if self.preview_active() {
-            return; // the wrap toggle is inert in the preview
+        if self.preview_active() || self.image_active() {
+            return; // wrap is inert in preview and image panes
         }
         self.wrap = !self.wrap;
         self.h_scroll = 0;
@@ -2529,6 +2669,10 @@ impl App {
         std::mem::swap(&mut self.preview_scroll, &mut self.stash.preview_scroll);
         std::mem::swap(&mut self.preview_text, &mut self.stash.preview_text);
         std::mem::swap(&mut self.preview_scrolled, &mut self.stash.preview_scrolled);
+        {
+            let mut active = self.image_pane.borrow_mut();
+            std::mem::swap(&mut *active, &mut self.stash.image_pane);
+        }
         std::mem::swap(&mut self.tab_visited, &mut self.stash.visited);
     }
 
@@ -3132,8 +3276,8 @@ impl App {
     }
 
     pub fn start_comment(&mut self) {
-        if self.preview_active() {
-            return; // the preview is read-only
+        if self.preview_active() || self.image_active() {
+            return; // preview and image panes are read-only
         }
         if self.focus == Focus::Diff && self.has_anchorable_selection() {
             self.reveal_diff = true; // scroll the anchored line into view before the box opens
@@ -4902,9 +5046,12 @@ fn is_markdown_path(path: &str) -> bool {
 /// The working-tree content of `path`, lossily as UTF-8; empty when the file is
 /// absent (a deletion) or unreadable.
 fn worktree_content(repo: &std::path::Path, path: &str) -> String {
-    std::fs::read(repo.join(path))
-        .map(|b| String::from_utf8_lossy(&b).into_owned())
-        .unwrap_or_default()
+    String::from_utf8_lossy(&worktree_bytes(repo, path)).into_owned()
+}
+
+/// Raw working-tree bytes of `path`; empty when absent or unreadable.
+fn worktree_bytes(repo: &std::path::Path, path: &str) -> Vec<u8> {
+    std::fs::read(repo.join(path)).unwrap_or_default()
 }
 
 fn line_in(c: &Comment, row: &Row) -> bool {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -110,12 +110,14 @@ impl Row {
     }
 }
 
-/// Whether the file renders as rows, or a notice instead.
+/// Whether the file renders as rows, or a notice / image preview instead.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum FileState {
     Normal,
     Binary,
     TooLarge,
+    /// A supported image in the Changes Diff view (`specs/diff-view.md` Image preview).
+    Image,
 }
 
 /// How the pane renders the model: the `Changes` diff, or the `All files` whole-file content.
@@ -282,6 +284,22 @@ impl FileDiff {
             view: View::File,
             rows: Vec::new(),
         }
+    }
+
+    /// The Diff-view image placeholder: no rows; the pane paints via `App`'s image state
+    /// (`specs/diff-view.md` Image preview).
+    pub fn image_notice(path: String, previous_path: Option<String>) -> Self {
+        Self { path, previous_path, state: FileState::Image, view: View::Diff, rows: Vec::new() }
+    }
+
+    /// The Diff-view `too_large` notice without reading or diffing the sides.
+    pub fn too_large_diff_notice(path: String, previous_path: Option<String>) -> Self {
+        Self { path, previous_path, state: FileState::TooLarge, view: View::Diff, rows: Vec::new() }
+    }
+
+    /// The Diff-view binary notice without reading or diffing the sides.
+    pub fn binary_notice(path: String, previous_path: Option<String>) -> Self {
+        Self { path, previous_path, state: FileState::Binary, view: View::Diff, rows: Vec::new() }
     }
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -25,15 +25,15 @@ fn git(repo: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
-/// Like [`git`], but returns stdout even on non-zero exit (e.g. `diff --no-index`).
-fn git_lenient(repo: &Path, args: &[&str]) -> String {
+/// Like [`git`], but returns stdout bytes even on non-zero exit (e.g. missing `rev:path`).
+fn git_lenient_bytes(repo: &Path, args: &[&str]) -> Vec<u8> {
     crate::proc::command("git")
         .arg("-C")
         .arg(repo)
         .args(["-c", "core.quotepath=false"])
         .args(args)
         .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+        .map(|o| o.stdout)
         .unwrap_or_default()
 }
 
@@ -1000,7 +1000,14 @@ pub fn merge_base(repo: &Path, base_oid: &str) -> Option<String> {
 /// The content of `path` at `rev` (`git show <rev>:<path>`). Empty when the path does
 /// not exist at that rev — an added file against its old side, say.
 pub fn file_content(repo: &Path, rev: &str, path: &str) -> String {
-    git_lenient(repo, &["show", &format!("{rev}:{path}")])
+    String::from_utf8_lossy(&file_bytes(repo, rev, path)).into_owned()
+}
+
+/// Raw bytes of `path` at `rev` (`git show <rev>:<path>`). Empty when the path does not
+/// exist at that rev. Used for image classification — never UTF-8 lossy
+/// (`specs/diff-view.md` Image preview).
+pub fn file_bytes(repo: &Path, rev: &str, path: &str) -> Vec<u8> {
+    git_lenient_bytes(repo, &["show", &format!("{rev}:{path}")])
 }
 
 // --- base pick (branch scope) --------------------------------------------------

--- a/src/image_view.rs
+++ b/src/image_view.rs
@@ -1,0 +1,198 @@
+//! Image classification and preview helpers for the Changes Diff view
+//! (`specs/diff-view.md` Image preview).
+
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::io::Cursor;
+
+use image::DynamicImage;
+use ratatui::layout::{Rect, Size};
+use ratatui_image::picker::Picker;
+use ratatui_image::protocol::Protocol;
+use ratatui_image::{Image, Resize};
+
+/// Byte budget for a single image side. Larger blobs degrade to `too_large` without decode.
+pub const MAX_IMAGE_BYTES: usize = 8_000_000;
+
+/// How raw file bytes should be shown in the Diff view.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ContentKind {
+    /// Valid image decode — paint the visual preview.
+    Image,
+    /// No NUL and not an image — the text diff pipeline.
+    Text,
+    /// NUL-bearing non-image (or undecodable binary) — the binary notice.
+    Binary,
+    /// Over the image byte budget.
+    TooLarge,
+}
+
+/// Classify `bytes` for the Changes Diff view: image decode wins over the NUL binary rule.
+#[must_use]
+pub fn classify(bytes: &[u8]) -> ContentKind {
+    if bytes.is_empty() {
+        return ContentKind::Text;
+    }
+    if bytes.len() > MAX_IMAGE_BYTES {
+        return ContentKind::TooLarge;
+    }
+    if decode(bytes).is_some() {
+        return ContentKind::Image;
+    }
+    if bytes.contains(&0) { ContentKind::Binary } else { ContentKind::Text }
+}
+
+/// Decode image bytes when the format is recognized; `None` on failure.
+#[must_use]
+pub fn decode(bytes: &[u8]) -> Option<DynamicImage> {
+    let reader = image::ImageReader::new(Cursor::new(bytes)).with_guessed_format().ok()?;
+    reader.decode().ok()
+}
+
+/// Content hash for cache invalidation of an image pane (path-independent; path is separate).
+#[must_use]
+pub fn bytes_hash(bytes: &[u8]) -> u64 {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut h);
+    h.finish()
+}
+
+/// The open image in the Diff pane: decoded pixels plus a fitted protocol for paint.
+///
+/// `Protocol` does not implement `Debug`; this type does, so `App` can keep deriving it.
+pub struct ImagePane {
+    pub path: String,
+    pub content_hash: u64,
+    image: DynamicImage,
+    protocol: Option<Protocol>,
+    /// Cell size the current `protocol` was fitted for; recreate when the pane area changes.
+    fitted: Option<Size>,
+}
+
+impl fmt::Debug for ImagePane {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ImagePane")
+            .field("path", &self.path)
+            .field("content_hash", &self.content_hash)
+            .field("fitted", &self.fitted)
+            .field("has_protocol", &self.protocol.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ImagePane {
+    /// Build a pane from already-decoded pixels. Protocol is created on first fit.
+    #[must_use]
+    pub fn new(path: String, content_hash: u64, image: DynamicImage) -> Self {
+        Self { path, content_hash, image, protocol: None, fitted: None }
+    }
+
+    /// Ensure `protocol` fits `area`, recreating when the cell size changes.
+    /// Returns `false` when encoding fails (caller paints the error notice).
+    pub fn ensure_fitted(&mut self, picker: &Picker, area: Size) -> bool {
+        if area.width == 0 || area.height == 0 {
+            return false;
+        }
+        if self.fitted == Some(area) && self.protocol.is_some() {
+            return true;
+        }
+        if let Ok(protocol) = picker.new_protocol(self.image.clone(), area, Resize::Fit(None)) {
+            self.protocol.replace(protocol);
+            self.fitted = Some(area);
+            true
+        } else {
+            self.protocol = None;
+            self.fitted = None;
+            false
+        }
+    }
+
+    /// The protocol ready for [`Image`], if fitted.
+    #[must_use]
+    pub fn protocol(&self) -> Option<&Protocol> {
+        self.protocol.as_ref()
+    }
+}
+
+/// Center a widget of `size` inside `area`.
+#[must_use]
+pub fn centered(area: Rect, size: Size) -> Rect {
+    let width = size.width.min(area.width);
+    let height = size.height.min(area.height);
+    let x = area.x + area.width.saturating_sub(width) / 2;
+    let y = area.y + area.height.saturating_sub(height) / 2;
+    Rect { x, y, width, height }
+}
+
+/// Paint an fitted image protocol into `area`, centered.
+pub fn render_centered(frame: &mut ratatui::Frame, protocol: &Protocol, area: Rect) {
+    let size = protocol.size();
+    let target = centered(area, size);
+    frame.render_widget(Image::new(protocol), target);
+}
+
+/// Prefer the worktree (new) side when present; otherwise the old side (a deletion).
+#[must_use]
+pub fn display_side<'a>(old: &'a [u8], new: &'a [u8]) -> &'a [u8] {
+    if new.is_empty() { old } else { new }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ContentKind, MAX_IMAGE_BYTES, classify, decode, display_side};
+
+    fn tiny_png() -> Vec<u8> {
+        let img = image::RgbImage::from_pixel(2, 2, image::Rgb([0xff, 0x00, 0x80]));
+        let mut buf = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, image::ImageFormat::Png)
+            .expect("encode png");
+        buf.into_inner()
+    }
+
+    use std::io::Cursor;
+
+    #[test]
+    fn classify_png_as_image() {
+        let png = tiny_png();
+        assert!(decode(&png).is_some());
+        assert_eq!(classify(&png), ContentKind::Image);
+    }
+
+    #[test]
+    fn classify_text_as_text() {
+        assert_eq!(classify(b"fn main() {}\n"), ContentKind::Text);
+    }
+
+    #[test]
+    fn classify_nul_binary_as_binary() {
+        assert_eq!(classify(b"\0\0\0seed\0"), ContentKind::Binary);
+    }
+
+    #[test]
+    fn classify_empty_as_text() {
+        assert_eq!(classify(b""), ContentKind::Text);
+    }
+
+    #[test]
+    fn classify_corrupt_png_header_with_nul_as_binary() {
+        // PNG magic then NUL junk that will not decode.
+        let mut bytes = b"\x89PNG\r\n\x1a\n".to_vec();
+        bytes.extend_from_slice(&[0, 0, 0, 1, b'I', b'H', b'D', b'R', 0]);
+        assert_eq!(classify(&bytes), ContentKind::Binary);
+    }
+
+    #[test]
+    fn classify_oversize_as_too_large() {
+        let mut bytes = tiny_png();
+        bytes.resize(MAX_IMAGE_BYTES + 1, 0);
+        assert_eq!(classify(&bytes), ContentKind::TooLarge);
+    }
+
+    #[test]
+    fn display_side_prefers_new() {
+        assert_eq!(display_side(b"old", b"new"), b"new");
+        assert_eq!(display_side(b"old", b""), b"old");
+        assert_eq!(display_side(b"", b"new"), b"new");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod highlight;
 pub mod keymap;
 #[macro_use]
 pub mod log;
+pub mod image_view;
 pub mod markdown;
 pub mod model;
 pub mod proc;
@@ -81,6 +82,12 @@ pub fn run() -> Result<()> {
     let mut app = app_for(&cfg, &initial_config);
 
     let mut terminal = ratatui::init();
+    // Halfblocks only: `Picker::from_query_stdio` on a silent PTY times out while leaving a
+    // stdin reader that steals the next keypress, so the event loop never sees it. The unicode
+    // fallback still paints the preview (`specs/diff-view.md` Image preview). Kitty/Sixel via
+    // a safe capability probe is a later change.
+    let image_picker = ratatui_image::picker::Picker::halfblocks();
+    app.set_image_picker(image_picker.clone());
     // The kitty keyboard protocol reports modifiers on keys the legacy encoding drops — most
     // notably Ctrl/Alt+arrows — so word-jump by arrow works where the terminal supports it.
     let kbd = supports_keyboard_enhancement().unwrap_or(false);
@@ -121,6 +128,7 @@ pub fn run() -> Result<()> {
         cfg.plugin_config_dir = Some(dir.into());
         initial_config = config::plugin_config(cfg.plugin_config_dir.as_deref());
         app = app_for(&cfg, &initial_config);
+        app.set_image_picker(image_picker.clone());
         if let Err(error) = terminal.draw(|f| ui::render(f, &app)) {
             restore_terminal(kbd);
             herdr::clear_pane_label();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1814,13 +1814,28 @@ fn render_diff_view(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(block, area);
     app.note_diff_width(inner.width as usize);
 
+    // Image preview: visual pane, no text rows (`specs/diff-view.md` Image preview).
+    if app.image_active() {
+        let size = ratatui::layout::Size::new(inner.width, inner.height);
+        if app.ensure_image_fitted(size) {
+            let painted = app.with_image_protocol(|protocol| {
+                crate::image_view::render_centered(frame, protocol, inner);
+            });
+            if painted.is_some() {
+                return;
+            }
+        }
+        frame.render_widget(dim_paragraph("could not display image", p), inner);
+        return;
+    }
+
     if app.visible.is_empty() {
         // `All files` is a content browser, not a diff, so its empty/notice copy avoids diff
         // vocabulary and never shows the last-turn "waiting" state.
         let gone = app.commits_gone_message();
         let msg = match app.tab {
             Tab::AllFiles => match app.diff.state {
-                FileState::Binary => "binary — no line comments",
+                FileState::Binary | FileState::Image => "binary — no line comments",
                 FileState::TooLarge => "file too large",
                 FileState::Normal if app.diff_path.is_some() => "empty file",
                 FileState::Normal => "select a file to read",
@@ -1830,6 +1845,7 @@ fn render_diff_view(frame: &mut Frame, app: &App, area: Rect) {
             _ => match app.diff.state {
                 FileState::Binary => "binary — no line comments",
                 FileState::TooLarge => "file too large to diff",
+                FileState::Image => "could not display image",
                 FileState::Normal => "no diff",
             },
         };
@@ -3733,7 +3749,7 @@ fn render_search_preview(
         return;
     };
     let notice = match pv.diff.state {
-        FileState::Binary => Some("binary — no line comments"),
+        FileState::Binary | FileState::Image => Some("binary — no line comments"),
         FileState::TooLarge => Some("file too large"),
         FileState::Normal if pv.diff.rows.is_empty() => Some("no preview"),
         FileState::Normal => None,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -114,6 +114,14 @@ impl Repo {
         std::fs::write(path, contents).expect("write");
     }
 
+    pub fn write_bytes(&self, rel: &str, contents: &[u8]) {
+        let path = self.path().join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir");
+        }
+        std::fs::write(path, contents).expect("write");
+    }
+
     pub fn remove(&self, rel: &str) {
         std::fs::remove_file(self.path().join(rel)).expect("remove");
     }

--- a/tests/git_repo.rs
+++ b/tests/git_repo.rs
@@ -682,6 +682,24 @@ fn a_binary_change_lists_with_zero_stats() {
 }
 
 #[test]
+fn file_bytes_round_trips_png_without_utf8_lossy() {
+    use herdr_reviewr::git::file_bytes;
+    let r = Repo::init();
+    let png = {
+        use std::io::Cursor;
+        let img = image::RgbImage::from_pixel(2, 2, image::Rgb([1, 2, 3]));
+        let mut buf = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgb8(img).write_to(&mut buf, image::ImageFormat::Png).unwrap();
+        buf.into_inner()
+    };
+    r.write_bytes("logo.png", &png);
+    r.commit_all("init");
+    let got = file_bytes(r.path(), "HEAD", "logo.png");
+    assert_eq!(got, png, "raw bytes must match the committed blob");
+    assert!(image::load_from_memory(&got).is_ok(), "bytes must still decode");
+}
+
+#[test]
 fn git_access_never_mutates_the_repo() {
     let r = Repo::init();
     r.write("a.rs", "x\n");

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -6,6 +6,7 @@ mod common;
 use common::{Repo, app_on, enter_tab};
 use herdr_reviewr::app::{App, BaseChoice, BasePicker, BaseProbe, Focus, Mode, Tab};
 use herdr_reviewr::config::NavigatorPosition;
+use herdr_reviewr::diff::FileState;
 use herdr_reviewr::herdr::AgentChoice;
 use herdr_reviewr::keymap::Keymap;
 use herdr_reviewr::model::Scope;
@@ -1300,6 +1301,52 @@ fn a_binary_file_shows_the_no_line_comments_message() {
 
     let out = render(&app);
     assert!(out.contains("binary — no line comments"), "binary diff message shown:\n{out}");
+}
+
+fn tiny_png_bytes(rgb: [u8; 3]) -> Vec<u8> {
+    use std::io::Cursor;
+    let img = image::RgbImage::from_pixel(4, 4, image::Rgb(rgb));
+    let mut buf = Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgb8(img)
+        .write_to(&mut buf, image::ImageFormat::Png)
+        .expect("encode png");
+    buf.into_inner()
+}
+
+#[test]
+fn an_image_file_shows_a_visual_preview_not_the_binary_notice() {
+    let r = Repo::init();
+    r.write_bytes("logo.png", &tiny_png_bytes([0x10, 0x20, 0x30]));
+    r.commit_all("init");
+    r.write_bytes("logo.png", &tiny_png_bytes([0xaa, 0xbb, 0xcc]));
+
+    let mut app = app_on(&r);
+    let idx = app.entries.iter().position(|f| f.path == "logo.png").expect("image listed");
+    app.select_file(idx).unwrap();
+
+    assert_eq!(app.diff.state, FileState::Image);
+    assert!(app.image_active());
+    let out = render(&app);
+    assert!(
+        !out.contains("binary — no line comments"),
+        "image must not use the binary notice:\n{out}"
+    );
+    assert!(!out.contains("could not display image"), "halfblocks preview should paint:\n{out}");
+}
+
+#[test]
+fn an_image_file_does_not_accept_line_comments() {
+    let r = Repo::init();
+    r.write_bytes("pic.png", &tiny_png_bytes([1, 2, 3]));
+    r.commit_all("init");
+    r.write_bytes("pic.png", &tiny_png_bytes([9, 8, 7]));
+
+    let mut app = app_on(&r);
+    let idx = app.entries.iter().position(|f| f.path == "pic.png").unwrap();
+    app.select_file(idx).unwrap();
+    app.focus = Focus::Diff;
+    app.start_comment();
+    assert!(!matches!(app.mode, Mode::Composing { .. }), "image preview is read-only");
 }
 
 #[test]


### PR DESCRIPTION
## What

Supported images in the Changes Diff view paint a visual preview instead of the binary notice. Non-image binaries and text diffs are unchanged; previews use unicode halfblocks so a silent terminal never eats the first keypress.

## Checklist

- [X] `just ci` is green
- [X] The governing spec under `specs/` says the new behavior (or the change touches no behavior)
- [X] `CHANGELOG.md` has a bullet under `## [Unreleased]` (or the change is invisible to users)
- [X] Perf-relevant paths (reload, render, git, highlight): before/after numbers from `scripts/bench_tui.py` are in the description
