### PR TITLE
feat: add edit-file action to open the cursor's file in $EDITOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- **Edit the file under the cursor in your editor.** `E` opens the file you're reviewing in
-  `$VISUAL`/`$EDITOR` — at the line under the cursor in the diff, at the selected file in
-  the tree, or at a highlighted comment's anchor from the comments list. `Ctrl+E` does it
-  from the search screen on the picked result, where every printable key types into the
-  query. reviewr suspends while the editor runs and refreshes the diff when you return, so
-  your edits show up immediately. Rebindable as `edit-file`.
+- **Edit the file under the cursor in your editor.** `Ctrl+E` opens the file you're
+  reviewing in `$VISUAL`/`$EDITOR` — at the line under the cursor in the diff, at the
+  selected file in the tree, or at a highlighted comment's anchor from the comments list.
+  The chord also works from the search screen on the picked result, where every printable
+  key types into the query. reviewr suspends while the editor runs and refreshes the diff
+  when you return, so your edits show up immediately. Rebindable as `edit-file`.
 
 ## [0.34.0] — 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Edit the file under the cursor in your editor.** `E` opens the file you're reviewing in
+  `$VISUAL`/`$EDITOR` — at the line under the cursor in the diff, at the selected file in
+  the tree, or at a highlighted comment's anchor from the comments list. reviewr suspends
+  while the editor runs and refreshes the diff when you return, so your edits show up
+  immediately. Rebindable as `edit-file`.
+
 ## [0.34.0] — 2026-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - **Edit the file under the cursor in your editor.** `E` opens the file you're reviewing in
   `$VISUAL`/`$EDITOR` — at the line under the cursor in the diff, at the selected file in
-  the tree, or at a highlighted comment's anchor from the comments list. reviewr suspends
-  while the editor runs and refreshes the diff when you return, so your edits show up
-  immediately. Rebindable as `edit-file`.
+  the tree, or at a highlighted comment's anchor from the comments list. `Ctrl+E` does it
+  from the search screen on the picked result, where every printable key types into the
+  query. reviewr suspends while the editor runs and refreshes the diff when you return, so
+  your edits show up immediately. Rebindable as `edit-file`.
 
 ## [0.34.0] — 2026-08-20
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The keys below are defaults. You can rebind every action, even to several keys a
 | `v` | Select lines |
 | `c` | Comment on line or selection |
 | `e` `d` | Edit / delete comment |
-| `E` · `Ctrl+E` | Open the file under the cursor in `$EDITOR` (`Ctrl+E` works from the search screen on the picked result) |
+| `Ctrl+E` | Open the file under the cursor in `$EDITOR` — works from the search screen on the picked result |
 | `n` `N` | Jump to next / previous comment |
 | `l` | List all comments |
 | `s` | Send comments to agent |

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The keys below are defaults. You can rebind every action, even to several keys a
 | `v` | Select lines |
 | `c` | Comment on line or selection |
 | `e` `d` | Edit / delete comment |
-| `E` | Open the file under the cursor in `$EDITOR` |
+| `E` · `Ctrl+E` | Open the file under the cursor in `$EDITOR` (`Ctrl+E` works from the search screen on the picked result) |
 | `n` `N` | Jump to next / previous comment |
 | `l` | List all comments |
 | `s` | Send comments to agent |

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The keys below are defaults. You can rebind every action, even to several keys a
 | `v` | Select lines |
 | `c` | Comment on line or selection |
 | `e` `d` | Edit / delete comment |
+| `E` | Open the file under the cursor in `$EDITOR` |
 | `n` `N` | Jump to next / previous comment |
 | `l` | List all comments |
 | `s` | Send comments to agent |

--- a/specs/input.md
+++ b/specs/input.md
@@ -48,6 +48,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 | `comment`                                                | comment on the selection                    | `c`, type, `enter`                          | click or drag the gutter                       |
 | —                                                        | copy text (`text-selection.md`)             | —                                           | drag over text                                 |
 | `edit`                                                   | edit the comment under the cursor           | `e`                                         | —                                              |
+| `edit-file`                                              | open the file under the cursor in `$EDITOR` | `E`                                         | —                                              |
 | `delete`                                                 | delete the comment under the cursor         | `d`                                         | —                                              |
 | `next-comment` / `prev-comment`                          | jump to next / previous comment             | `n` / `N`                                   | —                                              |
 | `comments`                                               | list and manage all comments                | `l`                                         | —                                              |
@@ -107,6 +108,35 @@ The steps and the skips share the rest:
 - On a directory row in the focused file list, `expand` shows its children and `collapse` hides them.
 - On a fold in the diff, `expand` opens it. An open fold never closes again, so `collapse` scrolls there.
 - Elsewhere, `expand` scrolls the diff right and `collapse` scrolls it left. The scroll is inert while wrap is on.
+
+### Edit file
+
+`edit-file` opens the file the cursor names in the user's editor, so a fix spotted mid-review
+is one keypress away. The target follows the press:
+
+- In the read pane — the `Changes` diff, an `All files` File view, or a markdown preview —
+  the open file at the line under the cursor. A deletion or fold row carries no new-file
+  number, so the nearest numbered row above it names the line.
+- On a file row in the navigator, that file, without a line. A directory row is inert.
+- In the comments list, the highlighted comment's file at its anchor start. An old-side
+  anchor numbers revision lines rather than worktree lines, so it opens without one.
+
+The comment editor, the find band, the agent picker, and the base picker are text fields and
+strictly modal: every printable is theirs, so `edit-file` never fires there. The search
+screen's pick opens with `enter`, and `E` works from the opened file. The `PR` tab has no
+files to name and stays inert.
+
+The pane suspends — alternate screen, raw mode, mouse capture, bracketed paste, and the
+keyboard protocol all release — so the editor owns the terminal cleanly, then rebuilds the
+same mode stack on return. The editor is `$VISUAL` or `$EDITOR`, run through the host PATH;
+its whole value is the command, so `code -w` works. When a line is known it passes as
+`+LINE` before the path, the convention vim, nvim, nano, hx, and kakoune share; editors
+without it open at their own position. With neither variable set, the press reports what to
+set instead of failing silently.
+
+A successful edit refreshes the changeset, so the diff reconciles to the edited file in place
+(`overview.md` Continuity) — reviewr itself still never writes (`overview.md`). The status
+names the edited file; a nonzero exit or a failed launch reports it instead.
 
 ### Footer
 

--- a/specs/input.md
+++ b/specs/input.md
@@ -48,7 +48,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 | `comment`                                                | comment on the selection                    | `c`, type, `enter`                          | click or drag the gutter                       |
 | —                                                        | copy text (`text-selection.md`)             | —                                           | drag over text                                 |
 | `edit`                                                   | edit the comment under the cursor           | `e`                                         | —                                              |
-| `edit-file`                                              | open the file under the cursor in `$EDITOR` | `E`                                         | —                                              |
+| `edit-file`                                              | open the file under the cursor in `$EDITOR` | `E` / `ctrl+e`                              | —                                              |
 | `delete`                                                 | delete the comment under the cursor         | `d`                                         | —                                              |
 | `next-comment` / `prev-comment`                          | jump to next / previous comment             | `n` / `N`                                   | —                                              |
 | `comments`                                               | list and manage all comments                | `l`                                         | —                                              |
@@ -123,8 +123,10 @@ is one keypress away. The target follows the press:
 
 The comment editor, the find band, the agent picker, and the base picker are text fields and
 strictly modal: every printable is theirs, so `edit-file` never fires there. The search
-screen's pick opens with `enter`, and `E` works from the opened file. The `PR` tab has no
-files to name and stays inert.
+screen is a text field too, so its default carries a chord alongside `E`: `ctrl+e` opens the
+picked result's file straight from the screen, outranking the shared caret-to-end control
+there alone (`search.md`); `End` still moves the caret, and the screen's footer names the
+chord, not the character. The `PR` tab has no files to name and stays inert.
 
 The pane suspends — alternate screen, raw mode, mouse capture, bracketed paste, and the
 keyboard protocol all release — so the editor owns the terminal cleanly, then rebuilds the

--- a/specs/input.md
+++ b/specs/input.md
@@ -48,7 +48,7 @@ The keymap is rebindable per action through `[keybindings]` in the plugin config
 | `comment`                                                | comment on the selection                    | `c`, type, `enter`                          | click or drag the gutter                       |
 | —                                                        | copy text (`text-selection.md`)             | —                                           | drag over text                                 |
 | `edit`                                                   | edit the comment under the cursor           | `e`                                         | —                                              |
-| `edit-file`                                              | open the file under the cursor in `$EDITOR` | `E` / `ctrl+e`                              | —                                              |
+| `edit-file`                                              | open the file under the cursor in `$EDITOR` | `ctrl+e`                                    | —                                              |
 | `delete`                                                 | delete the comment under the cursor         | `d`                                         | —                                              |
 | `next-comment` / `prev-comment`                          | jump to next / previous comment             | `n` / `N`                                   | —                                              |
 | `comments`                                               | list and manage all comments                | `l`                                         | —                                              |
@@ -122,11 +122,11 @@ is one keypress away. The target follows the press:
   anchor numbers revision lines rather than worktree lines, so it opens without one.
 
 The comment editor, the find band, the agent picker, and the base picker are text fields and
-strictly modal: every printable is theirs, so `edit-file` never fires there. The search
-screen is a text field too, so its default carries a chord alongside `E`: `ctrl+e` opens the
-picked result's file straight from the screen, outranking the shared caret-to-end control
-there alone (`search.md`); `End` still moves the caret, and the screen's footer names the
-chord, not the character. The `PR` tab has no files to name and stays inert.
+strictly modal: every printable is theirs, so `edit-file` never fires there. Its default is
+a chord — `ctrl+e` — so it also reaches the search screen, where every printable types into
+the query: there it opens the picked result's file straight from the screen, outranking the
+shared caret-to-end control on that screen alone (`search.md`); `End` still moves the caret.
+The `PR` tab has no files to name and stays inert.
 
 The pane suspends — alternate screen, raw mode, mouse capture, bracketed paste, and the
 keyboard protocol all release — so the editor owns the terminal cleanly, then rebuilds the

--- a/specs/search.md
+++ b/specs/search.md
@@ -138,10 +138,14 @@ Printable keys edit the query. The rest:
 | `↓` / `↑`, `ctrl+n/p`   | move the pick                            | click a result, wheel   |
 | `PageUp` / `PageDown`   | scroll the preview                       | wheel over the preview  |
 | `enter`                 | open the pick                            | click the picked result |
+| `ctrl+e`                | edit the picked result's file in `$EDITOR` (`input.md` Edit file) | —      |
 | `esc`                   | close, place untouched                   | —                       |
 
 The footer shows these while the screen is open. With nothing to pick — warming, errored,
-or no matches — it shows the mode flip and `esc`.
+or no matches — it shows the mode flip and `esc`. The `ctrl+e` row shows only while
+something is pickable, and its hint names the bound chord rather than the bare character,
+since every printable types into the query here. The chord outranks the shared
+caret-to-end control on this screen alone; `End` still moves the caret.
 
 ## Opening a result
 

--- a/specs/search.md
+++ b/specs/search.md
@@ -143,9 +143,8 @@ Printable keys edit the query. The rest:
 
 The footer shows these while the screen is open. With nothing to pick — warming, errored,
 or no matches — it shows the mode flip and `esc`. The `ctrl+e` row shows only while
-something is pickable, and its hint names the bound chord rather than the bare character,
-since every printable types into the query here. The chord outranks the shared
-caret-to-end control on this screen alone; `End` still moves the caret.
+something is pickable. The chord outranks the shared caret-to-end control on this screen
+alone; `End` still moves the caret.
 
 ## Opening a result
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -393,6 +393,7 @@ pub enum FooterAction {
     Select,
     ClearSelection,
     EditComment,
+    EditFile,
     DeleteComment,
     JumpComment,
     ExpandFold,
@@ -470,6 +471,14 @@ pub enum Band {
     Do,
     Go,
     Move,
+}
+
+/// The file an `edit-file` press named: a repo-relative path and, when the cursor sat on a
+/// known line, the 1-based line to open (`specs/input.md`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EditorTarget {
+    pub path: String,
+    pub line: Option<u32>,
 }
 
 /// The full state of the review session.
@@ -666,6 +675,9 @@ pub struct App {
     pub search_dirty: bool,
     /// A picked path awaiting its frecency record; the event loop hands it to the worker.
     pub search_track: Option<String>,
+    /// An `edit-file` request awaiting dispatch; the event loop suspends the terminal,
+    /// runs `$EDITOR` on the file, and resumes (`specs/input.md`). `None` when idle.
+    pub editor_request: Option<EditorTarget>,
     /// The in-file find band's state while `mode == Mode::Find`, `None` otherwise
     /// (specs/find-in-file.md).
     pub find: Option<Find>,
@@ -815,6 +827,7 @@ impl App {
             search: None,
             search_dirty: false,
             search_track: None,
+            editor_request: None,
             find: None,
             refresh_indicator: false,
             refresh_commanded: false,
@@ -2940,6 +2953,56 @@ impl App {
         }
     }
 
+    /// `edit-file`: name the file the cursor points at, so the event loop can open it in
+    /// `$EDITOR` (`specs/input.md`). The target follows the press: the highlighted
+    /// comment in the list overlay, the picked search result, the selected navigator
+    /// file row, or the read-pane line under the cursor. A directory row, an unpickable
+    /// search screen, and the text-entry modes name nothing.
+    pub fn request_edit_file(&mut self) {
+        let Some((path, line)) = self.edit_file_target() else { return };
+        if !self.repo.join(&path).is_file() {
+            return;
+        }
+        self.editor_request = Some(EditorTarget { path, line });
+    }
+
+    /// The file and line the cursor names right now, or `None` when nothing here is
+    /// editable. Pure: unit-tested without a terminal.
+    fn edit_file_target(&self) -> Option<(String, Option<u32>)> {
+        match self.mode {
+            // The highlighted comment's file at its anchor start. An old-side anchor
+            // numbers a revision's lines, not the worktree file's, so it opens without
+            // one (`specs/input.md`).
+            Mode::List => {
+                let c = self.store.get(self.list_cursor)?;
+                let line = (c.side == Side::New).then_some(c.start);
+                Some((c.file.clone(), line))
+            }
+            // The search screen's pick: a file hit opens bare, a code hit at its line.
+            Mode::Search => match self.search.as_ref()?.picked()? {
+                PickedResult::File(f) => Some((f.path.clone(), None)),
+                PickedResult::Code(c) => Some((c.path.clone(), u32::try_from(c.line).ok())),
+            },
+            // The comment editor, the find band, the agent picker, and the base picker
+            // are text fields or strictly modal: every printable is theirs, so
+            // `edit-file` never fires there (`specs/input.md`).
+            Mode::Composing { .. } | Mode::Find | Mode::Picker | Mode::BasePick => None,
+            Mode::Normal => {
+                if self.focus == Focus::Files {
+                    // The selected navigator file; a directory row names nothing.
+                    let entry = self.current_entry()?;
+                    return Some((entry.path.clone(), None));
+                }
+                // The read pane's line under the cursor: the nearest row at or above
+                // the cursor carrying a new-file number — deletions and folds carry
+                // none of their own (`specs/input.md`).
+                let path = self.shown_entry()?.path;
+                let line = self.visible[..=self.diff_cursor].iter().rev().find_map(Row::new_no);
+                Some((path, line))
+            }
+        }
+    }
+
     pub fn start_edit(&mut self) {
         // Cards don't show in the preview, so `e` on the invisible source cursor is inert;
         // an edit reached through the comments-list overlay drops back to source, where
@@ -3799,6 +3862,7 @@ impl App {
                     (A::CloseList, Do),
                     (A::Copy, Do),
                     (A::EditComment, Do),
+                    (A::EditFile, Do),
                     (A::DeleteComment, Do),
                 ];
             }
@@ -3891,6 +3955,10 @@ impl App {
                 _ => {
                     out.push((A::TogglePane, Primary)); // tab into the diff to review
                     pane_is_primary = true;
+                    // A file row (not a directory) can open in `$EDITOR` (`specs/input.md`).
+                    if self.current_entry().is_some() {
+                        out.push((A::EditFile, Do));
+                    }
                 }
             }
             // The files pane's calm row 1 has the room for the hide key (specs/input.md).
@@ -3922,6 +3990,12 @@ impl App {
             if self.previewable() {
                 out.push((A::Preview, Do));
             }
+        }
+
+        // `edit-file` works wherever the read pane shows a file's lines — source, a
+        // markdown preview, folds included (`specs/input.md`).
+        if self.focus == Focus::Diff && !self.visible.is_empty() && self.shown_entry().is_some() {
+            out.push((A::EditFile, Do));
         }
 
         // An armed crossing leads row 1: nothing else on screen says the next press leaves the
@@ -4653,5 +4727,118 @@ mod tests {
         assert!(app.set_tab(super::Tab::AllFiles).is_err());
         assert!(app.move_cursor(1).is_err());
         assert!(app.select_file(0).is_err());
+    }
+
+    /// A read pane showing `src/lib.rs` with an insertion at new line 10, a deletion of
+    /// old line 11, and an insertion at new line 12, cursor on the deletion.
+    fn diff_app() -> App {
+        use crate::diff::{Row, Span};
+        let mut app = App::new(PathBuf::from("."), Scope::Uncommitted, None);
+        app.entries.push(crate::file_list::Entry {
+            path: "src/lib.rs".into(),
+            previous_path: None,
+            annotation: None,
+            ignored: false,
+            is_dir: false,
+        });
+        app.diff_path = Some("src/lib.rs".into());
+        app.focus = crate::Focus::Diff;
+        let bare = || Vec::<Span>::new();
+        app.visible = vec![
+            Row::Insertion { new_no: 10, spans: bare(), emphasis: Vec::new() },
+            Row::Deletion { old_no: 11, spans: bare(), emphasis: Vec::new() },
+            Row::Insertion { new_no: 12, spans: bare(), emphasis: Vec::new() },
+        ];
+        app.diff_cursor = 1;
+        app
+    }
+
+    #[test]
+    fn edit_file_names_the_read_pane_line_nearest_above_the_cursor() {
+        // The cursor sits on a deletion, which carries no new-file number, so the target
+        // falls back to the nearest numbered row above (`specs/input.md`).
+        let app = diff_app();
+        assert_eq!(
+            app.edit_file_target(),
+            Some(("src/lib.rs".into(), Some(10))),
+            "a deletion falls back to the nearest new-file line above"
+        );
+
+        // On a numbered row the cursor's own line wins.
+        let mut app = diff_app();
+        app.diff_cursor = 2;
+        assert_eq!(app.edit_file_target(), Some(("src/lib.rs".into(), Some(12))));
+    }
+
+    #[test]
+    fn edit_file_names_the_selected_navigator_file_without_a_line() {
+        use crate::file_list::{Row as ListRow, RowKind};
+        let mut app = diff_app();
+        app.focus = crate::Focus::Files;
+        app.file_rows = vec![ListRow {
+            depth: 1,
+            name: "lib.rs".into(),
+            kind: RowKind::File { index: 0, annotation: None },
+            ignored: false,
+        }];
+        assert_eq!(app.edit_file_target(), Some(("src/lib.rs".into(), None)));
+
+        // A directory row names nothing.
+        app.file_rows[0].kind = RowKind::Dir { path: "src".into(), expanded: true };
+        assert_eq!(app.edit_file_target(), None, "a directory row is not editable");
+    }
+
+    #[test]
+    fn edit_file_from_the_list_overlay_opens_the_comment_anchor() {
+        let mut app = diff_app();
+        app.store.add(crate::model::Comment {
+            file: "src/lib.rs".into(),
+            side: Side::New,
+            start: 41,
+            end: 42,
+            lines: "+x".into(),
+            text: "note".into(),
+            diff_anchored: true,
+        });
+        app.mode = Mode::List;
+        assert_eq!(app.edit_file_target(), Some(("src/lib.rs".into(), Some(41))));
+
+        // An old-side anchor numbers revision lines, not worktree lines, so no line.
+        let old_side = crate::model::Comment {
+            side: Side::Old,
+            start: 7,
+            file: "gone.rs".into(),
+            ..app.store.iter().next().unwrap().clone()
+        };
+        app.store.add(old_side);
+        app.list_cursor = 1;
+        assert_eq!(app.edit_file_target(), Some(("gone.rs".into(), None)));
+    }
+
+    #[test]
+    fn edit_file_is_inert_in_the_text_entry_modes() {
+        for mode in [Mode::Find, Mode::Picker, Mode::BasePick] {
+            let mut app = diff_app();
+            app.mode = mode.clone();
+            assert_eq!(app.edit_file_target(), None, "{mode:?} owns every printable");
+        }
+    }
+
+    #[test]
+    fn request_edit_file_only_fires_for_a_real_file() {
+        let mut app = diff_app();
+        app.request_edit_file();
+        assert_eq!(
+            app.editor_request.map(|t| (t.path, t.line)),
+            Some(("src/lib.rs".into(), Some(10))),
+            "the existing path produces a dispatchable request"
+        );
+
+        // A path that is not a file under the repo root never requests.
+        let mut app = diff_app();
+        app.diff_path = Some("nope/missing.rs".into());
+        app.entries[0].path = "nope/missing.rs".into();
+        app.request_edit_file();
+        assert!(app.editor_request.is_none(), "a missing file stays inert");
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -3885,6 +3885,7 @@ impl App {
                         (A::FlipSearchMode, Primary),
                         (A::PickResult, Do),
                         (A::OpenResult, Do),
+                        (A::EditFile, Do),
                         (A::CloseSearch, Do),
                     ]
                 } else {

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -35,6 +35,7 @@ pub enum Action {
     Select,
     Comment,
     Edit,
+    EditFile,
     Delete,
     NextComment,
     PrevComment,
@@ -158,7 +159,7 @@ impl Key {
 
 /// Every action with its config name and default keys — the single source the default keymap,
 /// the name lookup, and the config error message are built from.
-const ACTIONS: [(Action, &str, &[Key]); 40] = [
+const ACTIONS: [(Action, &str, &[Key]); 41] = [
     (Action::Down, "down", &[Key::plain('j'), Key::named(KeyCode::Down)]),
     (Action::Up, "up", &[Key::plain('k'), Key::named(KeyCode::Up)]),
     (Action::NextHunk, "next-hunk", &[Key::plain(']')]),
@@ -187,6 +188,7 @@ const ACTIONS: [(Action, &str, &[Key]); 40] = [
     (Action::Select, "select", &[Key::plain('v')]),
     (Action::Comment, "comment", &[Key::plain('c')]),
     (Action::Edit, "edit", &[Key::plain('e')]),
+    (Action::EditFile, "edit-file", &[Key::plain('E')]),
     (Action::Delete, "delete", &[Key::plain('d')]),
     (Action::NextComment, "next-comment", &[Key::plain('n')]),
     (Action::PrevComment, "prev-comment", &[Key::plain('N')]),
@@ -325,6 +327,10 @@ mod tests {
     fn defaults_bind_every_action_and_hint_is_first_key() {
         let keymap = Keymap::default();
         assert_eq!(keymap.action_for(Key::plain('c')), Some(Action::Comment));
+        // `e` stays the comment editor; `E` is the file editor (`specs/input.md`).
+        assert_eq!(keymap.action_for(Key::plain('e')), Some(Action::Edit));
+        assert_eq!(keymap.action_for(Key::plain('E')), Some(Action::EditFile));
+        assert_eq!(keymap.hint(Action::EditFile), Key::plain('E'));
         assert_eq!(keymap.action_for(Key::plain('S')), Some(Action::Send));
         assert_eq!(keymap.action_for(Key::plain('m')), Some(Action::Preview));
         assert_eq!(keymap.action_for(Key::plain('p')), Some(Action::NavigatorPosition));

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -188,7 +188,7 @@ const ACTIONS: [(Action, &str, &[Key]); 41] = [
     (Action::Select, "select", &[Key::plain('v')]),
     (Action::Comment, "comment", &[Key::plain('c')]),
     (Action::Edit, "edit", &[Key::plain('e')]),
-    (Action::EditFile, "edit-file", &[Key::plain('E'), Key::ctrl('e')]),
+    (Action::EditFile, "edit-file", &[Key::ctrl('e')]),
     (Action::Delete, "delete", &[Key::plain('d')]),
     (Action::NextComment, "next-comment", &[Key::plain('n')]),
     (Action::PrevComment, "prev-comment", &[Key::plain('N')]),
@@ -327,13 +327,14 @@ mod tests {
     fn defaults_bind_every_action_and_hint_is_first_key() {
         let keymap = Keymap::default();
         assert_eq!(keymap.action_for(Key::plain('c')), Some(Action::Comment));
-        // `e` stays the comment editor; `E` is the file editor, with `ctrl+e` as its
-        // chord so the search screen — where every printable types into the query —
-        // still reaches it (`specs/input.md`).
+        // `e` stays the comment editor; `ctrl+e` is the file editor — a chord, so it
+        // also reaches the search screen, where every printable types into the query
+        // (`specs/input.md`).
         assert_eq!(keymap.action_for(Key::plain('e')), Some(Action::Edit));
-        assert_eq!(keymap.action_for(Key::plain('E')), Some(Action::EditFile));
+        assert_eq!(keymap.action_for(Key::plain('E')), None);
         assert_eq!(keymap.action_for(Key::ctrl('e')), Some(Action::EditFile));
-        assert_eq!(keymap.hint(Action::EditFile), Key::plain('E'));
+        assert_eq!(keymap.hint(Action::EditFile), Key::ctrl('e'));
+        assert_eq!(keymap.hint(Action::EditFile).label(), "ctrl+e");
         assert_eq!(keymap.action_for(Key::plain('S')), Some(Action::Send));
         assert_eq!(keymap.action_for(Key::plain('m')), Some(Action::Preview));
         assert_eq!(keymap.action_for(Key::plain('p')), Some(Action::NavigatorPosition));

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -188,7 +188,7 @@ const ACTIONS: [(Action, &str, &[Key]); 41] = [
     (Action::Select, "select", &[Key::plain('v')]),
     (Action::Comment, "comment", &[Key::plain('c')]),
     (Action::Edit, "edit", &[Key::plain('e')]),
-    (Action::EditFile, "edit-file", &[Key::plain('E')]),
+    (Action::EditFile, "edit-file", &[Key::plain('E'), Key::ctrl('e')]),
     (Action::Delete, "delete", &[Key::plain('d')]),
     (Action::NextComment, "next-comment", &[Key::plain('n')]),
     (Action::PrevComment, "prev-comment", &[Key::plain('N')]),
@@ -327,9 +327,12 @@ mod tests {
     fn defaults_bind_every_action_and_hint_is_first_key() {
         let keymap = Keymap::default();
         assert_eq!(keymap.action_for(Key::plain('c')), Some(Action::Comment));
-        // `e` stays the comment editor; `E` is the file editor (`specs/input.md`).
+        // `e` stays the comment editor; `E` is the file editor, with `ctrl+e` as its
+        // chord so the search screen — where every printable types into the query —
+        // still reaches it (`specs/input.md`).
         assert_eq!(keymap.action_for(Key::plain('e')), Some(Action::Edit));
         assert_eq!(keymap.action_for(Key::plain('E')), Some(Action::EditFile));
+        assert_eq!(keymap.action_for(Key::ctrl('e')), Some(Action::EditFile));
         assert_eq!(keymap.hint(Action::EditFile), Key::plain('E'));
         assert_eq!(keymap.action_for(Key::plain('S')), Some(Action::Send));
         assert_eq!(keymap.action_for(Key::plain('m')), Some(Action::Preview));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,10 @@ use ratatui::crossterm::event::{
     MouseEvent, MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use ratatui::crossterm::execute;
-use ratatui::crossterm::terminal::supports_keyboard_enhancement;
+use ratatui::crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+    supports_keyboard_enhancement,
+};
 use ratatui::layout::Rect;
 
 use crate::app::{App, Focus, Mode};
@@ -150,6 +153,79 @@ fn restore_terminal(kbd: bool) {
     }
     let _ = execute!(io::stdout(), DisableMouseCapture, DisableBracketedPaste);
     ratatui::restore();
+}
+
+/// Service one `edit-file` request (`specs/input.md`): suspend the TUI exactly as
+/// [`restore_terminal`] tears it down, run `$VISUAL`/`$EDITOR` on the file — `+LINE`
+/// first when a line is known, the vi-family convention vim, nvim, nano, hx, and
+/// kakoune share — then rebuild the terminal and repaint. The editor inherits the pane's
+/// environment; its PATH resolves through [`proc::command`], since a herdr pane may strip
+/// it. Afterward the file may have changed on disk, so a world refresh reconciles the
+/// diff in place (`overview.md` Continuity) and the status names what happened.
+fn run_editor(terminal: &mut DefaultTerminal, app: &mut App, kbd: bool) -> Result<()> {
+    use crate::app::EditorTarget;
+    let Some(EditorTarget { path, line }) = app.editor_request.take() else {
+        return Ok(());
+    };
+    // The whole value is the command: `$EDITOR="code -w"` runs `code` with `-w`. A bare
+    // name resolves on the host PATH; anything else must be runnable as spelled.
+    let Some(program) = std::env::var_os("VISUAL")
+        .or_else(|| std::env::var_os("EDITOR"))
+        .map(|value| value.to_string_lossy().into_owned())
+    else {
+        app.status = "set $EDITOR (or $VISUAL) to edit files".into();
+        return Ok(());
+    };
+    let mut words = program.split_whitespace();
+    let Some(bin) = words.next() else {
+        app.status = "set $EDITOR (or $VISUAL) to edit files".into();
+        return Ok(());
+    };
+    let mut cmd = proc::command(bin);
+    cmd.args(words);
+    if let Some(no) = line {
+        cmd.arg(format!("+{no}"));
+    }
+    cmd.arg(app.repo.join(&path));
+
+    // Suspend: leave the alternate screen and release every input mode, so the editor
+    // owns the terminal cleanly.
+    let _ = terminal.clear();
+    if kbd {
+        let _ = execute!(io::stdout(), PopKeyboardEnhancementFlags);
+    }
+    let _ =
+        execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture, DisableBracketedPaste);
+    let _ = disable_raw_mode();
+
+    let launched = cmd.status();
+
+    // Resume: rebuild the exact mode stack the loop expects, force a full repaint, and
+    // drop any keystrokes the editor's exit left unread.
+    let _ = enable_raw_mode();
+    if kbd {
+        let _ = execute!(
+            io::stdout(),
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        );
+    }
+    let _ = execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture, EnableBracketedPaste);
+    let _ = terminal.clear();
+    while event::poll(Duration::ZERO)? {
+        let _ = event::read();
+    }
+    terminal.draw(|f| ui::render(f, app))?;
+
+    match launched {
+        Ok(status) if status.success() => {
+            app.status = format!("edited {path}");
+            app.request_world_refresh(false, false);
+            app.refresh_commanded = true;
+        }
+        Ok(status) => app.status = format!("editor exited with {status}"),
+        Err(e) => app.status = format!("editor failed: {e}"),
+    }
+    Ok(())
 }
 
 /// The reviewed repository, resolved to its git top level. Every `App` goes through this,
@@ -1173,6 +1249,11 @@ fn event_loop(
             if app.config_error().is_none() {
                 app.tick_base_picker_probe();
             }
+            // An `edit-file` press left a target: suspend, run `$EDITOR`, resume, and
+            // repaint before the loop continues (`specs/input.md`).
+            if app.editor_request.is_some() {
+                run_editor(terminal, app, kbd)?;
+            }
             if app.should_quit {
                 break;
             }
@@ -1642,6 +1723,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
                 app.export(&Clipboard);
             }
             (Some(K::Edit), _) => app.start_edit(),
+            (Some(K::EditFile), _) => app.request_edit_file(),
             (Some(K::Delete), _) => app.delete_comment(),
             _ => {}
         }
@@ -1697,6 +1779,9 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
             // off-screen cursor. (The comments-list overlay targets the highlighted row instead.)
             K::Edit if app.focus == Focus::Diff => app.start_edit(),
             K::Delete if app.focus == Focus::Diff => app.delete_comment(),
+            // `edit-file` follows the cursor wherever a file is named: the read pane's
+            // line, the navigator's selected file row (`specs/input.md`).
+            K::EditFile => app.request_edit_file(),
             K::Send => app.send_to_agent(),
             K::Copy => {
                 app.export(&Clipboard);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1581,6 +1581,10 @@ pub fn handle_key(app: &mut App, key: KeyEvent, area: Rect, keymap: &Keymap) -> 
         match key.code {
             Esc => app.close_search(),
             Enter => app.search_open_pick()?,
+            // `edit-file` on the picked result. The chord is the only way in — every
+            // printable, `E` included, types into the query (`specs/search.md`) — so
+            // here it outranks the shared caret-to-end control, which `End` still does.
+            Char('e') if ctrl => app.request_edit_file(),
             Tab => app.search_flip(),
             PageDown => app.scroll_search_preview(PAGE),
             PageUp => app.scroll_search_preview(-PAGE),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2426,7 +2426,23 @@ fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
         A::Select => (hint(K::Select), "select"),
         A::ClearSelection => ("esc".into(), "clear"),
         A::EditComment => (hint(K::Edit), "edit"),
-        A::EditFile => (hint(K::EditFile), "edit file"),
+        A::EditFile => {
+            // The search screen's printables all type into the query, so its bar names
+            // the bound chord, not the bare character (`specs/search.md`).
+            if app.mode == Mode::Search {
+                let chord = app
+                    .keymap()
+                    .bindings()
+                    .iter()
+                    .find(|(action, _)| *action == K::EditFile)
+                    .and_then(|(_, keys)| keys.iter().find(|key| key.ctrl))
+                    .map(|key| key.label());
+                if let Some(chord) = chord {
+                    return (chord, "edit file".into());
+                }
+            }
+            (hint(K::EditFile), "edit file")
+        }
         A::DeleteComment => (hint(K::Delete), "delete"),
         A::JumpComment => (format!("{}/{}", hint(K::NextComment), hint(K::PrevComment)), "jump"),
         A::ExpandFold => (hint(K::Expand), "expand fold"),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2426,6 +2426,7 @@ fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
         A::Select => (hint(K::Select), "select"),
         A::ClearSelection => ("esc".into(), "clear"),
         A::EditComment => (hint(K::Edit), "edit"),
+        A::EditFile => (hint(K::EditFile), "edit file"),
         A::DeleteComment => (hint(K::Delete), "delete"),
         A::JumpComment => (format!("{}/{}", hint(K::NextComment), hint(K::PrevComment)), "jump"),
         A::ExpandFold => (hint(K::Expand), "expand fold"),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2426,23 +2426,7 @@ fn action_key_label(app: &App, action: FooterAction) -> (String, String) {
         A::Select => (hint(K::Select), "select"),
         A::ClearSelection => ("esc".into(), "clear"),
         A::EditComment => (hint(K::Edit), "edit"),
-        A::EditFile => {
-            // The search screen's printables all type into the query, so its bar names
-            // the bound chord, not the bare character (`specs/search.md`).
-            if app.mode == Mode::Search {
-                let chord = app
-                    .keymap()
-                    .bindings()
-                    .iter()
-                    .find(|(action, _)| *action == K::EditFile)
-                    .and_then(|(_, keys)| keys.iter().find(|key| key.ctrl))
-                    .map(|key| key.label());
-                if let Some(chord) = chord {
-                    return (chord, "edit file".into());
-                }
-            }
-            (hint(K::EditFile), "edit file")
-        }
+        A::EditFile => (hint(K::EditFile), "edit file"),
         A::DeleteComment => (hint(K::Delete), "delete"),
         A::JumpComment => (format!("{}/{}", hint(K::NextComment), hint(K::PrevComment)), "jump"),
         A::ExpandFold => (hint(K::Expand), "expand fold"),

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -1445,6 +1445,54 @@ fn edit_file_requests_the_open_diff_line_and_stays_inert_where_nothing_is_editab
 }
 
 #[test]
+fn edit_file_opens_the_picked_result_from_the_search_screen_by_chord() {
+    use herdr_reviewr::app::{SearchMode, SearchOverlay, SearchPhase};
+    use herdr_reviewr::search::{CodeHit, SearchResults};
+
+    let r = edited_repo();
+    let mut app = app_on(&r);
+    // A settled code search with one hit in a real file — the state `enter` would open.
+    app.search = Some(SearchOverlay {
+        query: "BETA".into(),
+        caret: 4,
+        search_mode: SearchMode::Code,
+        pick: 0,
+        scroll: std::cell::Cell::new(0),
+        results: SearchResults {
+            code: vec![CodeHit {
+                path: "a.rs".into(),
+                line: 2,
+                text: "BETA".into(),
+                spans: vec![(0, 4)],
+            }],
+            ..Default::default()
+        },
+        phase: SearchPhase::Ready,
+        preview: None,
+    });
+    app.mode = Mode::Search;
+
+    // The chord reaches `edit-file` where the bare `E` types into the query.
+    let keymap = Keymap::default();
+    handle_key(
+        &mut app,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL),
+        Rect::new(0, 0, 120, 40),
+        &keymap,
+    )
+    .unwrap();
+    let target = app.editor_request.take().expect("ctrl+e names the picked result");
+    assert_eq!(target.path, "a.rs");
+    assert_eq!(target.line, Some(2));
+    assert_eq!(app.mode, Mode::Search, "the screen stays until the editor returns");
+
+    // The bare character still types into the query, never the editor.
+    press(&mut app, &keymap, KeyCode::Char('E'));
+    assert!(app.editor_request.is_none(), "`E` is query text on the search screen");
+    assert_eq!(app.search.as_ref().unwrap().query, "BETAE");
+}
+
+#[test]
 fn page_down_rebinds_and_half_page_defaults_hold() {
     let r = edited_repo();
     let mut app = app_on(&r);
@@ -4701,6 +4749,7 @@ mod search_overlay {
                 flip,
                 FooterAction::PickResult,
                 FooterAction::OpenResult,
+                FooterAction::EditFile,
                 FooterAction::CloseSearch
             ]
         );

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -1427,16 +1427,23 @@ fn edit_file_requests_the_open_diff_line_and_stays_inert_where_nothing_is_editab
     app.diff_cursor = 1; // a changed row of `a.rs`
 
     let keymap = Keymap::default();
-    press(&mut app, &keymap, KeyCode::Char('E'));
-    let target = app.editor_request.take().expect("`E` names the open file");
+    handle_key(
+        &mut app,
+        KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL),
+        Rect::new(0, 0, 120, 40),
+        &keymap,
+    )
+    .unwrap();
+    let target = app.editor_request.take().expect("ctrl+e names the open file");
     assert_eq!(target.path, "a.rs", "the request carries the open file");
     assert!(target.line.is_some(), "the cursor's new-file line rides along");
 
-    // `e` keeps its comment meaning: no file request, and the mode is untouched when no
-    // comment sits under the cursor.
+    // The bare characters keep their own meanings: no file request from either.
     press(&mut app, &keymap, KeyCode::Char('e'));
     assert!(app.editor_request.is_none(), "`e` never requests a file");
     assert_eq!(app.mode, Mode::Normal);
+    press(&mut app, &keymap, KeyCode::Char('E'));
+    assert!(app.editor_request.is_none(), "`E` is unbound");
 
     // The read-only PR tab has no files to name.
     enter_tab(&mut app, herdr_reviewr::app::Tab::Pr);

--- a/tests/app_flow.rs
+++ b/tests/app_flow.rs
@@ -1420,6 +1420,31 @@ fn expand_rebinds_to_a_character_and_the_freed_arrow_goes_dead() {
 }
 
 #[test]
+fn edit_file_requests_the_open_diff_line_and_stays_inert_where_nothing_is_editable() {
+    let r = edited_repo();
+    let mut app = app_on(&r);
+    app.focus = Focus::Diff;
+    app.diff_cursor = 1; // a changed row of `a.rs`
+
+    let keymap = Keymap::default();
+    press(&mut app, &keymap, KeyCode::Char('E'));
+    let target = app.editor_request.take().expect("`E` names the open file");
+    assert_eq!(target.path, "a.rs", "the request carries the open file");
+    assert!(target.line.is_some(), "the cursor's new-file line rides along");
+
+    // `e` keeps its comment meaning: no file request, and the mode is untouched when no
+    // comment sits under the cursor.
+    press(&mut app, &keymap, KeyCode::Char('e'));
+    assert!(app.editor_request.is_none(), "`e` never requests a file");
+    assert_eq!(app.mode, Mode::Normal);
+
+    // The read-only PR tab has no files to name.
+    enter_tab(&mut app, herdr_reviewr::app::Tab::Pr);
+    press(&mut app, &keymap, KeyCode::Char('E'));
+    assert!(app.editor_request.is_none(), "`E` is inert on the PR tab");
+}
+
+#[test]
 fn page_down_rebinds_and_half_page_defaults_hold() {
     let r = edited_repo();
     let mut app = app_on(&r);


### PR DESCRIPTION
## What

`ctrl+e` opens the file the cursor names in `$VISUAL`/`$EDITOR`, so a fix spotted mid-review is one keypress away. The target follows the press:

| Surface | Opens |
| --- | --- |
| Read pane (Changes diff, All files File view, markdown preview) | the open file at the line under the cursor; deletions and folds fall back to the nearest new-file line above |
| Navigator | the selected file row (directory rows inert) |
| Comments list (`l`) | the highlighted comment's file at its anchor start (old-side anchors open without a line) |
| Search screen | the picked result's file at its hit line — the chord is the only way in there, since every printable types into the query |

The pane suspends completely (alternate screen, raw mode, mouse capture, bracketed paste, keyboard-enhancement flags), the editor runs through the host PATH with `+LINE` before the path when a line is known, and on return the same mode stack rebuilds and a world refresh reconciles the diff in place — reviewr itself still never writes. With neither `$VISUAL` nor `$EDITOR` set, the status line says what to set instead of failing silently.

The default is deliberately a chord: it reaches every surface that names a file, including the search screen, where it outranks the shared caret-to-end control on that screen alone (`End` still moves the caret). The text-entry modes that stay strictly modal (comment editor, find band, agent picker, base picker) keep `ctrl+e` as caret-to-end. Rebindable as `edit-file`.

## Authorship

This PR was written entirely using AI, including this description. The human contributor directed the feature — key choice, scope across surfaces, and the chord-only binding — reviewed each iteration, and tested the builds in real herdr panes via the qa-install flow.

## Checklist

- [x] `just ci` is green (run as its exact cargo steps: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`, release build — `just` itself isn't installed locally)
- [x] The governing spec under `specs/` says the new behavior (`specs/input.md` gains an "Edit file" section and the keymap row; `specs/search.md` gains the screen's key row)
- [x] `CHANGELOG.md` has a bullet under `## [Unreleased]`
- [x] Perf-relevant paths: N/A — no changes to reload, render, git, or highlight paths; the loop-side cost is one boolean check per iteration, and the editor spawn only runs on demand