### PR TITLE
Keep emphasized words readable on a dim syntax color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Changed words inside a comment stay readable.** Word emphasis floors the fill's contrast
+  against the palette's `text` only, so a dim syntax color — a comment above all — dropped to
+  ~1.2 on the emphasis fill and the changed words were unreadable. Emphasized cells now lift
+  their foreground toward `text` until they clear the same floor.
+
 ## [0.36.2] — 2026-08-29
 
 ### Fixed

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -341,6 +341,25 @@ const BLACK: Color = Color::Rgb(0x00, 0x00, 0x00);
 /// legible on any base.
 const MIN_FILL_CONTRAST: f64 = 4.5;
 
+/// Lift `fg` toward `toward` until it clears [`MIN_FILL_CONTRAST`] against `bg`.
+///
+/// [`readable_tint`] floors a fill against the palette's `text` only; a dim syntax color —
+/// a comment, above all — lands far below that on the same fill, which leaves the changed
+/// words of a commented line unreadable. `toward` is the palette's `text`, so this lightens
+/// on a dark theme and darkens on a light one. When even `toward` cannot clear the floor
+/// (the fill itself sits at the floor for `text`), `toward` is the best available.
+pub fn legible(fg: Color, bg: Color, toward: Color) -> Color {
+    let mut t = 0.0;
+    while t < 1.0 {
+        let lifted = blend(fg, toward, t);
+        if contrast(lifted, bg) >= MIN_FILL_CONTRAST {
+            return lifted;
+        }
+        t += 0.02;
+    }
+    toward
+}
+
 /// A diff-row fill: tint `base` with `accent`, stepping the tint down from its start strength
 /// until the row's `fg` clears [`MIN_FILL_CONTRAST`]. `strong` is the brighter word-emphasis
 /// fill. When even a faint tint can't clear the floor (a light theme with light text), the
@@ -421,7 +440,8 @@ fn channels(color: Color) -> (u8, u8, u8) {
 #[cfg(test)]
 mod tests {
     use super::{
-        Appearance, CATPPUCCIN_LATTE, MIN_FILL_CONTRAST, Palette, contrast, derive, resolve,
+        Appearance, CATPPUCCIN_LATTE, MIN_FILL_CONTRAST, Palette, contrast, derive, legible,
+        resolve,
     };
     use ratatui::style::Color;
 
@@ -461,6 +481,23 @@ mod tests {
     #[test]
     fn latte_is_a_selectable_light_theme() {
         assert_eq!(resolve(Some("catppuccin-latte")).name, "catppuccin-latte");
+    }
+
+    #[test]
+    fn dim_syntax_colors_lift_to_the_floor_on_emphasis_fills() {
+        // Tokyo Night's comment color, the dimmest fg the syntax theme paints: on the raw
+        // emphasis fills it sits near 1.2, far under the floor.
+        let comment = Color::Rgb(0x56, 0x5f, 0x89);
+        for name in ["tokyo-night", "catppuccin", "catppuccin-latte"] {
+            let p = resolve(Some(name)).palette;
+            for fill in [p.emph_del_bg, p.emph_ins_bg] {
+                let lifted = legible(comment, fill, p.text);
+                assert!(
+                    contrast(lifted, fill) >= MIN_FILL_CONTRAST,
+                    "{name}: emphasized comment on {fill:?} stays under the floor",
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2094,7 +2094,20 @@ fn render_row(row: &Row, layout: RowLayout<'_>, state: RowState) -> Vec<Line<'st
     // like word emphasis.
     let hl_ranges =
         find.map(|(q, cs)| crate::app::find_match_ranges(&row.text(), q, cs)).unwrap_or_default();
-    let cells = code_cells(row, emph_on, &hl_ranges);
+    let mut cells = code_cells(row, emph_on, &hl_ranges);
+    // A dim syntax color — a comment above all — is unreadable on the emphasis fill, which
+    // `readable_tint` floors against `text` only. Lift the changed words' fg until they clear
+    // the same floor. Find matches already reverse to their own colors.
+    // Cells in a syntax run share one color, so one memo spares the contrast walk per char.
+    let mut last: Option<(Color, Color)> = None;
+    for cell in cells.iter_mut().filter(|c| c.emph && !c.hl) {
+        let lifted = match last {
+            Some((fg, lifted)) if fg == cell.fg => lifted,
+            _ => crate::theme::legible(cell.fg, emph_bg, pal.text),
+        };
+        last = Some((cell.fg, lifted));
+        cell.fg = lifted;
+    }
 
     let prefix_w = gutter_prefix_width(gutter_w);
     let code_width = width.saturating_sub(prefix_w).max(1);


### PR DESCRIPTION
## What

Word-level diff emphasis was unreadable when the changed words sat inside a code comment. On
Tokyo Night, the comment foreground `#565f89` reads at **1.19** against `emph_ins_bg` and
**1.38** against `emph_del_bg` — the changed words were the *least* readable part of the row.
They now clear the same 4.5 floor the fills already keep against `text`.

Root cause: `readable_tint` floors a diff fill against the palette's `text` only. A dim syntax
color — a comment above all — was never checked, and lands far below that on the same fill.
The fill side has no answer: that comment color is only 2.76 against the bare `base`, so the
fix has to be conditional on a fill being present, which is code rather than a color value.

- `theme::legible(fg, bg, toward)` blends `fg` toward `toward` until it clears
  `MIN_FILL_CONTRAST`, returning `toward` when even that cannot (a fill already sitting at the
  floor for `text`).
- `render_row` applies it to emphasized cells only, with `toward = pal.text`, so it lightens on
  a dark theme and darkens on a light one. Find matches keep their own reverse colors.
  Memoized on the previous colour pair — a syntax run shares one `fg`, so this is a few calls
  per emphasized row, not one per char.

## Checklist

- [x] `just ci` is green — `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features --no-fail-fast` (820 pass) all clean. One unrelated pre-existing failure: `pane_actions::the_cli_fallback_resolves_the_config_dir_when_the_env_names_none` fails on `main` too when that file runs in full (passes in isolation). Note `--no-fail-fast` is needed to see the whole suite at all: `pane_actions` runs early, so a plain `cargo test` stops there and never reaches `render`, `send_flow`, or three later targets.
- [ ] The change spec under `docs/specs/` says the new behavior — no spec: this is a legibility fix to an existing rendering rule, not new behavior.
- [x] `CHANGELOG.md` has a bullet under `## [Unreleased]`
- [x] Perf-relevant paths: `scripts/bench_tui.py` A/B run, interleaved NEW/OLD, 3 rounds × 10 iterations per side on one machine, comparing the median of per-run painted medians. **No regression.** On the committed fixture every scenario moves ≤ +0.5% (`file_next_changes` 12.4 → 11.5 ms). One caveat worth flagging: the fixture's uncommitted changeset only *appends* whole lines, so similar-line pairing never runs and `cell.emph` is never true — it gates the untouched render path but cannot measure the lift. So I also benched a repo of 12 × 300 lines all modified *in place*: half trailing-comment lines (one syntax color per run, so the memo hits) and half mixed keyword/string/number tokens (the worst case — the memo holds one entry and misses nearly every word). There: `file_next_changes` painted 251.1 → 250.4 ms, `tab_enter_changes` 58.3 → 59.2 ms. The largest delta anywhere is +0.9 ms against a round-to-round spread of up to 24.5 ms, so everything is inside noise. Frame captures confirm the lift really fires on both shapes rather than being optimised out: the new binary's set of emitted foreground colors is a strict superset of the old one (+1 lifted color on the comment shape, +2 on the mixed shape, none dropped).
